### PR TITLE
Explicitly define request body type and schema

### DIFF
--- a/json-fleece-codegen-util/json-fleece-codegen-util.cabal
+++ b/json-fleece-codegen-util/json-fleece-codegen-util.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-codegen-util
-version:        0.2.7.0
+version:        0.2.7.1
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-codegen-util#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-codegen-util/package.yaml
+++ b/json-fleece-codegen-util/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-codegen-util
-version:             0.2.7.0
+version:             0.2.7.1
 github:              "flipstone/json-fleece/json-fleece-codegen-util"
 license:             BSD3
 author:              "Author name here"

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-openapi3
-version:        0.2.3.0
+version:        0.2.3.1
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-openapi3#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-openapi3/package.yaml
+++ b/json-fleece-openapi3/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-openapi3
-version:             0.2.3.0
+version:             0.2.3.1
 github:              "flipstone/json-fleece/json-fleece-openapi3"
 license:             BSD3
 author:              "Author name here"

--- a/json-fleece-openapi3/src/Fleece/OpenApi3.hs
+++ b/json-fleece-openapi3/src/Fleece/OpenApi3.hs
@@ -153,7 +153,7 @@ mkOperation schemaMap filePath pathItem method operation = do
         , CGU.codeGenOperationMethod = method
         , CGU.codeGenOperationPath = pathPieces
         , CGU.codeGenOperationParams = Map.elems params
-        , CGU.codeGenOperationRequestBody = fmap schemaCodeGenType mbRequestBodySchema
+        , CGU.codeGenOperationRequestBody = mbRequestBodySchema
         , CGU.codeGenOperationResponses = responses
         }
 
@@ -192,12 +192,13 @@ lookupRequestBodySchema ::
   T.Text ->
   SchemaMap ->
   OA.MediaTypeObject ->
-  CGU.CodeGen (Maybe SchemaEntry)
+  CGU.CodeGen (Maybe CGU.SchemaTypeInfo)
 lookupRequestBodySchema operationKey schemaMap mediaTypeObject =
   case OA._mediaTypeObjectSchema mediaTypeObject of
     Just (OA.Ref (OA.Reference refKey)) ->
       case Map.lookup refKey schemaMap of
-        Just schemaEntry -> pure (Just schemaEntry)
+        Just schemaEntry ->
+          pure . Just . CGU.codeGenTypeSchemaInfo . schemaCodeGenType $ schemaEntry
         Nothing ->
           CGU.codeGenError $
             "Error finding request body schema for operation "


### PR DESCRIPTION
Instead of inferring the request body schema from the type name by relying upon convention, we would like to explicitly define the type and schema to use.

This will also make it easier to implement inline request body schemas in the future.