### PR TITLE
Adds more codegen support for `additionalProperties`

### DIFF
--- a/json-fleece-codegen-util/json-fleece-codegen-util.cabal
+++ b/json-fleece-codegen-util/json-fleece-codegen-util.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-codegen-util
-version:        0.7.3.0
+version:        0.8.0.0
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-codegen-util#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-codegen-util/package.yaml
+++ b/json-fleece-codegen-util/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-codegen-util
-version:             0.7.3.0
+version:             0.8.0.0
 github:              "flipstone/json-fleece/json-fleece-codegen-util"
 license:             BSD3
 author:              "Author name here"

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringRefResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringRefResponse.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module TestCases.Operations.TestCases.InlineObjectStringRefResponse
+  ( operation
+  , route
+  , Responses(..)
+  , responseSchemas
+  ) where
+
+import qualified Beeline.HTTP.Client as H
+import Beeline.Routing ((/-))
+import qualified Beeline.Routing as R
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Fleece.Aeson.Beeline as FA
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Show, fmap)
+import qualified TestCases.Types.AStringType as AStringType
+
+operation ::
+  H.Operation
+    H.ContentTypeDecodingError
+    H.NoPathParams
+    H.NoQueryParams
+    H.NoHeaderParams
+    H.NoRequestBody
+    Responses
+operation =
+  H.defaultOperation
+    { H.requestRoute = route
+    , H.responseSchemas = responseSchemas
+    }
+
+route :: R.Router r => r H.NoPathParams
+route =
+  R.get $
+    R.make H.NoPathParams
+      /- "test-cases"
+      /- "inline-object-string-ref-response"
+
+data Responses
+  = Response200 (Map.Map T.Text AStringType.AStringType)
+  deriving (Eq, Show)
+
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas =
+  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map AStringType.aStringTypeSchema)))
+  ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse
+  ( operation
+  , route
+  , Responses(..)
+  , responseSchemas
+  ) where
+
+import qualified Beeline.HTTP.Client as H
+import Beeline.Routing ((/-))
+import qualified Beeline.Routing as R
+import qualified Fleece.Aeson.Beeline as FA
+import Prelude (($), Eq, Show, fmap)
+import qualified TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200Body as Response200Body
+
+operation ::
+  H.Operation
+    H.ContentTypeDecodingError
+    H.NoPathParams
+    H.NoQueryParams
+    H.NoHeaderParams
+    H.NoRequestBody
+    Responses
+operation =
+  H.defaultOperation
+    { H.requestRoute = route
+    , H.responseSchemas = responseSchemas
+    }
+
+route :: R.Router r => r H.NoPathParams
+route =
+  R.get $
+    R.make H.NoPathParams
+      /- "test-cases"
+      /- "inline-object-with-properties-and-additional-json-response"
+
+data Responses
+  = Response200 Response200Body.Response200Body
+  deriving (Eq, Show)
+
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas =
+  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON Response200Body.response200BodySchema))
+  ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200Body.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200Body.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200Body
+  ( Response200Body(..)
+  , response200BodySchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Fleece.Core ((#*), (#+))
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Maybe, Show)
+import qualified TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200Body.Bar as Bar
+import qualified TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200Body.Foo as Foo
+import qualified TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200BodyItem as Response200BodyItem
+
+data Response200Body = Response200Body
+  { foo :: Foo.Foo
+  , bar :: Maybe Bar.Bar
+  , additionalProperties :: (Map.Map T.Text Response200BodyItem.Response200BodyItem)
+  }
+  deriving (Eq, Show)
+
+response200BodySchema :: FC.Fleece schema => schema Response200Body
+response200BodySchema =
+  FC.object $
+    FC.constructor Response200Body
+      #+ FC.required "foo" foo Foo.fooSchema
+      #+ FC.optional "bar" bar Bar.barSchema
+      #* FC.additionalFields additionalProperties Response200BodyItem.response200BodyItemSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200Body/Bar.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200Body/Bar.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200Body.Bar
+  ( Bar(..)
+  , barSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Bar = Bar T.Text
+  deriving (Show, Eq)
+
+barSchema :: FC.Fleece schema => schema Bar
+barSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200Body/Foo.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200Body/Foo.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200Body.Foo
+  ( Foo(..)
+  , fooSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Foo = Foo T.Text
+  deriving (Show, Eq)
+
+fooSchema :: FC.Fleece schema => schema Foo
+fooSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200BodyItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200BodyItem.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200BodyItem
+  ( Response200BodyItem(..)
+  , response200BodyItemSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Response200BodyItem = Response200BodyItem T.Text
+  deriving (Show, Eq)
+
+response200BodyItemSchema :: FC.Fleece schema => schema Response200BodyItem
+response200BodyItemSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/AStringType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/AStringType.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.AStringType
+  ( AStringType(..)
+  , aStringTypeSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype AStringType = AStringType T.Text
+  deriving (Show, Eq)
+
+aStringTypeSchema :: FC.Fleece schema => schema AStringType
+aStringTypeSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaInline.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaInline.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.JustAdditionalPropertiesSchemaInline
+  ( JustAdditionalPropertiesSchemaInline(..)
+  , justAdditionalPropertiesSchemaInlineSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+import qualified TestCases.Types.JustAdditionalPropertiesSchemaInlineItem as JustAdditionalPropertiesSchemaInlineItem
+
+newtype JustAdditionalPropertiesSchemaInline = JustAdditionalPropertiesSchemaInline (Map.Map T.Text JustAdditionalPropertiesSchemaInlineItem.JustAdditionalPropertiesSchemaInlineItem)
+  deriving (Show, Eq)
+
+justAdditionalPropertiesSchemaInlineSchema :: FC.Fleece schema => schema JustAdditionalPropertiesSchemaInline
+justAdditionalPropertiesSchemaInlineSchema =
+  FC.coerceSchema (FC.map JustAdditionalPropertiesSchemaInlineItem.justAdditionalPropertiesSchemaInlineItemSchema)

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaInlineItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaInlineItem.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.JustAdditionalPropertiesSchemaInlineItem
+  ( JustAdditionalPropertiesSchemaInlineItem(..)
+  , justAdditionalPropertiesSchemaInlineItemSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype JustAdditionalPropertiesSchemaInlineItem = JustAdditionalPropertiesSchemaInlineItem T.Text
+  deriving (Show, Eq)
+
+justAdditionalPropertiesSchemaInlineItemSchema :: FC.Fleece schema => schema JustAdditionalPropertiesSchemaInlineItem
+justAdditionalPropertiesSchemaInlineItemSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaRef.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaRef.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.JustAdditionalPropertiesSchemaRef
+  ( JustAdditionalPropertiesSchemaRef(..)
+  , justAdditionalPropertiesSchemaRefSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+import qualified TestCases.Types.AStringType as AStringType
+
+newtype JustAdditionalPropertiesSchemaRef = JustAdditionalPropertiesSchemaRef (Map.Map T.Text AStringType.AStringType)
+  deriving (Show, Eq)
+
+justAdditionalPropertiesSchemaRefSchema :: FC.Fleece schema => schema JustAdditionalPropertiesSchemaRef
+justAdditionalPropertiesSchemaRefSchema =
+  FC.coerceSchema (FC.map AStringType.aStringTypeSchema)

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesTrue.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesTrue.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.JustAdditionalPropertiesTrue
+  ( JustAdditionalPropertiesTrue(..)
+  , justAdditionalPropertiesTrueSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype JustAdditionalPropertiesTrue = JustAdditionalPropertiesTrue (Map.Map T.Text FC.AnyJSON)
+  deriving (Show, Eq)
+
+justAdditionalPropertiesTrueSchema :: FC.Fleece schema => schema JustAdditionalPropertiesTrue
+justAdditionalPropertiesTrueSchema =
+  FC.coerceSchema (FC.map FC.anyJSON)

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInAdditionalPropertiesTrue
+  ( MixedInAdditionalPropertiesTrue(..)
+  , mixedInAdditionalPropertiesTrueSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Fleece.Core ((#*), (#+))
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Maybe, Show)
+import qualified TestCases.Types.MixedInAdditionalPropertiesTrue.Bar as Bar
+import qualified TestCases.Types.MixedInAdditionalPropertiesTrue.Foo as Foo
+
+data MixedInAdditionalPropertiesTrue = MixedInAdditionalPropertiesTrue
+  { foo :: Maybe Foo.Foo
+  , bar :: Maybe Bar.Bar
+  , additionalProperties :: (Map.Map T.Text FC.AnyJSON)
+  }
+  deriving (Eq, Show)
+
+mixedInAdditionalPropertiesTrueSchema :: FC.Fleece schema => schema MixedInAdditionalPropertiesTrue
+mixedInAdditionalPropertiesTrueSchema =
+  FC.object $
+    FC.constructor MixedInAdditionalPropertiesTrue
+      #+ FC.optional "foo" foo Foo.fooSchema
+      #+ FC.optional "bar" bar Bar.barSchema
+      #* FC.additionalFields additionalProperties FC.anyJSON

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue/Bar.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue/Bar.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInAdditionalPropertiesTrue.Bar
+  ( Bar(..)
+  , barSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Bar = Bar T.Text
+  deriving (Show, Eq)
+
+barSchema :: FC.Fleece schema => schema Bar
+barSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue/Foo.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue/Foo.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInAdditionalPropertiesTrue.Foo
+  ( Foo(..)
+  , fooSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Foo = Foo T.Text
+  deriving (Show, Eq)
+
+fooSchema :: FC.Fleece schema => schema Foo
+fooSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInline.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInline.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInJustAdditionalPropertiesSchemaInline
+  ( MixedInJustAdditionalPropertiesSchemaInline(..)
+  , mixedInJustAdditionalPropertiesSchemaInlineSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Fleece.Core ((#*), (#+))
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Maybe, Show)
+import qualified TestCases.Types.MixedInJustAdditionalPropertiesSchemaInline.Bar as Bar
+import qualified TestCases.Types.MixedInJustAdditionalPropertiesSchemaInline.Foo as Foo
+import qualified TestCases.Types.MixedInJustAdditionalPropertiesSchemaInlineItem as MixedInJustAdditionalPropertiesSchemaInlineItem
+
+data MixedInJustAdditionalPropertiesSchemaInline = MixedInJustAdditionalPropertiesSchemaInline
+  { foo :: Maybe Foo.Foo
+  , bar :: Maybe Bar.Bar
+  , additionalProperties :: (Map.Map T.Text MixedInJustAdditionalPropertiesSchemaInlineItem.MixedInJustAdditionalPropertiesSchemaInlineItem)
+  }
+  deriving (Eq, Show)
+
+mixedInJustAdditionalPropertiesSchemaInlineSchema :: FC.Fleece schema => schema MixedInJustAdditionalPropertiesSchemaInline
+mixedInJustAdditionalPropertiesSchemaInlineSchema =
+  FC.object $
+    FC.constructor MixedInJustAdditionalPropertiesSchemaInline
+      #+ FC.optional "foo" foo Foo.fooSchema
+      #+ FC.optional "bar" bar Bar.barSchema
+      #* FC.additionalFields additionalProperties MixedInJustAdditionalPropertiesSchemaInlineItem.mixedInJustAdditionalPropertiesSchemaInlineItemSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInline/Bar.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInline/Bar.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInJustAdditionalPropertiesSchemaInline.Bar
+  ( Bar(..)
+  , barSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Bar = Bar T.Text
+  deriving (Show, Eq)
+
+barSchema :: FC.Fleece schema => schema Bar
+barSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInline/Foo.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInline/Foo.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInJustAdditionalPropertiesSchemaInline.Foo
+  ( Foo(..)
+  , fooSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Foo = Foo T.Text
+  deriving (Show, Eq)
+
+fooSchema :: FC.Fleece schema => schema Foo
+fooSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInlineItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInlineItem.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInJustAdditionalPropertiesSchemaInlineItem
+  ( MixedInJustAdditionalPropertiesSchemaInlineItem(..)
+  , mixedInJustAdditionalPropertiesSchemaInlineItemSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype MixedInJustAdditionalPropertiesSchemaInlineItem = MixedInJustAdditionalPropertiesSchemaInlineItem T.Text
+  deriving (Show, Eq)
+
+mixedInJustAdditionalPropertiesSchemaInlineItemSchema :: FC.Fleece schema => schema MixedInJustAdditionalPropertiesSchemaInlineItem
+mixedInJustAdditionalPropertiesSchemaInlineItemSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaRef.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaRef.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInJustAdditionalPropertiesSchemaRef
+  ( MixedInJustAdditionalPropertiesSchemaRef(..)
+  , mixedInJustAdditionalPropertiesSchemaRefSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Fleece.Core ((#*), (#+))
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Maybe, Show)
+import qualified TestCases.Types.AStringType as AStringType
+import qualified TestCases.Types.MixedInJustAdditionalPropertiesSchemaRef.Bar as Bar
+import qualified TestCases.Types.MixedInJustAdditionalPropertiesSchemaRef.Foo as Foo
+
+data MixedInJustAdditionalPropertiesSchemaRef = MixedInJustAdditionalPropertiesSchemaRef
+  { foo :: Maybe Foo.Foo
+  , bar :: Maybe Bar.Bar
+  , additionalProperties :: (Map.Map T.Text AStringType.AStringType)
+  }
+  deriving (Eq, Show)
+
+mixedInJustAdditionalPropertiesSchemaRefSchema :: FC.Fleece schema => schema MixedInJustAdditionalPropertiesSchemaRef
+mixedInJustAdditionalPropertiesSchemaRefSchema =
+  FC.object $
+    FC.constructor MixedInJustAdditionalPropertiesSchemaRef
+      #+ FC.optional "foo" foo Foo.fooSchema
+      #+ FC.optional "bar" bar Bar.barSchema
+      #* FC.additionalFields additionalProperties AStringType.aStringTypeSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaRef/Bar.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaRef/Bar.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInJustAdditionalPropertiesSchemaRef.Bar
+  ( Bar(..)
+  , barSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Bar = Bar T.Text
+  deriving (Show, Eq)
+
+barSchema :: FC.Fleece schema => schema Bar
+barSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaRef/Foo.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaRef/Foo.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInJustAdditionalPropertiesSchemaRef.Foo
+  ( Foo(..)
+  , fooSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Foo = Foo T.Text
+  deriving (Show, Eq)
+
+fooSchema :: FC.Fleece schema => schema Foo
+fooSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -47,7 +47,13 @@ library
       TestCases.Operations.TestCases.InlineObjectAdditionalPropertiesJsonResponse
       TestCases.Operations.TestCases.InlineObjectJsonResponse
       TestCases.Operations.TestCases.InlineObjectStringArrayResponse
+      TestCases.Operations.TestCases.InlineObjectStringRefResponse
       TestCases.Operations.TestCases.InlineObjectStringResponse
+      TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse
+      TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200Body
+      TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200Body.Bar
+      TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200Body.Foo
+      TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdditionalJsonResponse.Response200BodyItem
       TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse
       TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body
       TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Bar
@@ -67,6 +73,7 @@ library
       TestCases.Operations.TestCases.QueryParams.RequiredArrayParam
       TestCases.Operations.TestCases.QueryParams.StringParam
       TestCases.Operations.TestCases.RequestBody
+      TestCases.Types.AStringType
       TestCases.Types.DateTimeFormats
       TestCases.Types.DateTimeFormats.DefaultTimeField
       TestCases.Types.DateTimeFormats.LocalTimeField
@@ -89,7 +96,21 @@ library
       TestCases.Types.FieldTestCases.OptionalNullableField
       TestCases.Types.FieldTestCases.RequiredField
       TestCases.Types.FieldTestCases.RequiredNullableField
+      TestCases.Types.JustAdditionalPropertiesSchemaInline
+      TestCases.Types.JustAdditionalPropertiesSchemaInlineItem
+      TestCases.Types.JustAdditionalPropertiesSchemaRef
+      TestCases.Types.JustAdditionalPropertiesTrue
       TestCases.Types.LocalTimeType
+      TestCases.Types.MixedInAdditionalPropertiesTrue
+      TestCases.Types.MixedInAdditionalPropertiesTrue.Bar
+      TestCases.Types.MixedInAdditionalPropertiesTrue.Foo
+      TestCases.Types.MixedInJustAdditionalPropertiesSchemaInline
+      TestCases.Types.MixedInJustAdditionalPropertiesSchemaInline.Bar
+      TestCases.Types.MixedInJustAdditionalPropertiesSchemaInline.Foo
+      TestCases.Types.MixedInJustAdditionalPropertiesSchemaInlineItem
+      TestCases.Types.MixedInJustAdditionalPropertiesSchemaRef
+      TestCases.Types.MixedInJustAdditionalPropertiesSchemaRef.Bar
+      TestCases.Types.MixedInJustAdditionalPropertiesSchemaRef.Foo
       TestCases.Types.NameConflicts
       TestCases.Types.NameConflicts.Case
       TestCases.Types.NameConflicts.Class

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -281,6 +281,17 @@ paths:
                 type: object
                 additionalProperties:
                   type: string
+  /test-cases/inline-object-string-ref-response:
+    get:
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: "#/components/schemas/AStringType"
   /test-cases/inline-object-string-array-response:
     get:
       responses:
@@ -326,6 +337,25 @@ paths:
                     properties:
                       bax:
                         type: string
+  /test-cases/inline-object-with-properties-and-additional-json-response:
+    get:
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - foo
+                  - baz
+                properties:
+                  foo:
+                    type: string
+                  bar:
+                    type: string
+                additionalProperties:
+                  type: string
   /test-cases/inline-enum-responses:
     get:
       responses:
@@ -552,6 +582,7 @@ components:
       format: date-time
 
     DerivingNothing:
+      description: A simple string type with options set in codegen.dhall to derive nothing
       type: string
 
     FieldDescriptions:
@@ -569,3 +600,56 @@ components:
     2_SchemaStartingWithNumber:
       type: string
       description: This Schema's name starts with a number and must be renamed for the generated code to be correct.
+
+    JustAdditionalPropertiesTrue:
+      type: object
+      description: An object with just additionalProperties = true
+      additionalProperties: true
+
+    JustAdditionalPropertiesSchemaRef:
+      type: object
+      description: An object with just additionalProperties as a schema ref
+      additionalProperties:
+        $ref: '#/components/schemas/AStringType'
+
+    JustAdditionalPropertiesSchemaInline:
+      type: object
+      description: An object with just additionalProperties as an inline schema
+      additionalProperties:
+        type: string
+
+    MixedInAdditionalPropertiesTrue:
+      type: object
+      description: An object with additionalProperties = true mixed in with other properties
+      properties:
+        foo:
+          type: string
+        bar:
+          type: string
+      additionalProperties: true
+
+    MixedInJustAdditionalPropertiesSchemaRef:
+      type: object
+      description: An object with additionalProperties as a schema ref mixed in with other properties
+      properties:
+        foo:
+          type: string
+        bar:
+          type: string
+      additionalProperties:
+        $ref: '#/components/schemas/AStringType'
+
+    MixedInJustAdditionalPropertiesSchemaInline:
+      type: object
+      description: An object with additionalProperties as an inline schema mixed in with other properties
+      properties:
+        foo:
+          type: string
+        bar:
+          type: string
+      additionalProperties:
+        type: string
+
+    AStringType:
+      description: An explicit type that is just a string for use in other test cases
+      type: string

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-openapi3
-version:        0.4.1.0
+version:        0.4.2.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-openapi3#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -1894,7 +1894,13 @@ extra-source-files:
     examples/test-cases/TestCases/Operations/TestCases/InlineObjectAdditionalPropertiesJsonResponse.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineObjectJsonResponse.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringArrayResponse.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringRefResponse.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringResponse.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200Body.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200Body/Bar.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200Body/Foo.hs
+    examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse/Response200BodyItem.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body.hs
     examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Bar.hs
@@ -1914,6 +1920,7 @@ extra-source-files:
     examples/test-cases/TestCases/Operations/TestCases/QueryParams/RequiredArrayParam.hs
     examples/test-cases/TestCases/Operations/TestCases/QueryParams/StringParam.hs
     examples/test-cases/TestCases/Operations/TestCases/RequestBody.hs
+    examples/test-cases/TestCases/Types/AStringType.hs
     examples/test-cases/TestCases/Types/DateTimeFormats.hs
     examples/test-cases/TestCases/Types/DateTimeFormats/DefaultTimeField.hs
     examples/test-cases/TestCases/Types/DateTimeFormats/LocalTimeField.hs
@@ -1936,7 +1943,21 @@ extra-source-files:
     examples/test-cases/TestCases/Types/FieldTestCases/OptionalNullableField.hs
     examples/test-cases/TestCases/Types/FieldTestCases/RequiredField.hs
     examples/test-cases/TestCases/Types/FieldTestCases/RequiredNullableField.hs
+    examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaInline.hs
+    examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaInlineItem.hs
+    examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaRef.hs
+    examples/test-cases/TestCases/Types/JustAdditionalPropertiesTrue.hs
     examples/test-cases/TestCases/Types/LocalTimeType.hs
+    examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue.hs
+    examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue/Bar.hs
+    examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue/Foo.hs
+    examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInline.hs
+    examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInline/Bar.hs
+    examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInline/Foo.hs
+    examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaInlineItem.hs
+    examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaRef.hs
+    examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaRef/Bar.hs
+    examples/test-cases/TestCases/Types/MixedInJustAdditionalPropertiesSchemaRef/Foo.hs
     examples/test-cases/TestCases/Types/NameConflicts.hs
     examples/test-cases/TestCases/Types/NameConflicts/Case.hs
     examples/test-cases/TestCases/Types/NameConflicts/Class.hs
@@ -1995,7 +2016,7 @@ library
     , base >=4.7 && <5
     , containers ==0.6.*
     , insert-ordered-containers ==0.2.*
-    , json-fleece-codegen-util ==0.7.*
+    , json-fleece-codegen-util ==0.8.*
     , non-empty-text ==0.2.*
     , openapi3 ==3.2.*
     , text ==1.2.*
@@ -2014,7 +2035,7 @@ executable fleece-openapi3
   ghc-options: -rtsopts -threaded
   build-depends:
       base >=4.7 && <5
-    , json-fleece-codegen-util ==0.7.*
+    , json-fleece-codegen-util ==0.8.*
     , json-fleece-openapi3
   default-language: Haskell2010
   if flag(strict)
@@ -2035,7 +2056,7 @@ test-suite json-fleece-openapi3-test
     , bytestring ==0.11.*
     , file-embed ==0.0.15.*
     , hedgehog
-    , json-fleece-codegen-util ==0.7.*
+    , json-fleece-codegen-util ==0.8.*
     , json-fleece-openapi3
     , yaml ==0.11.*
   default-language: Haskell2010

--- a/json-fleece-openapi3/package.yaml
+++ b/json-fleece-openapi3/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-openapi3
-version:             0.4.1.0
+version:             0.4.2.0
 github:              "flipstone/json-fleece/json-fleece-openapi3"
 license:             BSD3
 author:              "Author name here"
@@ -44,7 +44,7 @@ when:
 
 dependencies:
   - base >= 4.7 && < 5
-  - json-fleece-codegen-util >= 0.7 && < 0.8
+  - json-fleece-codegen-util >= 0.8 && < 0.9
 
 extra-source-files:
   - examples/star-trek/codegen.dhall

--- a/json-fleece-swagger2/json-fleece-swagger2.cabal
+++ b/json-fleece-swagger2/json-fleece-swagger2.cabal
@@ -85,7 +85,7 @@ library
   build-depends:
       base >=4.7 && <5
     , insert-ordered-containers ==0.2.*
-    , json-fleece-codegen-util >=0.6 && <0.8
+    , json-fleece-codegen-util >=0.6 && <0.9
     , json-fleece-openapi3 ==0.4.*
     , openapi3 ==3.2.*
     , swagger2 ==2.8.*
@@ -105,7 +105,7 @@ executable fleece-swagger2
   ghc-options: -rtsopts -threaded
   build-depends:
       base >=4.7 && <5
-    , json-fleece-codegen-util >=0.6 && <0.8
+    , json-fleece-codegen-util >=0.6 && <0.9
     , json-fleece-swagger2
   default-language: Haskell2010
   if flag(strict)
@@ -127,7 +127,7 @@ test-suite json-fleece-swagger2-test
     , bytestring ==0.11.*
     , file-embed ==0.0.15.*
     , hedgehog
-    , json-fleece-codegen-util >=0.6 && <0.8
+    , json-fleece-codegen-util >=0.6 && <0.9
     , json-fleece-swagger2
   default-language: Haskell2010
   if flag(strict)

--- a/json-fleece-swagger2/package.yaml
+++ b/json-fleece-swagger2/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-swagger2
-version:             0.4.0.1
+version:             0.4.0.2
 github:              "flipstone/json-fleece/json-fleece-swagger2"
 license:             BSD3
 author:              "Author name here"
@@ -17,7 +17,7 @@ description:         Please see the README on GitHub at <https://github.com/gith
 
 dependencies:
 - base >= 4.7 && < 5
-- json-fleece-codegen-util >= 0.6 && < 0.8
+- json-fleece-codegen-util >= 0.6 && < 0.9
 
 flags:
   strict:


### PR DESCRIPTION
This expands the code gen support for OpenApi `additionalProperties`
specifications to both types defined in the `components` section of the
OpenApi spec as well as objects that contain both explicit properties
and additional properties.
