### PR TITLE
Adds EncoderDecoder type

### DIFF
--- a/json-fleece-aeson/json-fleece-aeson.cabal
+++ b/json-fleece-aeson/json-fleece-aeson.cabal
@@ -32,6 +32,7 @@ library
       Fleece.Aeson.Encoder
   other-modules:
       Fleece.Aeson.AnyJSON
+      Fleece.Aeson.EncoderDecoder
       Paths_json_fleece_aeson
   hs-source-dirs:
       src

--- a/json-fleece-aeson/src/Fleece/Aeson.hs
+++ b/json-fleece-aeson/src/Fleece/Aeson.hs
@@ -7,3 +7,4 @@ module Fleece.Aeson
 import Fleece.Aeson.AnyJSON as Export
 import Fleece.Aeson.Decoder as Export
 import Fleece.Aeson.Encoder as Export
+import Fleece.Aeson.EncoderDecoder as Export

--- a/json-fleece-aeson/src/Fleece/Aeson/Decoder.hs
+++ b/json-fleece-aeson/src/Fleece/Aeson/Decoder.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Fleece.Aeson.Decoder
-  ( Decoder
+  ( Decoder (..)
   , decode
   , fromValue
   , toParser

--- a/json-fleece-aeson/src/Fleece/Aeson/Encoder.hs
+++ b/json-fleece-aeson/src/Fleece/Aeson/Encoder.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Fleece.Aeson.Encoder
-  ( Encoder
+  ( Encoder (..)
   , encode
   ) where
 

--- a/json-fleece-aeson/src/Fleece/Aeson/EncoderDecoder.hs
+++ b/json-fleece-aeson/src/Fleece/Aeson/EncoderDecoder.hs
@@ -1,0 +1,165 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Fleece.Aeson.EncoderDecoder
+  ( EncoderDecoder (..)
+  ) where
+
+import Fleece.Aeson.Decoder (Decoder)
+import Fleece.Aeson.Encoder (Encoder)
+import qualified Fleece.Core as FC
+
+data EncoderDecoder a = EncoderDecoder
+  { encoder :: Encoder a
+  , decoder :: Decoder a
+  }
+
+instance FC.Fleece EncoderDecoder where
+  data Object EncoderDecoder object constructor = Object
+    { objectEncoder :: FC.Object Encoder object constructor
+    , objectDecoder :: FC.Object Decoder object constructor
+    }
+
+  data Field EncoderDecoder object a = Field
+    { fieldEncoder :: FC.Field Encoder object a
+    , fieldDecoder :: FC.Field Decoder object a
+    }
+
+  data AdditionalFields EncoderDecoder object a = AdditionalFields
+    { additionalFieldsEncoder :: FC.AdditionalFields Encoder object a
+    , additionalFieldsDecoder :: FC.AdditionalFields Decoder object a
+    }
+
+  data UnionMembers EncoderDecoder allTypes handledTypes = UnionMembers
+    { unionMembersEncoder :: FC.UnionMembers Encoder allTypes handledTypes
+    , unionMembersDecoder :: FC.UnionMembers Decoder allTypes handledTypes
+    }
+
+  schemaName = FC.schemaName . encoder
+
+  number =
+    EncoderDecoder
+      { encoder = FC.number
+      , decoder = FC.number
+      }
+
+  text =
+    EncoderDecoder
+      { encoder = FC.text
+      , decoder = FC.text
+      }
+
+  boolean =
+    EncoderDecoder
+      { encoder = FC.boolean
+      , decoder = FC.boolean
+      }
+
+  array itemEncoderDecoder =
+    EncoderDecoder
+      { encoder = FC.array $ encoder itemEncoderDecoder
+      , decoder = FC.array $ decoder itemEncoderDecoder
+      }
+
+  null =
+    EncoderDecoder
+      { encoder = FC.null
+      , decoder = FC.null
+      }
+
+  nullable itemEncoderDecoder =
+    EncoderDecoder
+      { encoder = FC.nullable $ encoder itemEncoderDecoder
+      , decoder = FC.nullable $ decoder itemEncoderDecoder
+      }
+
+  required name accessor itemEncoderDecoder =
+    Field
+      { fieldEncoder = FC.required name accessor $ encoder itemEncoderDecoder
+      , fieldDecoder = FC.required name accessor $ decoder itemEncoderDecoder
+      }
+
+  optional name accessor itemEncoderDecoder =
+    Field
+      { fieldEncoder = FC.optional name accessor $ encoder itemEncoderDecoder
+      , fieldDecoder = FC.optional name accessor $ decoder itemEncoderDecoder
+      }
+
+  mapField f fieldEncoderDecoder =
+    Field
+      { fieldEncoder = FC.mapField f $ fieldEncoder fieldEncoderDecoder
+      , fieldDecoder = FC.mapField f $ fieldDecoder fieldEncoderDecoder
+      }
+
+  additionalFields accessor itemEncoderDecoder =
+    AdditionalFields
+      { additionalFieldsEncoder = FC.additionalFields accessor $ encoder itemEncoderDecoder
+      , additionalFieldsDecoder = FC.additionalFields accessor $ decoder itemEncoderDecoder
+      }
+
+  objectNamed name objectEncoderDecoder =
+    EncoderDecoder
+      { encoder = FC.objectNamed name $ objectEncoder objectEncoderDecoder
+      , decoder = FC.objectNamed name $ objectDecoder objectEncoderDecoder
+      }
+
+  constructor f =
+    Object
+      { objectEncoder = FC.constructor f
+      , objectDecoder = FC.constructor f
+      }
+
+  field object field =
+    Object
+      { objectEncoder = FC.field (objectEncoder object) (fieldEncoder field)
+      , objectDecoder = FC.field (objectDecoder object) (fieldDecoder field)
+      }
+
+  additional object addFields =
+    Object
+      { objectEncoder =
+          FC.additional (objectEncoder object) (additionalFieldsEncoder addFields)
+      , objectDecoder =
+          FC.additional (objectDecoder object) (additionalFieldsDecoder addFields)
+      }
+
+  validateNamed name uncheck check itemEncoderDecoder =
+    EncoderDecoder
+      { encoder = FC.validateNamed name uncheck check $ encoder itemEncoderDecoder
+      , decoder = FC.validateNamed name uncheck check $ decoder itemEncoderDecoder
+      }
+
+  boundedEnumNamed name toText =
+    EncoderDecoder
+      { encoder = FC.boundedEnumNamed name toText
+      , decoder = FC.boundedEnumNamed name toText
+      }
+
+  unionNamed name members =
+    EncoderDecoder
+      { encoder = FC.unionNamed name $ unionMembersEncoder members
+      , decoder = FC.unionNamed name $ unionMembersDecoder members
+      }
+
+  unionMemberWithIndex index itemEncoderDecoder =
+    UnionMembers
+      { unionMembersEncoder = FC.unionMemberWithIndex index $ encoder itemEncoderDecoder
+      , unionMembersDecoder = FC.unionMemberWithIndex index $ decoder itemEncoderDecoder
+      }
+
+  unionCombine leftMembers rightMembers =
+    UnionMembers
+      { unionMembersEncoder =
+          FC.unionCombine
+            (unionMembersEncoder leftMembers)
+            (unionMembersEncoder rightMembers)
+      , unionMembersDecoder =
+          FC.unionCombine
+            (unionMembersDecoder leftMembers)
+            (unionMembersDecoder rightMembers)
+      }
+
+  jsonString itemEncoderDecoder =
+    EncoderDecoder
+      { encoder = FC.jsonString $ encoder itemEncoderDecoder
+      , decoder = FC.jsonString $ decoder itemEncoderDecoder
+      }

--- a/json-fleece-core/json-fleece-core.cabal
+++ b/json-fleece-core/json-fleece-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-core
-version:        0.5.5.0
+version:        0.5.6.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-core#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-core/package.yaml
+++ b/json-fleece-core/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-core
-version:             0.5.5.0
+version:             0.5.6.0
 github:              "flipstone/json-fleece/json-fleece-core"
 license:             BSD3
 author:              "Author name here"


### PR DESCRIPTION
This adds a new `EncoderDecoder` type allows a single schema to act as both an `Encoder` and a `Decoder`.

Also in this commit: we are exporting the constructors for both `Encoder` and `Decoder`.