### PR TITLE
[sc-35836] Add initial oneOf schema code gen support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "haskell.serverExecutablePath": "${workspaceFolder}/.vim/haskell-language-server-wrapper",
+}

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/TopLevelOneOf.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/TopLevelOneOf.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.TopLevelOneOf
+  ( TopLevelOneOf(..)
+  , topLevelOneOfSchema
+  ) where
+
+import qualified Data.Text as T
+import Fleece.Core ((#|))
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Integer, Show)
+import qualified Shrubbery as Shrubbery
+import qualified TestCases.Types.AStringType as AStringType
+import qualified TestCases.Types.FieldDescriptions as FieldDescriptions
+import qualified TestCases.Types.MixedInJustAdditionalPropertiesSchemaInline as MixedInJustAdditionalPropertiesSchemaInline
+import qualified TestCases.Types.Num2SchemaStartingWithNumber as Num2SchemaStartingWithNumber
+
+newtype TopLevelOneOf = TopLevelOneOf (Shrubbery.Union '[T.Text, Integer, AStringType.AStringType, Num2SchemaStartingWithNumber.Num2SchemaStartingWithNumber, [FieldDescriptions.FieldDescriptions], [[MixedInJustAdditionalPropertiesSchemaInline.MixedInJustAdditionalPropertiesSchemaInline]]])
+  deriving (Show, Eq)
+
+topLevelOneOfSchema :: FC.Fleece schema => schema TopLevelOneOf
+topLevelOneOfSchema =
+  FC.coerceSchema $
+    FC.unionNamed (FC.unqualifiedName "TopLevelOneOf") $
+      FC.unionMember FC.text
+        #| FC.unionMember FC.integer
+        #| FC.unionMember AStringType.aStringTypeSchema
+        #| FC.unionMember Num2SchemaStartingWithNumber.num2SchemaStartingWithNumberSchema
+        #| FC.unionMember (FC.list FieldDescriptions.fieldDescriptionsSchema)
+        #| FC.unionMember (FC.list (FC.list MixedInJustAdditionalPropertiesSchemaInline.mixedInJustAdditionalPropertiesSchemaInlineSchema))

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/TopLevelOneOfOneOption.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/TopLevelOneOfOneOption.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.TopLevelOneOfOneOption
+  ( TopLevelOneOfOneOption(..)
+  , topLevelOneOfOneOptionSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Show)
+import qualified Shrubbery as Shrubbery
+
+newtype TopLevelOneOfOneOption = TopLevelOneOfOneOption (Shrubbery.Union '[T.Text])
+  deriving (Show, Eq)
+
+topLevelOneOfOneOptionSchema :: FC.Fleece schema => schema TopLevelOneOfOneOption
+topLevelOneOfOneOptionSchema =
+  FC.coerceSchema $
+    FC.unionNamed (FC.unqualifiedName "TopLevelOneOfOneOption") $
+      FC.unionMember FC.text

--- a/json-fleece-openapi3/examples/test-cases/package.yaml
+++ b/json-fleece-openapi3/examples/test-cases/package.yaml
@@ -18,6 +18,7 @@ dependencies:
   - json-fleece-aeson-beeline >= 0.1 && < 0.2
   - beeline-routing >= 0.2.4 && < 0.3
   - beeline-http-client >= 0.8 && < 0.9
+  - shrubbery >= 0.2 && < 0.3
   - time
 
 ghc-options:

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -145,6 +145,8 @@ library
       TestCases.Types.TopLevelArray.TopLevelArrayItem
       TestCases.Types.TopLevelArrayNullable
       TestCases.Types.TopLevelArrayNullable.TopLevelArrayNullableItem
+      TestCases.Types.TopLevelOneOf
+      TestCases.Types.TopLevelOneOfOneOption
       TestCases.Types.UtcTimeType
       TestCases.Types.ZonedTimeType
   other-modules:
@@ -160,6 +162,7 @@ library
     , json-fleece-aeson-beeline ==0.1.*
     , json-fleece-core >=0.1.3 && <0.7
     , scientific
+    , shrubbery ==0.2.*
     , text
     , time
   default-language: Haskell2010

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -483,6 +483,25 @@ components:
         - arrayField
         - nullableArrayField
 
+    TopLevelOneOf:
+      oneOf:
+        - type: string
+        - type: integer
+        - $ref: "#/components/schemas/AStringType"
+        - $ref: "#/components/schemas/2_SchemaStartingWithNumber"
+        - items:
+            $ref: "#/components/schemas/FieldDescriptions"
+          type: array
+        - items:
+            items:
+              $ref: "#/components/schemas/MixedInJustAdditionalPropertiesSchemaInline"
+            type: array
+          type: array
+
+    TopLevelOneOfOneOption:
+      oneOf:
+        - type: string
+
     TopLevelArray:
       type: array
       description: A schema that defines a top level array

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -1992,6 +1992,8 @@ extra-source-files:
     examples/test-cases/TestCases/Types/TopLevelArray/TopLevelArrayItem.hs
     examples/test-cases/TestCases/Types/TopLevelArrayNullable.hs
     examples/test-cases/TestCases/Types/TopLevelArrayNullable/TopLevelArrayNullableItem.hs
+    examples/test-cases/TestCases/Types/TopLevelOneOf.hs
+    examples/test-cases/TestCases/Types/TopLevelOneOfOneOption.hs
     examples/test-cases/TestCases/Types/UtcTimeType.hs
     examples/test-cases/TestCases/Types/ZonedTimeType.hs
 


### PR DESCRIPTION
This uses shrubbery untagged unions to implement oneOf code gen. We could use tagged unions here but I'm not sure if doing so adds any meaningful information.

Remaining notes and questions:
  - I don't fully understand `SchemaMap`s, so I think they may be handled incorrectly, what is there indended use, and should we try to use them here instead of inferType? If yes, is there a test case that would reveal an issue with not using them
  - Related to the above, should we extract/share code between `mkInlineOneOfSchema` and `mkInlineBodySchema`?
  - This does not implement openapi discriminators, which is where I imagine using tagged unions might become useful
  - This does not implement inline objects as choices for `oneOf`
  - Are there any other test cases we want for the initial implementation?
  - If we run into `anyOf` being used, it would probably be simple to have it just call out to the `oneOf` code (though hopefully no one ever uses `anyOf`...)