### PR TITLE
Adds three `Map` schemas using `fromListWith`

### DIFF
--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
@@ -34,7 +34,7 @@ module Fleece.CodeGenUtil
   , inferSchemaInfoForTypeName
   , inferTypeForInputName
   , arrayTypeInfo
-  , mapTypeInfo
+  , jsonMapTypeInfo
   , nullableTypeInfo
   , anyJSONSchemaTypeInfo
   , textFormat
@@ -423,8 +423,8 @@ arrayTypeInfo itemInfo =
           <> ")"
     }
 
-mapTypeInfo :: SchemaTypeInfo -> SchemaTypeInfo
-mapTypeInfo itemInfo =
+jsonMapTypeInfo :: SchemaTypeInfo -> SchemaTypeInfo
+jsonMapTypeInfo itemInfo =
   itemInfo
     { schemaTypeExpr =
         HC.mapOf
@@ -432,7 +432,7 @@ mapTypeInfo itemInfo =
           (schemaTypeExpr itemInfo)
     , schemaTypeSchema =
         "("
-          <> fleeceCoreVar "map"
+          <> fleeceCoreVar "jsonMap"
           <> " "
           <> schemaTypeSchema itemInfo
           <> ")"
@@ -1278,7 +1278,7 @@ generateFleeceObject typeMap typeName codeGenFields mbAdditionalProperties typeO
         Just (CodeGenAdditionalProperties additionalPropsTypeInfo) ->
           [
             ( additionalPropsFieldName
-            , schemaTypeExpr (mapTypeInfo additionalPropsTypeInfo)
+            , schemaTypeExpr (jsonMapTypeInfo additionalPropsTypeInfo)
             , Nothing
             )
           ]

--- a/json-fleece-core/src/Fleece/Core.hs
+++ b/json-fleece-core/src/Fleece/Core.hs
@@ -46,7 +46,10 @@ module Fleece.Core
   , boundedEnum
   , boundedEnumNamed
   , list
-  , Fleece.Core.Schemas.map
+  , jsonMap
+  , mapFrom
+  , strictMapFrom
+  , intMapFrom
   , nonEmpty
   , nonEmptyText
   , integer

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectAdditionalPropertiesJsonResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectAdditionalPropertiesJsonResponse.hs
@@ -44,5 +44,5 @@ data Responses
 
 responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
 responseSchemas =
-  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map FC.anyJSON)))
+  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.jsonMap FC.anyJSON)))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectJsonResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectJsonResponse.hs
@@ -44,5 +44,5 @@ data Responses
 
 responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
 responseSchemas =
-  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map FC.anyJSON)))
+  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.jsonMap FC.anyJSON)))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringArrayResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringArrayResponse.hs
@@ -44,5 +44,5 @@ data Responses
 
 responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
 responseSchemas =
-  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map (FC.list FC.text))))
+  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.jsonMap (FC.list FC.text))))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringRefResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringRefResponse.hs
@@ -45,5 +45,5 @@ data Responses
 
 responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
 responseSchemas =
-  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map AStringType.aStringTypeSchema)))
+  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.jsonMap AStringType.aStringTypeSchema)))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringResponse.hs
@@ -44,5 +44,5 @@ data Responses
 
 responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
 responseSchemas =
-  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map FC.text)))
+  [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.jsonMap FC.text)))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaInline.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaInline.hs
@@ -16,4 +16,4 @@ newtype JustAdditionalPropertiesSchemaInline = JustAdditionalPropertiesSchemaInl
 
 justAdditionalPropertiesSchemaInlineSchema :: FC.Fleece schema => schema JustAdditionalPropertiesSchemaInline
 justAdditionalPropertiesSchemaInlineSchema =
-  FC.coerceSchema (FC.map JustAdditionalPropertiesSchemaInlineItem.justAdditionalPropertiesSchemaInlineItemSchema)
+  FC.coerceSchema (FC.jsonMap JustAdditionalPropertiesSchemaInlineItem.justAdditionalPropertiesSchemaInlineItemSchema)

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaRef.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaRef.hs
@@ -16,4 +16,4 @@ newtype JustAdditionalPropertiesSchemaRef = JustAdditionalPropertiesSchemaRef (M
 
 justAdditionalPropertiesSchemaRefSchema :: FC.Fleece schema => schema JustAdditionalPropertiesSchemaRef
 justAdditionalPropertiesSchemaRefSchema =
-  FC.coerceSchema (FC.map AStringType.aStringTypeSchema)
+  FC.coerceSchema (FC.jsonMap AStringType.aStringTypeSchema)

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesTrue.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesTrue.hs
@@ -15,4 +15,4 @@ newtype JustAdditionalPropertiesTrue = JustAdditionalPropertiesTrue (Map.Map T.T
 
 justAdditionalPropertiesTrueSchema :: FC.Fleece schema => schema JustAdditionalPropertiesTrue
 justAdditionalPropertiesTrueSchema =
-  FC.coerceSchema (FC.map FC.anyJSON)
+  FC.coerceSchema (FC.jsonMap FC.anyJSON)

--- a/json-fleece-openapi3/src/Fleece/OpenApi3.hs
+++ b/json-fleece-openapi3/src/Fleece/OpenApi3.hs
@@ -1110,7 +1110,7 @@ mkAdditionalPropertiesMapSchema ::
   Maybe OA.AdditionalProperties ->
   CGU.CodeGen SchemaTypeInfoWithDeps
 mkAdditionalPropertiesMapSchema raiseError schemaKey mkInlineItemSchema mbAdditionalProperties =
-  fmap (fmapSchemaInfoAndDeps CGU.mapTypeInfo) $
+  fmap (fmapSchemaInfoAndDeps CGU.jsonMapTypeInfo) $
     mkAdditionalPropertiesSchema
       raiseError
       schemaKey


### PR DESCRIPTION
This adds schemas for `Data.Map`, `Data.Map.Strict`, and `Data.IntMap`. Each schema requires the user to provide a function to handle key collisions, which they use with their espective `fromListWith` functions, and a user-defined schema for the association list elements.

The existing `Map` schema has been renamed to `jsonMap`.