### PR TITLE
[sc-30225] OpenAPI3 Support for Inline schemas for objects with properties

### DIFF
--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse
+  ( operation
+  , route
+  , Responses(..)
+  , responseSchemas
+  ) where
+
+import qualified Beeline.HTTP.Client as H
+import Beeline.Routing ((/-))
+import qualified Beeline.Routing as R
+import qualified Fleece.Aeson.Beeline as FA
+import Prelude (($), Eq, Show, fmap)
+import qualified TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body as Response200Body
+
+operation ::
+  H.Operation
+    H.ContentTypeDecodingError
+    H.NoPathParams
+    H.NoQueryParams
+    H.NoHeaderParams
+    H.NoRequestBody
+    Responses
+operation =
+  H.defaultOperation
+    { H.requestRoute = route
+    , H.responseSchemas = responseSchemas
+    }
+
+route :: R.Router r => r H.NoPathParams
+route =
+  R.get $
+    R.make H.NoPathParams
+      /- "test-cases"
+      /- "inline-object-with-properties-json-response"
+
+data Responses
+  = Response200 Response200Body.Response200Body
+  deriving (Eq, Show)
+
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas =
+  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON Response200Body.response200BodySchema))
+  ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body
+  ( Response200Body(..)
+  , response200BodySchema
+  ) where
+
+import Fleece.Core ((#+))
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Maybe, Show)
+import qualified TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Bar as Bar
+import qualified TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Baz as Baz
+import qualified TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Foo as Foo
+
+data Response200Body = Response200Body
+  { foo :: Foo.Foo
+  , bar :: Maybe Bar.Bar
+  , baz :: Baz.Baz
+  }
+  deriving (Eq, Show)
+
+response200BodySchema :: FC.Fleece schema => schema Response200Body
+response200BodySchema =
+  FC.object $
+    FC.constructor Response200Body
+      #+ FC.required "foo" foo Foo.fooSchema
+      #+ FC.optional "bar" bar Bar.barSchema
+      #+ FC.required "baz" baz Baz.bazSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Bar.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Bar.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Bar
+  ( Bar(..)
+  , barSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Bar = Bar T.Text
+  deriving (Show, Eq)
+
+barSchema :: FC.Fleece schema => schema Bar
+barSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Baz.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Baz.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Baz
+  ( Baz(..)
+  , bazSchema
+  ) where
+
+import Fleece.Core ((#+))
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Maybe, Show)
+import qualified TestCases.Types.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Baz.Bax as Bax
+
+data Baz = Baz
+  { bax :: Maybe Bax.Bax
+  }
+  deriving (Eq, Show)
+
+bazSchema :: FC.Fleece schema => schema Baz
+bazSchema =
+  FC.object $
+    FC.constructor Baz
+      #+ FC.optional "bax" bax Bax.baxSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Foo.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Foo.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Foo
+  ( Foo(..)
+  , fooSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Foo = Foo T.Text
+  deriving (Show, Eq)
+
+fooSchema :: FC.Fleece schema => schema Foo
+fooSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Baz/Bax.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Baz/Bax.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Baz.Bax
+  ( Bax(..)
+  , baxSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Bax = Bax T.Text
+  deriving (Show, Eq)
+
+baxSchema :: FC.Fleece schema => schema Bax
+baxSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -48,6 +48,11 @@ library
       TestCases.Operations.TestCases.InlineObjectJsonResponse
       TestCases.Operations.TestCases.InlineObjectStringArrayResponse
       TestCases.Operations.TestCases.InlineObjectStringResponse
+      TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse
+      TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body
+      TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Bar
+      TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Baz
+      TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Foo
       TestCases.Operations.TestCases.InlineStringResponse
       TestCases.Operations.TestCases.MultipleResponsesCodes
       TestCases.Operations.TestCases.NoContentResponse
@@ -113,6 +118,7 @@ library
       TestCases.Types.NameConflicts.Where
       TestCases.Types.Num2SchemaStartingWithNumber
       TestCases.Types.StringParam
+      TestCases.Types.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Baz.Bax
       TestCases.Types.TopLevelArray
       TestCases.Types.TopLevelArray.TopLevelArrayItem
       TestCases.Types.TopLevelArrayNullable

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -304,6 +304,28 @@ paths:
               schema:
                 type: object
                 additionalProperties: true
+  /test-cases/inline-object-with-properties-json-response:
+    get:
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - foo
+                  - baz
+                properties:
+                  foo:
+                    type: string
+                  bar:
+                    type: string
+                  baz:
+                    type: object
+                    properties:
+                      bax:
+                        type: string
   /test-cases/inline-enum-responses:
     get:
       responses:

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-openapi3
-version:        0.4.0.1
+version:        0.4.1.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-openapi3#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -1895,6 +1895,11 @@ extra-source-files:
     examples/test-cases/TestCases/Operations/TestCases/InlineObjectJsonResponse.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringArrayResponse.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringResponse.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Bar.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Baz.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Foo.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineStringResponse.hs
     examples/test-cases/TestCases/Operations/TestCases/MultipleResponsesCodes.hs
     examples/test-cases/TestCases/Operations/TestCases/NoContentResponse.hs
@@ -1960,6 +1965,7 @@ extra-source-files:
     examples/test-cases/TestCases/Types/NameConflicts/Where.hs
     examples/test-cases/TestCases/Types/Num2SchemaStartingWithNumber.hs
     examples/test-cases/TestCases/Types/StringParam.hs
+    examples/test-cases/TestCases/Types/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Baz/Bax.hs
     examples/test-cases/TestCases/Types/TopLevelArray.hs
     examples/test-cases/TestCases/Types/TopLevelArray/TopLevelArrayItem.hs
     examples/test-cases/TestCases/Types/TopLevelArrayNullable.hs

--- a/json-fleece-openapi3/package.yaml
+++ b/json-fleece-openapi3/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-openapi3
-version:             0.4.0.1
+version:             0.4.1.0
 github:              "flipstone/json-fleece/json-fleece-openapi3"
 license:             BSD3
 author:              "Author name here"


### PR DESCRIPTION
Add support for inline schemas for objects with properties in OpenAPI3.
This involved specifying the CodeSection instead of defaulting to
CGU.Type in the schemaArrayItemsToFieldType function.

Also a test case was added for inline schemas for objects with properties.

Co-authored-by: David david@flipstone.com