### PR TITLE
Adds a `Set` schema

### DIFF
--- a/json-fleece-core/json-fleece-core.cabal
+++ b/json-fleece-core/json-fleece-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-core
-version:        0.5.1.0
+version:        0.5.1.1
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-core#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-core/package.yaml
+++ b/json-fleece-core/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-core
-version:             0.5.1.0
+version:             0.5.1.1
 github:              "flipstone/json-fleece/json-fleece-core"
 license:             BSD3
 author:              "Author name here"


### PR DESCRIPTION
This adds a schema for building `Data.Set` values from an array. The
schema itself allows for the option of either allowing duplicates on
input or rejecting duplicates as an error.
