### PR TITLE
Transforms digit prefixes to import qualifiers

### DIFF
--- a/json-fleece-codegen-util/json-fleece-codegen-util.cabal
+++ b/json-fleece-codegen-util/json-fleece-codegen-util.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-codegen-util
-version:        0.7.2.0
+version:        0.7.3.0
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-codegen-util#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-codegen-util/package.yaml
+++ b/json-fleece-codegen-util/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-codegen-util
-version:             0.7.2.0
+version:             0.7.3.0
 github:              "flipstone/json-fleece/json-fleece-codegen-util"
 license:             BSD3
 author:              "Author name here"

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
@@ -264,9 +264,9 @@ indent n code =
 toTypeName :: ModuleName -> Maybe T.Text -> T.Text -> TypeName
 toTypeName moduleName mbQualifier t =
   TypeName
-    { typeNameText = transformDigitPrefixes $ Manip.toPascal t
+    { typeNameText = transformDigitPrefixes . Manip.toPascal $ t
     , typeNameModule = moduleName
-    , typeNameSuggestedQualifier = fmap Manip.toPascal mbQualifier
+    , typeNameSuggestedQualifier = fmap (transformDigitPrefixes . Manip.toPascal) mbQualifier
     }
 
 toConstructorName :: TypeName -> T.Text -> ConstructorName

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/GetAResultNamedNumberSomething.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/GetAResultNamedNumberSomething.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module TestCases.Operations.GetAResultNamedNumberSomething
+  ( operation
+  , route
+  , Responses(..)
+  , responseSchemas
+  ) where
+
+import qualified Beeline.HTTP.Client as H
+import Beeline.Routing ((/-))
+import qualified Beeline.Routing as R
+import qualified Fleece.Aeson.Beeline as FA
+import Prelude (($), Eq, Show, fmap)
+import qualified TestCases.Types.Num2SchemaStartingWithNumber as Num2SchemaStartingWithNumber
+
+operation ::
+  H.Operation
+    H.ContentTypeDecodingError
+    H.NoPathParams
+    H.NoQueryParams
+    H.NoHeaderParams
+    H.NoRequestBody
+    Responses
+operation =
+  H.defaultOperation
+    { H.requestRoute = route
+    , H.responseSchemas = responseSchemas
+    }
+
+route :: R.Router r => r H.NoPathParams
+route =
+  R.get $
+    R.make H.NoPathParams
+      /- "test-cases"
+      /- "op-with-number-prefixed-type"
+
+data Responses
+  = Response200 Num2SchemaStartingWithNumber.Num2SchemaStartingWithNumber
+  deriving (Eq, Show)
+
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas =
+  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON Num2SchemaStartingWithNumber.num2SchemaStartingWithNumberSchema))
+  ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/Num2GetAResultNamedNumberSomething.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/Num2GetAResultNamedNumberSomething.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module TestCases.Operations.GetAResultNamedNumberSomething
+module TestCases.Operations.Num2GetAResultNamedNumberSomething
   ( operation
   , route
   , Responses(..)

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -16,6 +16,7 @@ build-type:     Simple
 
 library
   exposed-modules:
+      TestCases.Operations.GetAResultNamedNumberSomething
       TestCases.Operations.GetMultiplePathsParams
       TestCases.Operations.GetMultiplePathsParams.Param1
       TestCases.Operations.GetMultiplePathsParams.Param2

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -16,10 +16,10 @@ build-type:     Simple
 
 library
   exposed-modules:
-      TestCases.Operations.GetAResultNamedNumberSomething
       TestCases.Operations.GetMultiplePathsParams
       TestCases.Operations.GetMultiplePathsParams.Param1
       TestCases.Operations.GetMultiplePathsParams.Param2
+      TestCases.Operations.Num2GetAResultNamedNumberSomething
       TestCases.Operations.ParamSchemaReference
       TestCases.Operations.ParamSchemaReference.EnumIntParam
       TestCases.Operations.ParamSchemaReference.EnumParam

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -369,7 +369,7 @@ paths:
           description: "Invalid Post"
   /test-cases/op-with-number-prefixed-type:
     get:
-      operationId: GetAResultNamedNumberSomething
+      operationId: 2GetAResultNamedNumberSomething
       responses:
         '200':
           description: "Successful Get"

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -367,6 +367,16 @@ paths:
           description: "Successful Post"
         '422':
           description: "Invalid Post"
+  /test-cases/op-with-number-prefixed-type:
+    get:
+      operationId: GetAResultNamedNumberSomething
+      responses:
+        '200':
+          description: "Successful Get"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/2_SchemaStartingWithNumber'
 components:
   schemas:
     string-param:

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -1863,10 +1863,10 @@ extra-source-files:
     examples/star-trek/StarTrek/Types/WeaponHeader/Uid.hs
     examples/test-cases/codegen.dhall
     examples/test-cases/test-cases.yaml
-    examples/test-cases/TestCases/Operations/GetAResultNamedNumberSomething.hs
     examples/test-cases/TestCases/Operations/GetMultiplePathsParams.hs
     examples/test-cases/TestCases/Operations/GetMultiplePathsParams/Param1.hs
     examples/test-cases/TestCases/Operations/GetMultiplePathsParams/Param2.hs
+    examples/test-cases/TestCases/Operations/Num2GetAResultNamedNumberSomething.hs
     examples/test-cases/TestCases/Operations/ParamSchemaReference.hs
     examples/test-cases/TestCases/Operations/ParamSchemaReference/EnumIntParam.hs
     examples/test-cases/TestCases/Operations/ParamSchemaReference/EnumParam.hs

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -1863,6 +1863,7 @@ extra-source-files:
     examples/star-trek/StarTrek/Types/WeaponHeader/Uid.hs
     examples/test-cases/codegen.dhall
     examples/test-cases/test-cases.yaml
+    examples/test-cases/TestCases/Operations/GetAResultNamedNumberSomething.hs
     examples/test-cases/TestCases/Operations/GetMultiplePathsParams.hs
     examples/test-cases/TestCases/Operations/GetMultiplePathsParams/Param1.hs
     examples/test-cases/TestCases/Operations/GetMultiplePathsParams/Param2.hs

--- a/json-fleece-swagger2/json-fleece-swagger2.cabal
+++ b/json-fleece-swagger2/json-fleece-swagger2.cabal
@@ -17,53 +17,6 @@ build-type:     Simple
 extra-source-files:
     examples/uber/codegen.dhall
     examples/uber/uber.json
-    examples/uber/Uber/Operations/Estimates/Price.hs
-    examples/uber/Uber/Operations/Estimates/Price/EndLatitude.hs
-    examples/uber/Uber/Operations/Estimates/Price/EndLongitude.hs
-    examples/uber/Uber/Operations/Estimates/Price/StartLatitude.hs
-    examples/uber/Uber/Operations/Estimates/Price/StartLongitude.hs
-    examples/uber/Uber/Operations/Estimates/Time.hs
-    examples/uber/Uber/Operations/Estimates/Time/CustomerUuid.hs
-    examples/uber/Uber/Operations/Estimates/Time/ProductId.hs
-    examples/uber/Uber/Operations/Estimates/Time/StartLatitude.hs
-    examples/uber/Uber/Operations/Estimates/Time/StartLongitude.hs
-    examples/uber/Uber/Operations/History.hs
-    examples/uber/Uber/Operations/History/Limit.hs
-    examples/uber/Uber/Operations/History/Offset.hs
-    examples/uber/Uber/Operations/Me.hs
-    examples/uber/Uber/Operations/Products.hs
-    examples/uber/Uber/Operations/Products/Latitude.hs
-    examples/uber/Uber/Operations/Products/Longitude.hs
-    examples/uber/Uber/Types/Activities.hs
-    examples/uber/Uber/Types/Activities/Count.hs
-    examples/uber/Uber/Types/Activities/Limit.hs
-    examples/uber/Uber/Types/Activities/Offset.hs
-    examples/uber/Uber/Types/Activity.hs
-    examples/uber/Uber/Types/Activity/Uuid.hs
-    examples/uber/Uber/Types/Error.hs
-    examples/uber/Uber/Types/Error/Code.hs
-    examples/uber/Uber/Types/Error/Fields.hs
-    examples/uber/Uber/Types/Error/Message.hs
-    examples/uber/Uber/Types/PriceEstimate.hs
-    examples/uber/Uber/Types/PriceEstimate/CurrencyCode.hs
-    examples/uber/Uber/Types/PriceEstimate/DisplayName.hs
-    examples/uber/Uber/Types/PriceEstimate/Estimate.hs
-    examples/uber/Uber/Types/PriceEstimate/HighEstimate.hs
-    examples/uber/Uber/Types/PriceEstimate/LowEstimate.hs
-    examples/uber/Uber/Types/PriceEstimate/ProductId.hs
-    examples/uber/Uber/Types/PriceEstimate/SurgeMultiplier.hs
-    examples/uber/Uber/Types/Product.hs
-    examples/uber/Uber/Types/Product/Capacity.hs
-    examples/uber/Uber/Types/Product/Description.hs
-    examples/uber/Uber/Types/Product/DisplayName.hs
-    examples/uber/Uber/Types/Product/Image.hs
-    examples/uber/Uber/Types/Product/ProductId.hs
-    examples/uber/Uber/Types/Profile.hs
-    examples/uber/Uber/Types/Profile/Email.hs
-    examples/uber/Uber/Types/Profile/FirstName.hs
-    examples/uber/Uber/Types/Profile/LastName.hs
-    examples/uber/Uber/Types/Profile/Picture.hs
-    examples/uber/Uber/Types/Profile/PromoCode.hs
 
 source-repository head
   type: git


### PR DESCRIPTION
This applies the same digit-prefix transformation that we use on module
and type names to import qualifications, too, so that generated code
that references these digit-prefixed Schema elements will be usable.
