### PR TITLE
Custom day formatting

### DIFF
--- a/json-fleece-codegen-util/codegen-prelude.dhall
+++ b/json-fleece-codegen-util/codegen-prelude.dhall
@@ -2,6 +2,9 @@ let
   DateTimeFormat = < UTCTime | ZonedTime | LocalTime >
 
 let
+  DateFormat = < ISO8601Date | CustomDate : Text >
+
+let
   DerivableClass = < Show | Eq | Ord | Enum | Bounded >
 
 let
@@ -11,10 +14,12 @@ let
   TypeOptions =
     { Type =
         { dateTimeFormat : DateTimeFormat
+        , dateFormat : DateFormat
         , deriveClasses : DeriveClasses
         }
     , default =
         { dateTimeFormat = DateTimeFormat.UTCTime
+        , dateFormat = DateFormat.ISO8601Date
         , deriveClasses = DeriveClasses.Default
         }
     }
@@ -44,6 +49,7 @@ in
   , utcTime = DateTimeFormat.UTCTime
   , zonedTime = DateTimeFormat.ZonedTime
   , localTime = DateTimeFormat.LocalTime
+  , customDate = DateFormat.CustomDate
   , show = DerivableClass.Show
   , eq = DerivableClass.Eq
   , ord = DerivableClass.Ord

--- a/json-fleece-codegen-util/json-fleece-codegen-util.cabal
+++ b/json-fleece-codegen-util/json-fleece-codegen-util.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-codegen-util
-version:        0.8.0.0
+version:        0.8.0.1
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-codegen-util#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-codegen-util/package.yaml
+++ b/json-fleece-codegen-util/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-codegen-util
-version:             0.8.0.0
+version:             0.8.0.1
 github:              "flipstone/json-fleece/json-fleece-codegen-util"
 license:             BSD3
 author:              "Author name here"

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/Config.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/Config.hs
@@ -44,7 +44,15 @@ typeOptionsDecoder =
   Dhall.record $
     CGU.TypeOptions
       <$> Dhall.field "dateTimeFormat" dateTimeFormatDecoder
+      <*> Dhall.field "dateFormat" dateFormatDecoder
       <*> Dhall.field "deriveClasses" deriveClassesDecoder
+
+dateFormatDecoder :: Dhall.Decoder CGU.DateFormat
+dateFormatDecoder =
+  Dhall.union
+    ( (fmap (\() -> CGU.ISO8601DateFormat) (Dhall.constructor "ISO8601Date" Dhall.unit))
+        <> (fmap CGU.CustomDateFormat (Dhall.constructor "CustomDate" Dhall.strictText))
+    )
 
 dateTimeFormatDecoder :: Dhall.Decoder CGU.DateTimeFormat
 dateTimeFormatDecoder =

--- a/json-fleece-core/json-fleece-core.cabal
+++ b/json-fleece-core/json-fleece-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-core
-version:        0.5.1.0
+version:        0.5.2.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-core#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-core/package.yaml
+++ b/json-fleece-core/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-core
-version:             0.5.1.0
+version:             0.5.2.0
 github:              "flipstone/json-fleece/json-fleece-core"
 license:             BSD3
 author:              "Author name here"

--- a/json-fleece-core/src/Fleece/Core.hs
+++ b/json-fleece-core/src/Fleece/Core.hs
@@ -69,6 +69,7 @@ module Fleece.Core
   , localTime
   , zonedTime
   , day
+  , dayWithFormat
   , boundedIntegralNumber
   , boundedIntegralNumberNamed
   , unboundedIntegralNumber

--- a/json-fleece-core/src/Fleece/Core/Schemas.hs
+++ b/json-fleece-core/src/Fleece/Core/Schemas.hs
@@ -32,6 +32,7 @@ module Fleece.Core.Schemas
   , localTime
   , zonedTime
   , day
+  , dayWithFormat
   , boundedIntegralNumber
   , boundedIntegralNumberNamed
   , unboundedIntegralNumber
@@ -435,6 +436,20 @@ localTime =
 zonedTime :: Fleece schema => schema Time.ZonedTime
 zonedTime =
   iso8601Formatted "ZonedTime" ISO8601.iso8601Format AttoTime.zonedTime
+
+dayWithFormat :: Fleece schema => String -> schema Time.Day
+dayWithFormat formatString =
+  let
+    decode raw =
+      case Time.parseTimeM False Time.defaultTimeLocale formatString raw of
+        Just success -> Right success
+        Nothing -> Left "Invalid date in custom format"
+  in
+    validateNamed
+      (unqualifiedName $ "Day in " <> formatString <> " format")
+      (Time.formatTime Time.defaultTimeLocale formatString)
+      decode
+      string
 
 day :: Fleece schema => schema Time.Day
 day =

--- a/json-fleece-core/src/Fleece/Core/Schemas.hs
+++ b/json-fleece-core/src/Fleece/Core/Schemas.hs
@@ -443,7 +443,9 @@ dayWithFormat formatString =
     decode raw =
       case Time.parseTimeM False Time.defaultTimeLocale formatString raw of
         Just success -> Right success
-        Nothing -> Left "Invalid date in custom format"
+        Nothing ->
+          Left $
+            "Invalid date in custom format, format is: " <> formatString
   in
     validateNamed
       (unqualifiedName $ "Day in " <> formatString <> " format")

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/CustomDateFormat.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/CustomDateFormat.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.CustomDateFormat
+  ( CustomDateFormat(..)
+  , customDateFormatSchema
+  ) where
+
+import qualified Data.Time as Time
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype CustomDateFormat = CustomDateFormat Time.Day
+  deriving (Show, Eq)
+
+customDateFormatSchema :: FC.Fleece schema => schema CustomDateFormat
+customDateFormatSchema =
+  FC.coerceSchema (FC.dayWithFormat "%m/%d/%y")

--- a/json-fleece-openapi3/examples/test-cases/codegen.dhall
+++ b/json-fleece-openapi3/examples/test-cases/codegen.dhall
@@ -9,7 +9,13 @@ in
       , inputFileName = "${rootDir}/test-cases.yaml"
       , destination = rootDir
       , typeOptions =
-          [ { type = "TestCases.Types.DateTimeFormats.DateTimeFormats"
+          [ { type = "TestCases.Types.CustomDateFormat.CustomDateFormat"
+            , options =
+                CodeGen.TypeOptions::
+                  { dateFormat = CodeGen.customDate "%m/%d/%y"
+                  }
+            }
+          , { type = "TestCases.Types.DateTimeFormats.DateTimeFormats"
             , options =
                 CodeGen.TypeOptions::
                   { deriveClasses = CodeGen.derive [ CodeGen.show ]

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -74,6 +74,7 @@ library
       TestCases.Operations.TestCases.QueryParams.StringParam
       TestCases.Operations.TestCases.RequestBody
       TestCases.Types.AStringType
+      TestCases.Types.CustomDateFormat
       TestCases.Types.DateTimeFormats
       TestCases.Types.DateTimeFormats.DefaultTimeField
       TestCases.Types.DateTimeFormats.LocalTimeField

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -552,6 +552,10 @@ components:
         where:
           type: string
 
+    CustomDateFormat:
+      type: string
+      format: date
+
     DateTimeFormats:
       type: object
       properties:

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-openapi3
-version:        0.4.2.0
+version:        0.4.2.1
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-openapi3#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -1921,6 +1921,7 @@ extra-source-files:
     examples/test-cases/TestCases/Operations/TestCases/QueryParams/StringParam.hs
     examples/test-cases/TestCases/Operations/TestCases/RequestBody.hs
     examples/test-cases/TestCases/Types/AStringType.hs
+    examples/test-cases/TestCases/Types/CustomDateFormat.hs
     examples/test-cases/TestCases/Types/DateTimeFormats.hs
     examples/test-cases/TestCases/Types/DateTimeFormats/DefaultTimeField.hs
     examples/test-cases/TestCases/Types/DateTimeFormats/LocalTimeField.hs

--- a/json-fleece-openapi3/package.yaml
+++ b/json-fleece-openapi3/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-openapi3
-version:             0.4.2.0
+version:             0.4.2.1
 github:              "flipstone/json-fleece/json-fleece-openapi3"
 license:             BSD3
 author:              "Author name here"

--- a/json-fleece-openapi3/src/Fleece/OpenApi3.hs
+++ b/json-fleece-openapi3/src/Fleece/OpenApi3.hs
@@ -812,7 +812,10 @@ mkOpenApiStringFormat typeName schema = do
     Nothing ->
       pure $
         case OA._schemaFormat schema of
-          Just "date" -> CGU.dayFormat typeOptions
+          Just "date" ->
+            case CGU.dateFormat typeOptions of
+              CGU.ISO8601DateFormat -> CGU.dayFormat typeOptions
+              CGU.CustomDateFormat formatString -> CGU.dayCustomFormat formatString typeOptions
           Just "date-time" ->
             case CGU.dateTimeFormat typeOptions of
               CGU.UTCTimeFormat -> CGU.utcTimeFormat typeOptions

--- a/scripts/lib/run-in-container.sh
+++ b/scripts/lib/run-in-container.sh
@@ -2,6 +2,6 @@ if [ "$IN_DEV_CONTAINER" ]; then
   # Already in container, nothing to do
   :
 else
-  docker-compose build
-  exec docker-compose run dev $0 "$@"
+  docker compose build
+  exec docker compose run dev $0 "$@"
 fi


### PR DESCRIPTION
Many people are using custom day formats. This allows for conveniently specifying these formats, also with code gen.

This does of course allow for specifying schemas that don't round trip:

```
> stack repl --package json-fleece-aeson
ghci> :m +TestCases.Types.CustomDateFormat
ghci> :m +Fleece.Aeson
ghci> :set -XOverloadedStrings
ghci> decode customDateFormatSchema  "\"12/31/49\""
Right (CustomDateFormat 2049-12-31)
ghci> encode customDateFormatSchema  (CustomDateFormat (Time.fromGregorian 2049 12 31))
"\"12/31/49\""
ghci> encode customDateFormatSchema  (CustomDateFormat (Time.fromGregorian 1949 12 31))
"\"12/31/49\""
```