### PR TITLE
Adds a pretty decoder that removes Aeson portion of decoding error

### DIFF
--- a/json-fleece-aeson/json-fleece-aeson.cabal
+++ b/json-fleece-aeson/json-fleece-aeson.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -41,6 +41,7 @@ library
     , base >=4.7 && <5
     , bytestring ==0.11.*
     , containers ==0.6.*
+    , either ==5.0.2
     , json-fleece-core ==0.5.*
     , shrubbery >=0.1.2 && <0.2
     , text >=1.2 && <2.1

--- a/json-fleece-aeson/package.yaml
+++ b/json-fleece-aeson/package.yaml
@@ -57,6 +57,7 @@ library:
     - Fleece.Aeson.Decoder
     - Fleece.Aeson.Encoder
   dependencies:
+    - either == 5.0.2
     - shrubbery >= 0.1.2 && < 0.2
 
 tests:


### PR DESCRIPTION
This splits the error message produced by `fromValue` into two: the Aeson and Fleece error message combined (the original behavior) and just the Fleece error message (that produced by the schema and the `Decoder` functions). `decodePretty`, as a result, produces a slightly easier to understand error message that is more suitable for displaying to users. Ideally, we would be able to remove the type from the error messages produced by the `Decoder` functions as well, but for now, this isn't changing that since it would alter the current tests' expected results.