### PR TITLE
Add json-fleece-hermes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .stack-work
 .env
+tags

--- a/json-fleece-hermes/README.md
+++ b/json-fleece-hermes/README.md
@@ -1,0 +1,41 @@
+# json-fleece-hermes
+
+Interpret a `Fleece` schema as a `Data.Hermes.Decoder`.
+
+```haskell
+ghci> :set -XOverloadedStrings
+ghci> import qualified Fleece.Core as FC
+ghci> import qualified Fleece.Hermes as FH
+ghci> FH.decode (FC.list FC.text) "[\"hello\", \"world\"]"
+Right ["hello","world"]
+```
+
+## Benchmarks
+
+```
+Decode 9000 Persons
+  hermes-json:        OK (0.77s)
+    49.8 ms ± 3.0 ms,  99 MB allocated,  55 MB copied, 111 MB peak memory
+  json-fleece-hermes: OK (0.55s)
+    78.9 ms ± 5.5 ms, 188 MB allocated,  70 MB copied, 111 MB peak memory
+  json-fleece-aeson:  OK (0.78s)
+    257  ms ± 7.2 ms, 880 MB allocated, 262 MB copied, 194 MB peak memory
+```
+
+
+## Limitations / Future Work
+
+Having all numbers go through `Scientific` hurts performance. If Fleece offered
+core semantics for common number types then we could use the faster hermes
+versions.
+
+Hermes cannot currently decode scalar documents. That means decoding anything
+that isn't an object or an array will fail. This shouldn't be a deal-breaker
+for this library's use case, but it can be confusing and leads to a smelly
+`jsonString` implementation.
+
+If `jsonString` is mainly intended for numbers as strings, I think Fleece
+expressions like `intAsString`, `doubleAsString`, and `wordAsString` would be
+better, as it would allow us to use simdjson:
+https://github.com/simdjson/simdjson/blob/master/doc/basics.md#parsing-numbers-inside-strings.
+These would have to be added to Hermes, as well.

--- a/json-fleece-hermes/bench/Main.hs
+++ b/json-fleece-hermes/bench/Main.hs
@@ -1,0 +1,158 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main (main) where
+
+import Control.DeepSeq (NFData, force)
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import Test.Tasty.Bench (bench, bgroup, defaultMain, env, nf)
+
+import qualified Data.Hermes as H
+import qualified Fleece.Aeson as FA
+import Fleece.Core
+  ( Fleece
+  , NothingEncoding (EmitNull)
+  , boolean
+  , constructor
+  , double
+  , int
+  , list
+  , object
+  , optionalNullable
+  , required
+  , text
+  , (#+)
+  )
+import qualified Fleece.Core as FC
+import qualified Fleece.Hermes as FH
+
+main :: IO ()
+main =
+  defaultMain
+    [ env (force <$> BS.readFile "json/persons9000.json") $ \strBs ->
+        env (BSL.readFile "json/persons9000.json") $ \lazyBs ->
+          bgroup
+            "Decode 9000 Persons"
+            [ bench "hermes-json" $
+                nf (H.decodeEither $ H.list decodePerson) strBs
+            , bench "json-fleece-hermes" $
+                nf (FH.decode $ FC.list personSchema) strBs
+            , bench "json-fleece-aeson" $
+                nf (FA.decode $ FC.list personSchema) lazyBs
+            ]
+    ]
+
+data Person = Person
+  { _id :: Text
+  , index :: Int
+  , guid :: Text
+  , isActive :: Bool
+  , balance :: Text
+  , picture :: Maybe Text
+  , age :: Int
+  , eyeColor :: Text
+  , name :: Text
+  , gender :: Text
+  , company :: Text
+  , email :: Text
+  , phone :: Text
+  , address :: Text
+  , about :: Text
+  , registered :: Text
+  , latitude :: Double
+  , longitude :: Double
+  , tags :: [Text]
+  , friends :: [Friend]
+  , greeting :: Maybe Text
+  , favoriteFruit :: Text
+  }
+  deriving stock (Show, Generic)
+
+instance NFData Person
+
+instance Aeson.FromJSON Person where
+  parseJSON = FA.toParser personSchema
+
+personSchema :: Fleece schema => schema Person
+personSchema =
+  object $
+    constructor Person
+      #+ required "_id" _id text
+      #+ required "index" index int
+      #+ required "guid" guid text
+      #+ required "isActive" isActive boolean
+      #+ required "balance" balance text
+      #+ optionalNullable EmitNull "picture" picture text
+      #+ required "age" age int
+      #+ required "eyeColor" eyeColor text
+      #+ required "name" name text
+      #+ required "gender" gender text
+      #+ required "company" company text
+      #+ required "email" email text
+      #+ required "phone" phone text
+      #+ required "address" address text
+      #+ required "about" about text
+      #+ required "registered" registered text
+      #+ required "latitude" latitude double
+      #+ required "longitude" longitude double
+      #+ required "tags" tags (list text)
+      #+ required "friends" friends (list friendSchema)
+      #+ optionalNullable EmitNull "greeting" greeting text
+      #+ required "favoriteFruit" favoriteFruit text
+
+friendSchema :: Fleece schema => schema Friend
+friendSchema =
+  object $
+    constructor Friend
+      #+ required "id" fId int
+      #+ required "name" fName text
+
+data Friend = Friend
+  { fId :: Int
+  , fName :: Text
+  }
+  deriving stock (Show, Generic)
+
+instance NFData Friend
+
+instance Aeson.FromJSON Friend where
+  parseJSON = FA.toParser friendSchema
+
+decodePerson :: H.Decoder Person
+decodePerson =
+  H.object $
+    Person
+      <$> H.atKey "_id" H.text
+      <*> H.atKey "index" H.int
+      <*> H.atKey "guid" H.text
+      <*> H.atKey "isActive" H.bool
+      <*> H.atKey "balance" H.text
+      <*> H.atKey "picture" (H.nullable H.text)
+      <*> H.atKey "age" H.int
+      <*> H.atKey "eyeColor" H.text
+      <*> H.atKey "name" H.text
+      <*> H.atKey "gender" H.text
+      <*> H.atKey "company" H.text
+      <*> H.atKey "email" H.text
+      <*> H.atKey "phone" H.text
+      <*> H.atKey "address" H.text
+      <*> H.atKey "about" H.text
+      <*> H.atKey "registered" H.text
+      <*> H.atKey "latitude" H.double
+      <*> H.atKey "longitude" H.double
+      <*> H.atKey "tags" (H.list H.text)
+      <*> H.atKey "friends" (H.list decodeFriend)
+      <*> H.atKey "greeting" (H.nullable H.text)
+      <*> H.atKey "favoriteFruit" H.text
+
+decodeFriend :: H.Decoder Friend
+decodeFriend =
+  H.object $
+    Friend
+      <$> H.atKey "id" H.int
+      <*> H.atKey "name" H.text

--- a/json-fleece-hermes/json-fleece-hermes.cabal
+++ b/json-fleece-hermes/json-fleece-hermes.cabal
@@ -1,0 +1,101 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.35.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           json-fleece-hermes
+version:        0.1.0.0
+description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-hermes#readme>
+homepage:       https://github.com/flipstone/json-fleece#readme
+bug-reports:    https://github.com/flipstone/json-fleece/issues
+author:         Author name here
+maintainer:     example@example.com
+copyright:      2023 Author name here
+license:        BSD3
+build-type:     Simple
+
+source-repository head
+  type: git
+  location: https://github.com/flipstone/json-fleece
+  subdir: json-fleece-hermes
+
+flag strict
+  description: More strict ghc options used for development and ci, not intended for end-use.
+  manual: True
+  default: False
+
+library
+  exposed-modules:
+      Fleece.Hermes
+  other-modules:
+      Paths_json_fleece_hermes
+  hs-source-dirs:
+      src
+  build-depends:
+      base >=4.7 && <5
+    , bytestring ==0.11.*
+    , containers ==0.6.*
+    , hermes-json ==0.6.*
+    , json-fleece-core ==0.5.*
+    , shrubbery >=0.1.2 && <0.2
+    , text >=2.0
+  default-language: Haskell2010
+  if flag(strict)
+    ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations
+  else
+    ghc-options: -Wall
+
+test-suite json-fleece-hermes-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      Paths_json_fleece_hermes
+  hs-source-dirs:
+      test
+  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      aeson >=2.0 && <2.2
+    , base >=4.7 && <5
+    , bytestring ==0.11.*
+    , containers ==0.6.*
+    , hedgehog
+    , json-fleece-core ==0.5.*
+    , json-fleece-examples
+    , json-fleece-hermes
+    , scientific >=0.3.7 && <0.4
+    , text >=2.0
+    , time >=1.11 && <1.13
+    , vector >=0.12 && <0.14
+  default-language: Haskell2010
+  if flag(strict)
+    ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations
+  else
+    ghc-options: -Wall
+
+benchmark json-fleece-hermes-bench
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
+  other-modules:
+      Paths_json_fleece_hermes
+  hs-source-dirs:
+      bench
+  default-extensions:
+      OverloadedStrings
+  ghc-options: -Wall -rtsopts -with-rtsopts=-T +RTS -A32m -RTS
+  build-depends:
+      aeson >=2.0
+    , base
+    , bytestring
+    , deepseq
+    , hermes-json
+    , json-fleece-aeson
+    , json-fleece-core ==0.5.*
+    , json-fleece-hermes
+    , tasty-bench
+    , text
+  default-language: Haskell2010
+  if flag(strict)
+    ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations
+  else
+    ghc-options: -Wall

--- a/json-fleece-hermes/package.yaml
+++ b/json-fleece-hermes/package.yaml
@@ -1,0 +1,95 @@
+name:                json-fleece-hermes
+version:             0.1.0.0
+github:              "flipstone/json-fleece/json-fleece-hermes"
+license:             BSD3
+author:              "Author name here"
+maintainer:          "example@example.com"
+copyright:           "2023 Author name here"
+
+# Metadata used when publishing your package
+# synopsis:            Short description of your package
+# category:            Web
+
+# To avoid duplicated efforts in documentation and dealing with the
+# complications of embedding Haddock markup inside cabal files, it is
+# common to point users to the README.md file.
+description: Please see the README on GitHub at <https://github.com/flipstone/json-fleece-hermes#readme>
+
+dependencies:
+- base >= 4.7 && < 5
+- bytestring >= 0.11 && < 0.12
+- json-fleece-core >= 0.5 && < 0.6
+- text >= 2.0 # This could be problematic for anyone using LTS 20 or below
+
+flags:
+  strict:
+    description: More strict ghc options used for development and ci, not intended for end-use.
+    manual: true
+    default: false
+
+when:
+  - condition: flag(strict)
+    then:
+      ghc-options:
+        - -Weverything
+        - -Werror
+        - -Wno-missing-local-signatures
+        - -Wno-monomorphism-restriction
+        - -Wno-missing-kind-signatures
+        - -Wno-prepositive-qualified-module
+        - -Wno-implicit-prelude
+        - -Wno-safe
+        - -Wno-unsafe
+        - -Wno-missing-safe-haskell-mode
+        - -Wno-missing-deriving-strategies
+        - -Wno-all-missed-specialisations
+        - -Wno-missed-specialisations
+    else:
+      ghc-options:
+        - -Wall
+library:
+  source-dirs: src
+  exposed-modules:
+    - Fleece.Hermes
+  dependencies:
+    - containers >= 0.6 && < 0.7
+    - hermes-json >= 0.6 && < 0.7
+    - shrubbery >= 0.1.2 && < 0.2
+
+tests:
+  json-fleece-hermes-test:
+    main:                Spec.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - aeson >= 2.0 && < 2.2
+    - containers >= 0.6 && < 0.7
+    - json-fleece-hermes
+    - json-fleece-examples
+    - hedgehog
+    - scientific >= 0.3.7 && < 0.4
+    - time >= 1.11 && < 1.13
+    - vector >= 0.12 && < 0.14
+
+benchmarks:
+  json-fleece-hermes-bench:
+    source-dirs: bench
+    main: Main.hs
+    dependencies:
+      - aeson >= 2.0
+      - base
+      - bytestring
+      - deepseq
+      - hermes-json
+      - json-fleece-aeson
+      - json-fleece-hermes
+      - text
+      - tasty-bench
+    default-extensions: OverloadedStrings
+    ghc-options:
+      - -Wall
+      - -rtsopts
+      - -with-rtsopts=-T +RTS -A32m -RTS

--- a/json-fleece-hermes/src/Fleece/Hermes.hs
+++ b/json-fleece-hermes/src/Fleece/Hermes.hs
@@ -1,0 +1,182 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Fleece.Hermes
+  ( Decoder
+  , decode
+  , toDecoder
+  ) where
+
+import Control.Applicative ((<|>))
+import Data.Bifunctor (first)
+import qualified Data.ByteString as BS
+import qualified Data.Hermes as H
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as Enc
+import qualified Shrubbery
+
+import qualified Fleece.Core as FC
+
+data Decoder a
+  = Decoder FC.Name (H.Decoder a)
+
+toDecoder :: Decoder a -> H.Decoder a
+toDecoder (Decoder _name f) = f
+
+decode :: Decoder a -> BS.ByteString -> Either String a
+decode decoder input =
+  first (T.unpack . H.formatException) $
+    H.decodeEither (toDecoder decoder) input
+
+instance FC.Fleece Decoder where
+  data Object Decoder _object a = Object
+    { objectFields :: [Text]
+    , objectDecoder :: H.FieldsDecoder a
+    }
+
+  data Field Decoder _object a = Field
+    { fieldName :: Text
+    , fieldDecoder :: H.FieldsDecoder a
+    }
+
+  newtype AdditionalFields Decoder _object a = AdditionalFields
+    { additionalFieldsDecoder :: [Text] -> H.FieldsDecoder a
+    }
+
+  newtype UnionMembers Decoder allTypes _handledTypes
+    = UnionMembers (FC.Name -> H.Decoder (Shrubbery.Union allTypes))
+
+  schemaName (Decoder name _parseValue) =
+    name
+
+  {-# INLINE number #-}
+  number =
+    Decoder (FC.unqualifiedName "number") H.scientific
+
+  {-# INLINE text #-}
+  text =
+    Decoder (FC.unqualifiedName "text") H.text
+
+  {-# INLINE boolean #-}
+  boolean =
+    Decoder (FC.unqualifiedName "boolean") H.bool
+
+  {-# INLINE array #-}
+  array (Decoder name itemFromValue) =
+    Decoder (FC.annotateName name "array") $
+      H.vector itemFromValue
+
+  {-# INLINE null #-}
+  null =
+    Decoder (FC.unqualifiedName "null") $ do
+      isNull <- H.isNull
+      if isNull
+        then pure FC.Null
+        else fail "expected null"
+
+  {-# INLINE nullable #-}
+  nullable (Decoder name parseValue) =
+    Decoder (FC.annotateName name "nullable") $ do
+      isNull <- H.isNull
+      if isNull
+        then pure (Left FC.Null)
+        else fmap Right parseValue
+
+  {-# INLINE required #-}
+  required name _accessor (Decoder _name parseValue) =
+    let
+      key = T.pack name
+    in
+      Field key (H.atKey key parseValue)
+
+  {-# INLINE optional #-}
+  optional name _accessor (Decoder _name parseValue) =
+    let
+      key = T.pack name
+    in
+      Field key (H.atKeyOptional key parseValue)
+
+  {-# INLINE additionalFields #-}
+  additionalFields _accessor (Decoder _name parseValue) =
+    AdditionalFields $ \definedFields ->
+      H.liftObjectDecoder $ H.objectAsMapExcluding definedFields pure parseValue
+
+  {-# INLINE mapField #-}
+  mapField f (Field name parseField) =
+    Field name (fmap f parseField)
+
+  {-# INLINE constructor #-}
+  constructor f =
+    Object [] (pure f)
+
+  {-# INLINE field #-}
+  field (Object fieldNames parseF) field =
+    Object
+      { objectFields = fieldName field : fieldNames
+      , objectDecoder =
+          parseF <*> fieldDecoder field
+      }
+
+  {-# INLINE additional #-}
+  additional (Object fieldNames parseF) fields =
+    Object
+      { objectFields = fieldNames
+      , objectDecoder =
+          parseF <*> additionalFieldsDecoder fields fieldNames
+      }
+
+  {-# INLINE objectNamed #-}
+  objectNamed name (Object _definedFields parseObject) =
+    Decoder name $ H.object parseObject
+
+  {-# INLINE boundedEnumNamed #-}
+  boundedEnumNamed name toText =
+    let
+      decodingMap =
+        Map.fromList
+          . map (\e -> (toText e, e))
+          $ [minBound .. maxBound]
+    in
+      Decoder name $
+        H.withText $ \textValue ->
+          case Map.lookup textValue decodingMap of
+            Just enumValue -> pure enumValue
+            Nothing ->
+              fail $
+                "Unrecognized value for "
+                  <> FC.nameToString name
+                  <> " enum: "
+                  <> show textValue
+
+  validateNamed name _uncheck check (Decoder _unvalidatedName parseValue) =
+    Decoder name $ do
+      uncheckedValue <- parseValue
+      case check uncheckedValue of
+        Right checkedValue -> pure checkedValue
+        Left err -> fail $ "Error validating " <> FC.nameToString name <> ": " <> err
+
+  {-# INLINE unionNamed #-}
+  unionNamed name (UnionMembers parseMembers) =
+    Decoder name (parseMembers name)
+
+  {-# INLINE unionMemberWithIndex #-}
+  unionMemberWithIndex index (Decoder _name parseMember) =
+    UnionMembers (\_name -> fmap (Shrubbery.unifyUnion index) parseMember)
+
+  {-# INLINE unionCombine #-}
+  unionCombine (UnionMembers parseLeft) (UnionMembers parseRight) =
+    UnionMembers $ \name ->
+      parseLeft name
+        <|> parseRight name
+        <|> fail ("All union parsing options for " <> FC.nameUnqualified name <> " failed.")
+
+  jsonString (Decoder name parseValue) =
+    Decoder name $
+      H.withText $ \jsonText -> do
+        -- hermes currently cannot decode scalars. So we make a dummy object.
+        let
+          obj = Enc.encodeUtf8 $ T.pack "{ \"\": " <> jsonText <> T.pack "}"
+        case H.decodeEither (H.object $ H.atKey (T.pack "") parseValue) obj of
+          Left err -> fail ("Error decoding nested json string: " <> show err)
+          Right value -> pure value

--- a/json-fleece-hermes/test/Spec.hs
+++ b/json-fleece-hermes/test/Spec.hs
@@ -1,0 +1,467 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main
+  ( main
+  ) where
+
+import Control.Monad (join)
+import Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encoding as AesonEncoding
+import qualified Data.Aeson.Key as AesonKey
+import qualified Data.Aeson.Text as AesonText
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.Map.Strict as Map
+import Data.Scientific (Scientific, scientific)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as LT
+import qualified Data.Time as Time
+import qualified Data.Vector as V
+import Hedgehog ((===))
+import qualified Hedgehog as HH
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Main as HHM
+import qualified Hedgehog.Range as Range
+
+import qualified Fleece.Core as FC
+import qualified Fleece.Examples as Examples
+import qualified Fleece.Hermes as FH
+
+main :: IO ()
+main =
+  HHM.defaultMain [HH.checkParallel (HH.Group "json-fleece-hermes - json" tests)]
+
+tests :: [(HH.PropertyName, HH.Property)]
+tests =
+  [ ("prop_decode_number", prop_decode_number)
+  , ("prop_decode_string", prop_decode_string)
+  , ("prop_decode_boolean", prop_decode_boolean)
+  , ("prop_decode_null", prop_decode_null)
+  , ("prop_decode_array", prop_decode_array)
+  , ("prop_decode_object", prop_decode_object)
+  , ("prop_decode_boundedEnum", prop_decode_boundedEnum)
+  , ("prop_decode_nullableField", prop_decode_nullableField)
+  , ("prop_decode_validate", prop_decode_validate)
+  , ("prop_decode_nullableField_Failure", prop_decode_nullableField_Failure)
+  , ("prop_decode_optionalNullableFieldEmitNull", prop_decode_optionalNullableFieldEmitNull)
+  , ("prop_decode_optionalNullableFieldOmitKey", prop_decode_optionalNullableFieldOmitKey)
+  , ("prop_decode_additional", prop_decode_additional)
+  , ("prop_decode_abnormalNumbers", prop_decode_abnormalNumbers)
+  , ("prop_decode_listField", prop_decode_listField)
+  , ("prop_utcTimeAndZonedTime", prop_utcTimeAndZonedTime)
+  ]
+
+prop_decode_number :: HH.Property
+prop_decode_number =
+  HH.property $ do
+    num <- HH.forAll genScientific
+    let
+      encoded = encodeTestObject ["foo" .= Aeson.Number num]
+    FH.decode (dummyObj "foo" FC.number) encoded === Right num
+
+prop_decode_string :: HH.Property
+prop_decode_string =
+  HH.property $ do
+    text <- HH.forAll genText
+    let
+      encoded = encodeTestObject ["foo" .= Aeson.String text]
+    FH.decode (dummyObj "foo" FC.text) encoded === Right text
+
+prop_decode_boolean :: HH.Property
+prop_decode_boolean =
+  HH.property $ do
+    bool <- HH.forAll Gen.bool
+    let
+      encoded = encodeTestObject ["foo" .= Aeson.Bool bool]
+    FH.decode (dummyObj "foo" FC.boolean) encoded === Right bool
+
+prop_decode_null :: HH.Property
+prop_decode_null =
+  HH.withTests 1 . HH.property $ do
+    let
+      encoded = encodeTestObject ["foo" .= Aeson.Null]
+    FH.decode (dummyObj "foo" FC.null) encoded === Right FC.Null
+
+prop_decode_array :: HH.Property
+prop_decode_array =
+  HH.property $ do
+    texts <-
+      HH.forAll $
+        fmap
+          V.fromList
+          (Gen.list (Range.linear 0 10) genText)
+
+    let
+      testInput =
+        LBS.toStrict
+          . Aeson.encode
+          . Aeson.Array
+          . fmap Aeson.toJSON
+          $ texts
+
+      expected =
+        Right texts
+
+      decoded =
+        FH.decode
+          (FC.array FC.text)
+          testInput
+
+    decoded === expected
+
+prop_decode_object :: HH.Property
+prop_decode_object =
+  HH.property $ do
+    fooValue <- HH.forAll genText
+    barValue <- HH.forAll genScientific
+
+    let
+      jsonObject =
+        encodeTestObject
+          [ "foo" .= Aeson.String fooValue
+          , "bar" .= Aeson.Number barValue
+          ]
+
+      expected =
+        Examples.FooBar
+          { Examples.foo = fooValue
+          , Examples.bar = barValue
+          }
+
+    FH.decode Examples.fooBarSchema jsonObject === Right expected
+
+prop_decode_boundedEnum :: HH.Property
+prop_decode_boundedEnum =
+  HH.property $ do
+    textValue <-
+      HH.forAll $
+        Gen.choice
+          [ pure "apple"
+          , pure "orange"
+          , pure "kumquat"
+          , genText
+          ]
+
+    let
+      testInput =
+        encodeTestObject
+          [ "foo" .= Aeson.String textValue
+          ]
+
+      expected =
+        case textValue of
+          "apple" -> Right Examples.Apple
+          "orange" -> Right Examples.Orange
+          "kumquat" -> Right Examples.Kumquat
+          _ ->
+            Left $
+              "Error in /foo: Unrecognized value for Fleece.Examples.BoundedEnum enum: "
+                <> show textValue
+
+      decoded =
+        FH.decode
+          (dummyObj "foo" Examples.boundedEnumSchema)
+          testInput
+
+    decoded === expected
+
+prop_decode_nullableField :: HH.Property
+prop_decode_nullableField =
+  HH.property $ do
+    nullOrText <- HH.forAll (Gen.either (pure FC.Null) genText)
+
+    let
+      testInput =
+        encodeTestObject
+          ["nullableField" .= either (const Aeson.Null) Aeson.String nullOrText]
+
+      decoded =
+        FH.decode
+          Examples.nullableFieldSchema
+          testInput
+
+      expected =
+        Right
+          . Examples.NullableField
+          $ nullOrText
+
+    decoded === expected
+
+prop_decode_validate :: HH.Property
+prop_decode_validate =
+  HH.property $ do
+    text <- HH.forAll genText
+
+    let
+      testInput =
+        encodeTestObject
+          [ "foo" .= Aeson.String text
+          ]
+
+      decoded =
+        FH.decode (dummyObj "foo" Examples.validationSchema) testInput
+
+      expected =
+        if T.length text > 12
+          then
+            Left
+              "Error in /foo: Error validating Fleece.Examples.Validation: \
+              \At most 12 characters allowed"
+          else Right (Examples.Validation text)
+
+    decoded === expected
+
+prop_decode_nullableField_Failure :: HH.Property
+prop_decode_nullableField_Failure =
+  HH.withTests 1 . HH.property $ do
+    let
+      testInput =
+        encodeTestObject []
+
+      decoded =
+        FH.decode
+          Examples.nullableFieldSchema
+          testInput
+
+      expected =
+        Left
+          "Error in /nullableField: NO_SUCH_FIELD: The JSON field referenced does not \
+          \exist in this object."
+
+    decoded === expected
+
+prop_decode_optionalNullableFieldEmitNull :: HH.Property
+prop_decode_optionalNullableFieldEmitNull =
+  HH.property $ do
+    mbMbText <- HH.forAll (Gen.maybe (Gen.maybe genText))
+
+    let
+      testInput =
+        encodeTestObject $
+          case mbMbText of
+            Just mbText -> ["optionalNullableField" .= mbText]
+            Nothing -> []
+
+      decoded =
+        FH.decode
+          Examples.optionalNullableFieldEmitNullSchema
+          testInput
+
+      expected =
+        Right
+          . Examples.OptionalNullableFieldEmitNull
+          . join
+          $ mbMbText
+
+    decoded === expected
+
+prop_decode_optionalNullableFieldOmitKey :: HH.Property
+prop_decode_optionalNullableFieldOmitKey =
+  HH.property $ do
+    mbMbText <- HH.forAll (Gen.maybe (Gen.maybe genText))
+
+    let
+      testInput =
+        encodeTestObject $
+          case mbMbText of
+            Just mbText -> ["optionalNullableField" .= mbText]
+            Nothing -> []
+
+      decoded =
+        FH.decode
+          Examples.optionalNullableFieldOmitKeySchema
+          testInput
+
+      expected =
+        Right
+          . Examples.OptionalNullableFieldOmitKey
+          . join
+          $ mbMbText
+
+    decoded === expected
+
+prop_decode_additional :: HH.Property
+prop_decode_additional =
+  HH.property $ do
+    field1 <- HH.forAll genText
+    field2 <- HH.forAll genText
+
+    let
+      genPair = do
+        name <- Gen.filter (\e -> e `notElem` ["field1", "field2"]) genText
+        value <- genText
+        pure (name, value)
+
+    others <- HH.forAll (Gen.map (Range.linear 0 10) genPair)
+
+    let
+      testInput =
+        encodeTestObject
+          ( "field1" .= field1
+              : "field2" .= field2
+              : map (\(k, v) -> AesonKey.fromText k .= v) (Map.toList others)
+          )
+
+      decoded =
+        FH.decode
+          Examples.additionalFieldsExampleSchema
+          testInput
+
+      expected =
+        Right $
+          Examples.AdditionalFieldsExample
+            { Examples.field1 = field1
+            , Examples.field2 = field2
+            , Examples.otherFields = others
+            }
+
+    decoded === expected
+
+prop_decode_abnormalNumbers :: HH.Property
+prop_decode_abnormalNumbers =
+  HH.property $ do
+    stringyNumber <- HH.forAll genScientific
+    bareOrStringyNumber <- HH.forAll genScientific
+    encodeBare <- HH.forAll Gen.bool
+
+    let
+      encoded =
+        encodeTestObject
+          [ "stringyNumber" .= Aeson.String (encodeAesonText stringyNumber)
+          , "bareOrStringyNumber"
+              .= if encodeBare
+                then Aeson.Number bareOrStringyNumber
+                else Aeson.String (encodeAesonText bareOrStringyNumber)
+          ]
+
+      decoded =
+        FH.decode Examples.abnormalNumbersExampleSchema encoded
+
+      expected =
+        Examples.AbnormalNumbersExample
+          { Examples.stringyNumber = stringyNumber
+          , Examples.bareOrStringyNumber = bareOrStringyNumber
+          }
+
+    Right expected === decoded
+
+prop_decode_listField :: HH.Property
+prop_decode_listField =
+  HH.property $ do
+    values <- HH.forAll (Gen.list (Range.linear 0 10) Gen.enumBounded)
+
+    let
+      jsonObject =
+        encodeTestObject
+          [ "listField" .= map Examples.boundedEnumToText values
+          ]
+
+      expected =
+        Examples.ListFieldExample
+          { Examples.listField = values
+          }
+
+    FH.decode Examples.listFieldExampleSchema jsonObject === Right expected
+
+prop_utcTimeAndZonedTime :: HH.Property
+prop_utcTimeAndZonedTime =
+  HH.property $ do
+    utcOrZonedTime <-
+      HH.forAll $ Gen.either genUTCTime genZonedTime
+
+    let
+      encoded =
+        case utcOrZonedTime of
+          Left utcTime ->
+            encodeTestObject
+              [ "time" .= utcTime
+              ]
+          Right zonedTime ->
+            encodeTestObject
+              [ "time" .= zonedTime
+              ]
+
+      -- we only compare the minutes offset of the time zone because
+      -- otherwise UTC and +0000 are not equal
+      zonedTimeToTuple zonedTime =
+        ( Time.zonedTimeToLocalTime zonedTime
+        , Time.timeZoneMinutes (Time.zonedTimeZone zonedTime)
+        )
+
+    utcOrZonedTimeDecoded <-
+      HH.forAll $
+        Gen.either
+          (pure $ FH.decode (dummyObj "time" FC.utcTime) encoded)
+          (pure $ FH.decode (dummyObj "time" FC.zonedTime) encoded)
+
+    case (utcOrZonedTime, utcOrZonedTimeDecoded) of
+      (Left originalUTCTime, Left decodedUTCTime) ->
+        Right originalUTCTime === decodedUTCTime
+      (Left originalUTCTime, Right decodedZonedTime) ->
+        Right (zonedTimeToTuple (Time.utcToZonedTime Time.utc originalUTCTime))
+          === fmap zonedTimeToTuple decodedZonedTime
+      (Right originalZonedTime, Right decodedZonedTime) -> do
+        Right (zonedTimeToTuple originalZonedTime)
+          === fmap zonedTimeToTuple decodedZonedTime
+      (Right originalZonedTime, Left decodedUTCTime) -> do
+        Right (Time.zonedTimeToUTC originalZonedTime)
+          === decodedUTCTime
+
+encodeTestObject :: [AesonEncoding.Series] -> BS.ByteString
+encodeTestObject =
+  LBS.toStrict
+    . AesonEncoding.encodingToLazyByteString
+    . Aeson.pairs
+    . mconcat
+
+encodeAesonText :: Aeson.ToJSON a => a -> T.Text
+encodeAesonText =
+  LT.toStrict . AesonText.encodeToLazyText
+
+dummyObj :: FC.Fleece schema => String -> schema a -> schema a
+dummyObj field schema =
+  FC.objectNamed "" $
+    FC.constructor id
+      FC.#+ FC.required field id schema
+
+genScientific :: HH.Gen Scientific
+genScientific =
+  scientific
+    <$> Gen.integral (Range.linearFrom 0 (-10000) 10000)
+    <*> Gen.integral (Range.linearFrom 0 minBound maxBound)
+
+genText :: HH.Gen T.Text
+genText =
+  Gen.text (Range.linear 0 32) Gen.unicodeAll
+
+genUTCTime :: HH.Gen Time.UTCTime
+genUTCTime =
+  Time.UTCTime <$> genDay <*> genDiffTime
+
+genZonedTime :: HH.Gen Time.ZonedTime
+genZonedTime =
+  Time.ZonedTime <$> genLocalTime <*> genTimeZone
+
+genLocalTime :: HH.Gen Time.LocalTime
+genLocalTime =
+  Time.LocalTime <$> genDay <*> genTimeOfDay
+
+genTimeZone :: HH.Gen Time.TimeZone
+genTimeZone =
+  Time.minutesToTimeZone <$> Gen.integral (Range.linearFrom 0 (-60 * 12) (60 * 14))
+
+genDay :: HH.Gen Time.Day
+genDay = do
+  year <- Gen.integral (Range.linearFrom 2000 0 3000)
+  month <- Gen.integral (Range.constant 1 12)
+  day <- Gen.integral (Range.constant 1 (Time.gregorianMonthLength year month))
+
+  pure (Time.fromGregorian year month day)
+
+genTimeOfDay :: HH.Gen Time.TimeOfDay
+genTimeOfDay = fmap Time.timeToTimeOfDay genDiffTime
+
+genDiffTime :: HH.Gen Time.DiffTime
+genDiffTime =
+  Time.secondsToDiffTime <$> Gen.integral (Range.constant 0 85399)

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,6 +22,7 @@ packages:
 - json-fleece-openapi3
 - json-fleece-swagger2
 - json-fleece-pretty-print
+- json-fleece-hermes
 # Dependency packages to be pulled from upstream that are not in the resolver.
 # These entries can reference officially published versions as well as
 # forks / in-progress versions pinned to a git hash. For example:
@@ -56,6 +57,9 @@ flags:
   json-fleece-pretty-print:
     strict: true
 
+  json-fleece-hermes:
+    strict: true
+
 extra-deps:
   - git: https://github.com/flipstone/beeline
     commit: d6336c2bb3a72f3475bbe8a7bcfe65bfd861ed5d
@@ -65,6 +69,9 @@ extra-deps:
   - git: https://github.com/flipstone/shrubbery
     commit: 8cd0c45237be047a975d754859fc4b7fb24f49d4
   - non-empty-text-0.2.0@sha256:7d1c1f9a11c78c00c656269f940d2fcccd3c2eaf6b619f66bb83a9ea72decc1f,2438
+  - hermes-json-0.6.1.0@sha256:ab54609e63a83a8e07900360de60ba1e197ea499fa5d3eb782eed980ee07545b,3856
+  - integer-conversion-0.1@sha256:9f77cc7711d3100a4483f2dd1a22f4be5b59d235a556d910d0e6c5e90a967551,2208
+  - text-iso8601-0.1@sha256:fc10d8de72fc094d0d299644f17421b9430d1c1092a1355c7f0c02d8b6edf6a7,2371
 
 
 # Extra package databases containing global packages

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -48,6 +48,27 @@ packages:
       size: 400
   original:
     hackage: non-empty-text-0.2.0@sha256:7d1c1f9a11c78c00c656269f940d2fcccd3c2eaf6b619f66bb83a9ea72decc1f,2438
+- completed:
+    hackage: hermes-json-0.6.1.0@sha256:ab54609e63a83a8e07900360de60ba1e197ea499fa5d3eb782eed980ee07545b,3856
+    pantry-tree:
+      sha256: f7d164e4949316aec0ec1364fcaa2b7bcb52249c60d0ecb5f323d91d3a22b75b
+      size: 1387
+  original:
+    hackage: hermes-json-0.6.1.0@sha256:ab54609e63a83a8e07900360de60ba1e197ea499fa5d3eb782eed980ee07545b,3856
+- completed:
+    hackage: integer-conversion-0.1@sha256:9f77cc7711d3100a4483f2dd1a22f4be5b59d235a556d910d0e6c5e90a967551,2208
+    pantry-tree:
+      sha256: 17063e15091711b54f9a4a9ccb032f3c2ed68bb4ba097243333469ad8462b748
+      size: 509
+  original:
+    hackage: integer-conversion-0.1@sha256:9f77cc7711d3100a4483f2dd1a22f4be5b59d235a556d910d0e6c5e90a967551,2208
+- completed:
+    hackage: text-iso8601-0.1@sha256:fc10d8de72fc094d0d299644f17421b9430d1c1092a1355c7f0c02d8b6edf6a7,2371
+    pantry-tree:
+      sha256: f72aa62f5f4d1155b3d3f35e8227548a27cee83fb5d0742564b5ef26597f1431
+      size: 427
+  original:
+    hackage: text-iso8601-0.1@sha256:fc10d8de72fc094d0d299644f17421b9430d1c1092a1355c7f0c02d8b6edf6a7,2371
 snapshots:
 - completed:
     sha256: 97710f56bf093fca0ee5d8dbe19d96b654c752e405b66795b4baedd84a794c60


### PR DESCRIPTION
Benchmarks for a basic record schema show decent performance. Inlining the `Fleece` methods helps remove overhead at the cost of code size, but performance is the priority when using this library. `Fleece` still introduces some overhead, such as:

* `number` going through `Scientific`
* `list` going through `Vector`
* `required` and `optional` using `String`

`Fleece` core semantics could potentially allow for something like `FC.int`, `FC.double`, and `FC.word` with sane defaults but overridable here so we can use the faster `int`, `double`, and `uint` decoders from Hermes. Same for `FC.list`.

Other small things to note:

* Duplicated decode tests from `json-fleece-aeson`
* Benchmarks don't really cover the whole semantics
  * Would like to see large unions benchmarked