### PR TITLE
Add support for inline object schemas in responses

### DIFF
--- a/json-fleece-codegen-util/json-fleece-codegen-util.cabal
+++ b/json-fleece-codegen-util/json-fleece-codegen-util.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-codegen-util
-version:        0.2.4.0
+version:        0.2.5.0
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-codegen-util#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-codegen-util/package.yaml
+++ b/json-fleece-codegen-util/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-codegen-util
-version:             0.2.4.0
+version:             0.2.5.0
 github:              "flipstone/json-fleece/json-fleece-codegen-util"
 license:             BSD3
 author:              "Author name here"

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
@@ -30,6 +30,7 @@ module Fleece.CodeGenUtil
   , inferSchemaInfoForInputName
   , inferTypeForInputName
   , arrayTypeInfo
+  , mapTypeInfo
   , nullableTypeInfo
   , textFormat
   , textSchemaTypeInfo
@@ -318,6 +319,21 @@ arrayTypeInfo itemInfo =
     , schemaTypeSchema =
         "("
           <> fleeceCoreVar "list"
+          <> " "
+          <> schemaTypeSchema itemInfo
+          <> ")"
+    }
+
+mapTypeInfo :: SchemaTypeInfo -> SchemaTypeInfo
+mapTypeInfo itemInfo =
+  itemInfo
+    { schemaTypeExpr =
+        HC.mapOf
+          (HC.typeNameToCodeDefaultQualification textType)
+          (schemaTypeExpr itemInfo)
+    , schemaTypeSchema =
+        "("
+          <> fleeceCoreVar "map"
           <> " "
           <> schemaTypeSchema itemInfo
           <> ")"

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
@@ -41,6 +41,7 @@ module Fleece.CodeGenUtil.HaskellCode
   , toVarName
   , toConstructorVarName
   , listOf
+  , mapOf
   , maybeOf
   , eitherOf
   , dollar
@@ -383,6 +384,20 @@ deriving_ classes =
 listOf :: TypeExpression -> TypeExpression
 listOf itemName =
   TypeExpression ("[" <> toCode itemName <> "]")
+
+mapType :: TypeName
+mapType =
+  toTypeName "Data.Map" (Just "Map") "Map"
+
+mapOf :: TypeExpression -> TypeExpression -> TypeExpression
+mapOf keyName itemName =
+  "("
+    <> typeNameToCodeDefaultQualification mapType
+    <> " "
+    <> keyName
+    <> " "
+    <> itemName
+    <> ")"
 
 maybeOf :: TypeExpression -> TypeExpression
 maybeOf itemName =

--- a/json-fleece-core/json-fleece-core.cabal
+++ b/json-fleece-core/json-fleece-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-core
-version:        0.3.0.0
+version:        0.3.1.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-core#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-core/package.yaml
+++ b/json-fleece-core/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-core
-version:             0.3.0.0
+version:             0.3.1.0
 github:              "flipstone/json-fleece/json-fleece-core"
 license:             BSD3
 author:              "Author name here"

--- a/json-fleece-core/src/Fleece/Core.hs
+++ b/json-fleece-core/src/Fleece/Core.hs
@@ -46,6 +46,7 @@ module Fleece.Core
   , boundedEnum
   , boundedEnumNamed
   , list
+  , Fleece.Core.Schemas.map
   , nonEmpty
   , integer
   , int

--- a/json-fleece-core/src/Fleece/Core/Schemas.hs
+++ b/json-fleece-core/src/Fleece/Core/Schemas.hs
@@ -8,6 +8,7 @@ module Fleece.Core.Schemas
   , boundedEnum
   , validate
   , list
+  , Fleece.Core.Schemas.map
   , nonEmpty
   , integer
   , int
@@ -46,6 +47,7 @@ module Fleece.Core.Schemas
 import Data.Coerce (Coercible, coerce)
 import qualified Data.Int as I
 import qualified Data.List.NonEmpty as NEL
+import qualified Data.Map as Map
 import Data.Scientific (floatingOrInteger, fromFloatDigits, toBoundedInteger, toRealFloat)
 import qualified Data.Text as T
 import qualified Data.Time as Time
@@ -63,8 +65,10 @@ import Fleece.Core.Class
   , Null (Null)
   , Object
   , UnionMembers
+  , additionalFields
   , array
   , boundedEnumNamed
+  , constructor
   , nullable
   , number
   , objectNamed
@@ -74,6 +78,7 @@ import Fleece.Core.Class
   , unionMemberWithIndex
   , unionNamed
   , validateNamed
+  , (#*)
   )
 import Fleece.Core.Name
   ( Name
@@ -233,6 +238,12 @@ list itemSchema =
     V.fromList
     V.toList
     (array itemSchema)
+
+map :: (Fleece schema, Typeable a) => schema a -> schema (Map.Map T.Text a)
+map innerSchema =
+  object $
+    constructor id
+      #* additionalFields id innerSchema
 
 nonEmpty :: Fleece schema => schema a -> schema (NEL.NonEmpty a)
 nonEmpty itemSchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringArrayResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringArrayResponse.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module TestCases.Operations.TestCases.InlineObjectStringArrayResponse
+  ( operation
+  , route
+  , Responses(..)
+  , responseSchemas
+  ) where
+
+import qualified Beeline.HTTP.Client as H
+import Beeline.Routing ((/-))
+import qualified Beeline.Routing as R
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Fleece.Aeson.Beeline as FA
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Show, fmap)
+
+operation ::
+  H.Operation
+    H.ContentTypeDecodingError
+    H.NoPathParams
+    H.NoQueryParams
+    H.NoRequestBody
+    Responses
+operation =
+  H.defaultOperation
+    { H.requestRoute = route
+    , H.responseSchemas = responseSchemas
+    }
+
+route :: R.Router r => r H.NoPathParams
+route =
+  R.get $
+    R.make H.NoPathParams
+      /- "test-cases"
+      /- "inline-object-string-array-response"
+
+data Responses
+  = Response200 (Map.Map T.Text [T.Text])
+  deriving (Eq, Show)
+
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas =
+  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map (FC.list FC.text))))
+  ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringResponse.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module TestCases.Operations.TestCases.InlineObjectStringResponse
+  ( operation
+  , route
+  , Responses(..)
+  , responseSchemas
+  ) where
+
+import qualified Beeline.HTTP.Client as H
+import Beeline.Routing ((/-))
+import qualified Beeline.Routing as R
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Fleece.Aeson.Beeline as FA
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Show, fmap)
+
+operation ::
+  H.Operation
+    H.ContentTypeDecodingError
+    H.NoPathParams
+    H.NoQueryParams
+    H.NoRequestBody
+    Responses
+operation =
+  H.defaultOperation
+    { H.requestRoute = route
+    , H.responseSchemas = responseSchemas
+    }
+
+route :: R.Router r => r H.NoPathParams
+route =
+  R.get $
+    R.make H.NoPathParams
+      /- "test-cases"
+      /- "inline-object-string-response"
+
+data Responses
+  = Response200 (Map.Map T.Text T.Text)
+  deriving (Eq, Show)
+
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas =
+  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map FC.text)))
+  ]

--- a/json-fleece-openapi3/examples/test-cases/package.yaml
+++ b/json-fleece-openapi3/examples/test-cases/package.yaml
@@ -11,6 +11,7 @@ category:            Web
 
 dependencies:
   - base >= 4.7 && < 5
+  - containers
   - text
   - scientific
   - json-fleece-core >= 0.1.3 && < 0.4

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -29,6 +29,8 @@ library
       TestCases.Operations.TestCases.InlineInt32Response
       TestCases.Operations.TestCases.InlineInt64Response
       TestCases.Operations.TestCases.InlineIntegerResponse
+      TestCases.Operations.TestCases.InlineObjectStringArrayResponse
+      TestCases.Operations.TestCases.InlineObjectStringResponse
       TestCases.Operations.TestCases.InlineStringResponse
       TestCases.Operations.TestCases.MultipleResponsesCodes
       TestCases.Operations.TestCases.NoContentResponse
@@ -89,6 +91,7 @@ library
       base >=4.7 && <5
     , beeline-http-client >=0.3.1 && <0.5
     , beeline-routing >=0.2.4 && <0.3
+    , containers
     , json-fleece-aeson-beeline ==0.1.*
     , json-fleece-core >=0.1.3 && <0.4
     , scientific

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -178,6 +178,30 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/FieldTestCases'
+  /test-cases/inline-object-string-response:
+    get:
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+  /test-cases/inline-object-string-array-response:
+    get:
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string
   /test-cases/no-content-response:
     post:
       requestBody:

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -1714,6 +1714,8 @@ extra-source-files:
     examples/test-cases/TestCases/Operations/TestCases/InlineInt32Response.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineInt64Response.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineIntegerResponse.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringArrayResponse.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringResponse.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineStringResponse.hs
     examples/test-cases/TestCases/Operations/TestCases/MultipleResponsesCodes.hs
     examples/test-cases/TestCases/Operations/TestCases/NoContentResponse.hs


### PR DESCRIPTION
This adds support for when `additionalProperties` is defined and the schema has no explicitly defined properties.