### PR TITLE
Allow boundedEnum to accept a parameter to modify text beforehand

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "haskell.serverExecutablePath": "${workspaceFolder}/.vim/haskell-language-server-wrapper",
+}
+

--- a/json-fleece-aeson/json-fleece-aeson.cabal
+++ b/json-fleece-aeson/json-fleece-aeson.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-aeson
-version:        0.3.4.0
+version:        0.3.5.0
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-aeson#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -41,7 +41,7 @@ library
     , base >=4.7 && <5
     , bytestring ==0.11.*
     , containers ==0.6.*
-    , json-fleece-core ==0.6.*
+    , json-fleece-core ==0.7.*
     , shrubbery ==0.2.*
     , text >=1.2 && <2.1
     , vector >=0.12 && <0.14
@@ -66,7 +66,7 @@ test-suite json-fleece-aeson-test
     , containers ==0.6.*
     , hedgehog
     , json-fleece-aeson
-    , json-fleece-core ==0.6.*
+    , json-fleece-core ==0.7.*
     , json-fleece-examples
     , scientific >=0.3.7 && <0.4
     , shrubbery ==0.2.*

--- a/json-fleece-aeson/package.yaml
+++ b/json-fleece-aeson/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-aeson
-version:             0.3.4.0
+version:             0.3.5.0
 github:              "flipstone/json-fleece/json-fleece-aeson"
 license:             BSD3
 author:              "Author name here"
@@ -20,7 +20,7 @@ dependencies:
 - aeson >= 2.0 && < 2.2
 - bytestring >= 0.11 && < 0.12
 - containers >= 0.6 && < 0.7
-- json-fleece-core >= 0.6 && < 0.7
+- json-fleece-core >= 0.7 && < 0.8
 - text >= 1.2 && < 2.1
 - vector >= 0.12 && < 0.14
 - shrubbery >= 0.2 && < 0.3

--- a/json-fleece-aeson/src/Fleece/Aeson/Decoder.hs
+++ b/json-fleece-aeson/src/Fleece/Aeson/Decoder.hs
@@ -154,7 +154,7 @@ instance FC.Fleece Decoder where
     Decoder name $
       Aeson.withObject (FC.nameToString name) parseObject
 
-  boundedEnumNamed name toText =
+  boundedEnumNamedModifyText name toText modifyText =
     let
       decodingMap =
         Map.fromList
@@ -163,7 +163,7 @@ instance FC.Fleece Decoder where
     in
       Decoder name $
         Aeson.withText (FC.nameToString name) $ \textValue ->
-          case Map.lookup textValue decodingMap of
+          case Map.lookup (modifyText textValue) decodingMap of
             Just enumValue -> pure enumValue
             Nothing ->
               fail $

--- a/json-fleece-aeson/src/Fleece/Aeson/Encoder.hs
+++ b/json-fleece-aeson/src/Fleece/Aeson/Encoder.hs
@@ -119,7 +119,7 @@ instance FC.Fleece Encoder where
   objectNamed name (Object toSeries) =
     Encoder name (Aeson.pairs . toSeries)
 
-  boundedEnumNamed name toText =
+  boundedEnumNamedModifyText name toText _modifyText =
     Encoder name (Aeson.toEncoding . toText)
 
   validateNamed name uncheck _check (Encoder _unvalidatedName toEncoding) =

--- a/json-fleece-aeson/src/Fleece/Aeson/EncoderDecoder.hs
+++ b/json-fleece-aeson/src/Fleece/Aeson/EncoderDecoder.hs
@@ -133,10 +133,10 @@ instance FC.Fleece EncoderDecoder where
       , decoder = FC.validateNamed name uncheck check $ decoder itemEncoderDecoder
       }
 
-  boundedEnumNamed name toText =
+  boundedEnumNamedModifyText name toText modifyText =
     EncoderDecoder
-      { encoder = FC.boundedEnumNamed name toText
-      , decoder = FC.boundedEnumNamed name toText
+      { encoder = FC.boundedEnumNamedModifyText name toText modifyText
+      , decoder = FC.boundedEnumNamedModifyText name toText modifyText
       }
 
   unionNamed name members =

--- a/json-fleece-core/json-fleece-core.cabal
+++ b/json-fleece-core/json-fleece-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-core
-version:        0.6.0.0
+version:        0.7.0.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-core#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-core/package.yaml
+++ b/json-fleece-core/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-core
-version:             0.6.0.0
+version:             0.7.0.0
 github:              "flipstone/json-fleece/json-fleece-core"
 license:             BSD3
 author:              "Author name here"
@@ -63,4 +63,3 @@ library:
     - Fleece.Core.Class
     - Fleece.Core.Name
     - Fleece.Core.Schemas
-

--- a/json-fleece-core/src/Fleece/Core.hs
+++ b/json-fleece-core/src/Fleece/Core.hs
@@ -45,6 +45,8 @@ module Fleece.Core
     -- * Schemas for common Haskell data types that are useful with JSON
   , boundedEnum
   , boundedEnumNamed
+  , boundedEnumNamedModifyText
+  , boundedEnumModifyText
   , list
   , Fleece.Core.Schemas.map
   , nonEmpty

--- a/json-fleece-core/src/Fleece/Core/Class.hs
+++ b/json-fleece-core/src/Fleece/Core/Class.hs
@@ -27,7 +27,7 @@ module Fleece.Core.Class
       , field
       , additional
       , validateNamed
-      , boundedEnumNamed
+      , boundedEnumNamedModifyText
       , unionNamed
       , unionMemberWithIndex
       , unionCombine
@@ -123,10 +123,11 @@ class Fleece schema where
     (schema b) ->
     (schema a)
 
-  boundedEnumNamed ::
+  boundedEnumNamedModifyText ::
     (Bounded a, Enum a) =>
     Name ->
     (a -> T.Text) ->
+    (T.Text -> T.Text) ->
     schema a
 
   unionNamed ::

--- a/json-fleece-core/src/Fleece/Core/Schemas.hs
+++ b/json-fleece-core/src/Fleece/Core/Schemas.hs
@@ -8,6 +8,8 @@ module Fleece.Core.Schemas
   ( optionalNullable
   , object
   , boundedEnum
+  , boundedEnumNamed
+  , boundedEnumModifyText
   , validate
   , list
   , Fleece.Core.Schemas.map
@@ -83,7 +85,7 @@ import Fleece.Core.Class
   , UnionMembers
   , additionalFields
   , array
-  , boundedEnumNamed
+  , boundedEnumNamedModifyText
   , constructor
   , jsonString
   , nullable
@@ -244,12 +246,28 @@ boundedEnum ::
   (a -> T.Text) ->
   schema a
 boundedEnum toText =
+  boundedEnumModifyText toText id
+
+boundedEnumNamed ::
+  (Fleece schema, Enum a, Bounded a) =>
+  Name ->
+  (a -> T.Text) ->
+  schema a
+boundedEnumNamed name toText =
+  boundedEnumNamedModifyText name toText id
+
+boundedEnumModifyText ::
+  (Fleece schema, Typeable a, Enum a, Bounded a) =>
+  (a -> T.Text) ->
+  (T.Text -> T.Text) ->
+  schema a
+boundedEnumModifyText toText modifyText =
   let
     name =
       defaultSchemaName schema
 
     schema =
-      boundedEnumNamed name toText
+      boundedEnumNamedModifyText name toText modifyText
   in
     schema
 

--- a/json-fleece-examples/json-fleece-examples.cabal
+++ b/json-fleece-examples/json-fleece-examples.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-examples
-version:        0.2.3.0
+version:        0.2.4.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-examples#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -35,7 +35,7 @@ library
   build-depends:
       base >=4.7 && <5
     , containers ==0.6.*
-    , json-fleece-core ==0.6.*
+    , json-fleece-core ==0.7.*
     , scientific >=0.3.7 && <0.4
     , shrubbery ==0.2.*
     , text >=1.2 && <2.1

--- a/json-fleece-examples/package.yaml
+++ b/json-fleece-examples/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-examples
-version:             0.2.3.0
+version:             0.2.4.0
 github:              "flipstone/json-fleece/json-fleece-examples"
 license:             BSD3
 author:              "Author name here"
@@ -18,7 +18,7 @@ description:         Please see the README on GitHub at <https://github.com/flip
 dependencies:
 - base >= 4.7 && < 5
 - containers >= 0.6 && < 0.7
-- json-fleece-core >= 0.6 && < 0.7
+- json-fleece-core >= 0.7 && < 0.8
 - scientific >= 0.3.7 && < 0.4
 - shrubbery >= 0.2 && < 0.3
 - text >= 1.2 && < 2.1

--- a/json-fleece-examples/src/Fleece/Examples.hs
+++ b/json-fleece-examples/src/Fleece/Examples.hs
@@ -17,6 +17,7 @@ module Fleece.Examples
   , optionalNullableFieldOmitKeySchema
   , BoundedEnum (..)
   , boundedEnumSchema
+  , boundedEnumToLowerSchema
   , boundedEnumToText
   , AdditionalFieldsExample (..)
   , additionalFieldsExampleSchema
@@ -49,6 +50,7 @@ import Fleece.Core
   , bareOrJSONString
   , boolean
   , boundedEnum
+  , boundedEnumModifyText
   , constructor
   , int
   , jsonString
@@ -152,6 +154,10 @@ data BoundedEnum
 boundedEnumSchema :: Fleece schema => schema BoundedEnum
 boundedEnumSchema =
   boundedEnum boundedEnumToText
+
+boundedEnumToLowerSchema :: Fleece schema => schema BoundedEnum
+boundedEnumToLowerSchema =
+  boundedEnumModifyText boundedEnumToText T.toLower
 
 boundedEnumToText :: BoundedEnum -> T.Text
 boundedEnumToText e =

--- a/json-fleece-hermes/json-fleece-hermes.cabal
+++ b/json-fleece-hermes/json-fleece-hermes.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-hermes
-version:        0.1.1.0
+version:        0.1.2.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-hermes#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -37,7 +37,7 @@ library
     , bytestring ==0.11.*
     , containers ==0.6.*
     , hermes-json ==0.6.*
-    , json-fleece-core ==0.6.*
+    , json-fleece-core ==0.7.*
     , shrubbery ==0.2.*
     , text >=2.0
   default-language: Haskell2010
@@ -60,7 +60,7 @@ test-suite json-fleece-hermes-test
     , bytestring ==0.11.*
     , containers ==0.6.*
     , hedgehog
-    , json-fleece-core ==0.6.*
+    , json-fleece-core ==0.7.*
     , json-fleece-examples
     , json-fleece-hermes
     , scientific >=0.3.7 && <0.4
@@ -91,7 +91,7 @@ benchmark json-fleece-hermes-bench
     , deepseq
     , hermes-json
     , json-fleece-aeson
-    , json-fleece-core ==0.6.*
+    , json-fleece-core ==0.7.*
     , json-fleece-hermes
     , tasty-bench
     , text

--- a/json-fleece-hermes/package.yaml
+++ b/json-fleece-hermes/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-hermes
-version:             0.1.1.0
+version:             0.1.2.0
 github:              "flipstone/json-fleece/json-fleece-hermes"
 license:             BSD3
 author:              "Author name here"
@@ -18,7 +18,7 @@ description: Please see the README on GitHub at <https://github.com/flipstone/js
 dependencies:
 - base >= 4.7 && < 5
 - bytestring >= 0.11 && < 0.12
-- json-fleece-core >= 0.6 && < 0.7
+- json-fleece-core >= 0.7 && < 0.8
 - text >= 2.0 # This could be problematic for anyone using LTS 20 or below
 
 flags:

--- a/json-fleece-hermes/src/Fleece/Hermes.hs
+++ b/json-fleece-hermes/src/Fleece/Hermes.hs
@@ -141,8 +141,8 @@ instance FC.Fleece Decoder where
   objectNamed name (Object _definedFields parseObject) =
     Decoder name $ H.object parseObject
 
-  {-# INLINE boundedEnumNamed #-}
-  boundedEnumNamed name toText =
+  {-# INLINE boundedEnumNamedModifyText #-}
+  boundedEnumNamedModifyText name toText modifyText =
     let
       decodingMap =
         Map.fromList
@@ -151,7 +151,7 @@ instance FC.Fleece Decoder where
     in
       Decoder name $
         H.withText $ \textValue ->
-          case Map.lookup textValue decodingMap of
+          case Map.lookup (modifyText textValue) decodingMap of
             Just enumValue -> pure enumValue
             Nothing ->
               fail $

--- a/json-fleece-markdown/json-fleece-markdown.cabal
+++ b/json-fleece-markdown/json-fleece-markdown.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-markdown
-version:        0.5.0.0
+version:        0.6.0.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-markdown#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -39,7 +39,7 @@ library
       base >=4.7 && <5
     , containers ==0.6.*
     , dlist ==1.0.*
-    , json-fleece-core ==0.6.*
+    , json-fleece-core ==0.7.*
     , text >=1.2 && <2.1
   default-language: Haskell2010
   if flag(strict)

--- a/json-fleece-markdown/package.yaml
+++ b/json-fleece-markdown/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-markdown
-version:             0.5.0.0
+version:             0.6.0.0
 github:              "flipstone/json-fleece/json-fleece-markdown"
 license:             BSD3
 author:              "Author name here"
@@ -52,7 +52,7 @@ library:
   exposed-modules:
     - Fleece.Markdown
   dependencies:
-    - json-fleece-core >= 0.6 &&  < 0.7
+    - json-fleece-core >= 0.7 &&  < 0.8
     - containers >= 0.6 && < 0.7
     - dlist >= 1.0 && < 1.1
 

--- a/json-fleece-markdown/src/Fleece/Markdown/FleeceInstance.hs
+++ b/json-fleece-markdown/src/Fleece/Markdown/FleeceInstance.hs
@@ -125,7 +125,7 @@ instance FC.Fleece Markdown where
   validateNamed _name _check _unvalidate (Markdown schemaDocs) =
     Markdown schemaDocs
 
-  boundedEnumNamed name toText =
+  boundedEnumNamedModifyText name toText _modifyText =
     let
       enumValues =
         map toText [minBound .. maxBound]

--- a/json-fleece-openapi3/examples/star-trek/package.yaml
+++ b/json-fleece-openapi3/examples/star-trek/package.yaml
@@ -13,7 +13,7 @@ dependencies:
   - base >= 4.7 && < 5
   - text
   - scientific
-  - json-fleece-core >= 0.1.3 && < 0.7
+  - json-fleece-core >= 0.1.3 && < 0.8
   - json-fleece-aeson-beeline >= 0.1 && < 0.2
   - beeline-routing >= 0.2.4 && < 0.3
   - beeline-http-client >= 0.8 && < 0.9

--- a/json-fleece-openapi3/examples/star-trek/star-trek.cabal
+++ b/json-fleece-openapi3/examples/star-trek/star-trek.cabal
@@ -1870,7 +1870,7 @@ library
     , beeline-http-client ==0.8.*
     , beeline-routing >=0.2.4 && <0.3
     , json-fleece-aeson-beeline ==0.1.*
-    , json-fleece-core >=0.1.3 && <0.7
+    , json-fleece-core >=0.1.3 && <0.8
     , scientific
     , text
     , time

--- a/json-fleece-openapi3/examples/test-cases/package.yaml
+++ b/json-fleece-openapi3/examples/test-cases/package.yaml
@@ -14,7 +14,7 @@ dependencies:
   - containers
   - text
   - scientific
-  - json-fleece-core >= 0.1.3 && < 0.7
+  - json-fleece-core >= 0.1.3 && < 0.8
   - json-fleece-aeson-beeline >= 0.1 && < 0.2
   - beeline-routing >= 0.2.4 && < 0.3
   - beeline-http-client >= 0.8 && < 0.9

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -158,7 +158,7 @@ library
     , beeline-routing >=0.2.4 && <0.3
     , containers
     , json-fleece-aeson-beeline ==0.1.*
-    , json-fleece-core >=0.1.3 && <0.7
+    , json-fleece-core >=0.1.3 && <0.8
     , scientific
     , text
     , time

--- a/json-fleece-pretty-print/json-fleece-pretty-print.cabal
+++ b/json-fleece-pretty-print/json-fleece-pretty-print.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-pretty-print
-version:        0.1.3.0
+version:        0.1.4.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-pretty-print#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -36,7 +36,7 @@ library
       base >=4.7 && <5
     , containers ==0.6.*
     , dlist ==1.0.*
-    , json-fleece-core ==0.6.*
+    , json-fleece-core ==0.7.*
     , scientific ==0.3.*
     , shrubbery ==0.2.*
     , text >=1.2 && <2.1
@@ -58,7 +58,7 @@ test-suite json-fleece-pretty-print-test
       base >=4.7 && <5
     , containers ==0.6.*
     , hedgehog
-    , json-fleece-core ==0.6.*
+    , json-fleece-core ==0.7.*
     , json-fleece-examples
     , json-fleece-pretty-print
     , shrubbery ==0.2.*

--- a/json-fleece-pretty-print/package.yaml
+++ b/json-fleece-pretty-print/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-pretty-print
-version:             0.1.3.0
+version:             0.1.4.0
 github:              "flipstone/json-fleece/json-fleece-pretty-print"
 license:             BSD3
 author:              "Author name here"
@@ -17,7 +17,7 @@ description:         Please see the README on GitHub at <https://github.com/flip
 
 dependencies:
 - base >= 4.7 && < 5
-- json-fleece-core >= 0.6 && < 0.7
+- json-fleece-core >= 0.7 && < 0.8
 - shrubbery >= 0.2 && < 0.3
 - text >= 1.2 && < 2.1
 

--- a/json-fleece-pretty-print/src/Fleece/PrettyPrint.hs
+++ b/json-fleece-pretty-print/src/Fleece/PrettyPrint.hs
@@ -172,7 +172,7 @@ instance FC.Fleece PrettyPrinter where
         (renderName name)
         (toPretty (unvalidate value))
 
-  boundedEnumNamed name toText =
+  boundedEnumNamedModifyText name toText _modifyText =
     PrettyPrinter name (showInline . toText)
 
   unionNamed name (UnionMembers branches) =

--- a/json-fleece-swagger2/examples/uber/package.yaml
+++ b/json-fleece-swagger2/examples/uber/package.yaml
@@ -13,7 +13,7 @@ dependencies:
   - base >= 4.7 && < 5
   - text
   - scientific
-  - json-fleece-core >= 0.1.3 && < 0.7
+  - json-fleece-core >= 0.1.3 && < 0.8
   - json-fleece-aeson-beeline >= 0.1 && < 0.2
   - beeline-routing >= 0.2.4 && < 0.3
   - beeline-http-client >= 0.8 && < 0.9

--- a/json-fleece-swagger2/examples/uber/uber.cabal
+++ b/json-fleece-swagger2/examples/uber/uber.cabal
@@ -73,7 +73,7 @@ library
     , beeline-http-client ==0.8.*
     , beeline-routing >=0.2.4 && <0.3
     , json-fleece-aeson-beeline ==0.1.*
-    , json-fleece-core >=0.1.3 && <0.7
+    , json-fleece-core >=0.1.3 && <0.8
     , scientific
     , text
     , time


### PR DESCRIPTION
This let's us handle an enum where the input text may not exactly match the toText values but can be converted to them (such as converting to lower case values).