### PR TITLE
Ignores additional properties by default

### DIFF
--- a/json-fleece-codegen-util/codegen-prelude.dhall
+++ b/json-fleece-codegen-util/codegen-prelude.dhall
@@ -34,7 +34,7 @@ let
   baseConfig =
     { defaultTypeOptions = TypeOptions.default
     , typeOptions = [] : List SpecificTypeOptions
-    , ignoreAdditionalProperties = True
+    , strictAdditionalProperties = True
     }
 
 in

--- a/json-fleece-codegen-util/codegen-prelude.dhall
+++ b/json-fleece-codegen-util/codegen-prelude.dhall
@@ -34,6 +34,7 @@ let
   baseConfig =
     { defaultTypeOptions = TypeOptions.default
     , typeOptions = [] : List SpecificTypeOptions
+    , ignoreAdditionalProperties = True
     }
 
 in

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
@@ -93,7 +93,7 @@ data CodeGenOptions = CodeGenOptions
   { moduleBaseName :: T.Text
   , defaultTypeOptions :: TypeOptions
   , typeOptionsMap :: Map.Map T.Text TypeOptions
-  , ignoreAdditionalProperties :: Bool
+  , strictAdditionalProperties :: Bool
   }
 
 data TypeOptions = TypeOptions

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
@@ -93,6 +93,7 @@ data CodeGenOptions = CodeGenOptions
   { moduleBaseName :: T.Text
   , defaultTypeOptions :: TypeOptions
   , typeOptionsMap :: Map.Map T.Text TypeOptions
+  , ignoreAdditionalProperties :: Bool
   }
 
 data TypeOptions = TypeOptions

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/Config.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/Config.hs
@@ -26,6 +26,7 @@ decoder =
                 <$> Dhall.field "moduleBaseName" Dhall.strictText
                 <*> Dhall.field "defaultTypeOptions" typeOptionsDecoder
                 <*> Dhall.field "typeOptions" typeOptionsMapDecoder
+                <*> Dhall.field "ignoreAdditionalProperties" Dhall.bool
             )
         <*> Dhall.field "inputFileName" Dhall.string
         <*> Dhall.field "destination" Dhall.string

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/Config.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/Config.hs
@@ -26,7 +26,7 @@ decoder =
                 <$> Dhall.field "moduleBaseName" Dhall.strictText
                 <*> Dhall.field "defaultTypeOptions" typeOptionsDecoder
                 <*> Dhall.field "typeOptions" typeOptionsMapDecoder
-                <*> Dhall.field "ignoreAdditionalProperties" Dhall.bool
+                <*> Dhall.field "strictAdditionalProperties" Dhall.bool
             )
         <*> Dhall.field "inputFileName" Dhall.string
         <*> Dhall.field "destination" Dhall.string

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse.hs
@@ -5,9 +5,7 @@ module TestCases.Types.MixedInAdditionalPropertiesFalse
   , mixedInAdditionalPropertiesFalseSchema
   ) where
 
-import qualified Data.Map as Map
-import qualified Data.Text as T
-import Fleece.Core ((#*), (#+))
+import Fleece.Core ((#+))
 import qualified Fleece.Core as FC
 import Prelude (($), Eq, Maybe, Show)
 import qualified TestCases.Types.MixedInAdditionalPropertiesFalse.Bar as Bar
@@ -16,7 +14,6 @@ import qualified TestCases.Types.MixedInAdditionalPropertiesFalse.Foo as Foo
 data MixedInAdditionalPropertiesFalse = MixedInAdditionalPropertiesFalse
   { bar :: Maybe Bar.Bar
   , foo :: Maybe Foo.Foo
-  , additionalProperties :: (Map.Map T.Text FC.AnyJSON)
   }
   deriving (Eq, Show)
 
@@ -26,4 +23,3 @@ mixedInAdditionalPropertiesFalseSchema =
     FC.constructor MixedInAdditionalPropertiesFalse
       #+ FC.optional "bar" bar Bar.barSchema
       #+ FC.optional "foo" foo Foo.fooSchema
-      #* FC.additionalFields additionalProperties FC.anyJSON

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInAdditionalPropertiesFalse
+  ( MixedInAdditionalPropertiesFalse(..)
+  , mixedInAdditionalPropertiesFalseSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Fleece.Core ((#*), (#+))
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Maybe, Show)
+import qualified TestCases.Types.MixedInAdditionalPropertiesFalse.Bar as Bar
+import qualified TestCases.Types.MixedInAdditionalPropertiesFalse.Foo as Foo
+
+data MixedInAdditionalPropertiesFalse = MixedInAdditionalPropertiesFalse
+  { bar :: Maybe Bar.Bar
+  , foo :: Maybe Foo.Foo
+  , additionalProperties :: (Map.Map T.Text FC.AnyJSON)
+  }
+  deriving (Eq, Show)
+
+mixedInAdditionalPropertiesFalseSchema :: FC.Fleece schema => schema MixedInAdditionalPropertiesFalse
+mixedInAdditionalPropertiesFalseSchema =
+  FC.object $
+    FC.constructor MixedInAdditionalPropertiesFalse
+      #+ FC.optional "bar" bar Bar.barSchema
+      #+ FC.optional "foo" foo Foo.fooSchema
+      #* FC.additionalFields additionalProperties FC.anyJSON

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse/Bar.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse/Bar.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInAdditionalPropertiesFalse.Bar
+  ( Bar(..)
+  , barSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Bar = Bar T.Text
+  deriving (Show, Eq)
+
+barSchema :: FC.Fleece schema => schema Bar
+barSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse/Foo.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse/Foo.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MixedInAdditionalPropertiesFalse.Foo
+  ( Foo(..)
+  , fooSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Foo = Foo T.Text
+  deriving (Show, Eq)
+
+fooSchema :: FC.Fleece schema => schema Foo
+fooSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/codegen.dhall
+++ b/json-fleece-openapi3/examples/test-cases/codegen.dhall
@@ -8,6 +8,7 @@ in
       { moduleBaseName = "TestCases"
       , inputFileName = "${rootDir}/test-cases.yaml"
       , destination = rootDir
+      , strictAdditionalProperties = False
       , typeOptions =
           [ { type = "TestCases.Types.CustomDateFormat.CustomDateFormat"
             , options =

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -104,6 +104,9 @@ library
       TestCases.Types.JustAdditionalPropertiesSchemaRef
       TestCases.Types.JustAdditionalPropertiesTrue
       TestCases.Types.LocalTimeType
+      TestCases.Types.MixedInAdditionalPropertiesFalse
+      TestCases.Types.MixedInAdditionalPropertiesFalse.Bar
+      TestCases.Types.MixedInAdditionalPropertiesFalse.Foo
       TestCases.Types.MixedInAdditionalPropertiesTrue
       TestCases.Types.MixedInAdditionalPropertiesTrue.Bar
       TestCases.Types.MixedInAdditionalPropertiesTrue.Foo

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -715,6 +715,16 @@ components:
           type: string
       additionalProperties: true
 
+    MixedInAdditionalPropertiesFalse:
+      type: object
+      description: An object with additionalProperties = false mixed in with other properties. This will produce an error if `ignoreAdditionalProperties` is set to `False`.
+      properties:
+        foo:
+          type: string
+        bar:
+          type: string
+      additionalProperties: false
+
     MixedInJustAdditionalPropertiesSchemaRef:
       type: object
       description: An object with additionalProperties as a schema ref mixed in with other properties

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -717,7 +717,7 @@ components:
 
     MixedInAdditionalPropertiesFalse:
       type: object
-      description: An object with additionalProperties = false mixed in with other properties. This will produce an error if `ignoreAdditionalProperties` is set to `False`.
+      description: An object with additionalProperties = false mixed in with other properties. This will produce an error if `strictAdditionalProperties` is set to `True`.
       properties:
         foo:
           type: string

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -1951,6 +1951,9 @@ extra-source-files:
     examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaRef.hs
     examples/test-cases/TestCases/Types/JustAdditionalPropertiesTrue.hs
     examples/test-cases/TestCases/Types/LocalTimeType.hs
+    examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse.hs
+    examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse/Bar.hs
+    examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse/Foo.hs
     examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue.hs
     examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue/Bar.hs
     examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesTrue/Foo.hs
@@ -2025,6 +2028,7 @@ library
     , containers ==0.6.*
     , insert-ordered-containers ==0.2.*
     , json-fleece-codegen-util ==0.8.*
+    , mtl ==2.2.*
     , non-empty-text ==0.2.*
     , openapi3 ==3.2.*
     , text >=1.2 && <2.1

--- a/json-fleece-openapi3/package.yaml
+++ b/json-fleece-openapi3/package.yaml
@@ -63,6 +63,7 @@ library:
     - aeson >= 2.0 && < 2.2
     - insert-ordered-containers >= 0.2 && < 0.3
     - containers >= 0.6 && < 0.7
+    - mtl >= 2.2 && < 2.3
     - non-empty-text >= 0.2 && < 0.3
     - openapi3 >= 3.2 && < 3.3
     - text >= 1.2 && < 2.1

--- a/json-fleece-openapi3/src/Fleece/OpenApi3.hs
+++ b/json-fleece-openapi3/src/Fleece/OpenApi3.hs
@@ -391,17 +391,19 @@ mkInlineStringSchema schemaKey schema = do
     Nothing -> pure . schemaInfoWithoutDependencies $ CGU.textSchemaTypeInfo
     Just _values -> do
       (_moduleName, typeName) <- CGU.inferTypeForInputName CGU.Operation schemaKey
-      (inlinedTypes, schemaTypeInfo) <-
+      mbInlinedTypesAndSchemaTypeInfo <-
         mkSchemaTypeInfo
           schemaKey
           typeName
           schema
-
-      pure $
-        SchemaTypeInfoWithDeps
-          { schemaTypeInfoDependent = Left schemaTypeInfo
-          , schemaTypeInfoDependencies = inlinedTypes
-          }
+      case mbInlinedTypesAndSchemaTypeInfo of
+        Just (inlinedTypes, schemaTypeInfo) ->
+          pure $
+            SchemaTypeInfoWithDeps
+              { schemaTypeInfoDependent = Left schemaTypeInfo
+              , schemaTypeInfoDependencies = inlinedTypes
+              }
+        Nothing -> pure . schemaInfoWithoutDependencies $ CGU.textSchemaTypeInfo
 
 mkInlineBoolSchema :: CGU.CodeGen SchemaTypeInfoWithDeps
 mkInlineBoolSchema =
@@ -426,50 +428,63 @@ mkInlineBodyObjectSchema ::
   CGU.CodeGen SchemaTypeInfoWithDeps
 mkInlineBodyObjectSchema raiseError schemaKey schemaMap schema =
   if IOHM.null (OA._schemaProperties schema)
-    then
-      mkAdditionalPropertiesMapSchema
-        raiseError
-        schemaKey
-        (\key itemSchema -> mkInlineBodySchema raiseError key schemaMap itemSchema)
-        (OA._schemaAdditionalProperties schema)
-    else do
-      (_moduleName, typeName) <- CGU.inferTypeForInputName CGU.Operation schemaKey
-      (fieldsSchemaMap, dataFormat) <-
-        mkOpenApiObjectFormat
-          CGU.Operation
+    then do
+      mbAdditionalPropertiesMapSchema <-
+        mkAdditionalPropertiesMapSchema
+          raiseError
           schemaKey
-          typeName
-          schema
+          (\key itemSchema -> mkInlineBodySchema raiseError key schemaMap itemSchema)
+          (OA._schemaAdditionalProperties schema)
+      case mbAdditionalPropertiesMapSchema of
+        Just additionalPropertiesMapSchema ->
+          pure additionalPropertiesMapSchema
+        Nothing ->
+          mkInlineBodyObjectWithNoAdditionalPropertiesSchema schemaKey schema
+    else mkInlineBodyObjectWithNoAdditionalPropertiesSchema schemaKey schema
 
-      schemaTypeInfo <- CGU.inferSchemaInfoForTypeName typeName
+mkInlineBodyObjectWithNoAdditionalPropertiesSchema ::
+  T.Text ->
+  OA.Schema ->
+  CGU.CodeGen SchemaTypeInfoWithDeps
+mkInlineBodyObjectWithNoAdditionalPropertiesSchema schemaKey schema = do
+  (_moduleName, typeName) <- CGU.inferTypeForInputName CGU.Operation schemaKey
+  (fieldsSchemaMap, dataFormat) <-
+    mkOpenApiObjectFormat
+      CGU.Operation
+      schemaKey
+      typeName
+      schema
 
-      let
-        codeGenType =
-          CGU.CodeGenType
-            { CGU.codeGenTypeOriginalName = schemaKey
-            , CGU.codeGenTypeName = typeName
-            , CGU.codeGenTypeSchemaInfo = schemaTypeInfo
-            , CGU.codeGenTypeDescription = NET.fromText =<< OA._schemaDescription schema
-            , CGU.codeGenTypeDataFormat = dataFormat
-            }
+  schemaTypeInfo <- CGU.inferSchemaInfoForTypeName typeName
 
-        schemaEntry =
-          SchemaEntry
-            { schemaOpenApiSchema = schema
-            , schemaCodeGenType = codeGenType
-            }
+  let
+    codeGenType =
+      CGU.CodeGenType
+        { CGU.codeGenTypeOriginalName = schemaKey
+        , CGU.codeGenTypeName = typeName
+        , CGU.codeGenTypeSchemaInfo = schemaTypeInfo
+        , CGU.codeGenTypeDescription =
+            NET.fromText =<< OA._schemaDescription schema
+        , CGU.codeGenTypeDataFormat = dataFormat
+        }
 
-        codeGenModules =
-          Map.insert
-            (CGU.SchemaKey schemaKey)
-            schemaEntry
-            fieldsSchemaMap
+    schemaEntry =
+      SchemaEntry
+        { schemaOpenApiSchema = schema
+        , schemaCodeGenType = codeGenType
+        }
 
-      pure $
-        SchemaTypeInfoWithDeps
-          { schemaTypeInfoDependent = Left schemaTypeInfo
-          , schemaTypeInfoDependencies = codeGenModules
-          }
+    codeGenModules =
+      Map.insert
+        (CGU.SchemaKey schemaKey)
+        schemaEntry
+        fieldsSchemaMap
+
+  pure $
+    SchemaTypeInfoWithDeps
+      { schemaTypeInfoDependent = Left schemaTypeInfo
+      , schemaTypeInfoDependencies = codeGenModules
+      }
 
 mkInlineArraySchema ::
   (forall a. String -> CGU.CodeGen a) ->
@@ -818,53 +833,57 @@ schemaTypeToParamInfo schemaMap paramName paramLocation operationKey schema =
 mkSchemaMap :: CGU.CodeSection -> T.Text -> OA.Schema -> CGU.CodeGen SchemaMap
 mkSchemaMap section schemaKey schema = do
   (_moduleName, typeName) <- CGU.inferTypeForInputName section schemaKey
-  fmap fst (mkSchemaTypeInfo schemaKey typeName schema)
+  maybe Map.empty fst <$> mkSchemaTypeInfo schemaKey typeName schema
 
 mkSchemaTypeInfo ::
   T.Text ->
   HC.TypeName ->
   OA.Schema ->
-  CGU.CodeGen (SchemaMap, CGU.SchemaTypeInfo)
+  CGU.CodeGen (Maybe (SchemaMap, CGU.SchemaTypeInfo))
 mkSchemaTypeInfo schemaKey typeName schema = do
   baseSchemaInfo <- CGU.inferSchemaInfoForTypeName typeName
-  (inlinedTypes, dataFormat) <- mkOpenApiDataFormat schemaKey typeName schema
+  mbOpenApiDataFormat <- mkOpenApiDataFormat schemaKey typeName schema
 
-  let
-    schemaInfo =
-      case OA._schemaNullable schema of
-        Just True -> CGU.nullableTypeInfo baseSchemaInfo
-        _ -> baseSchemaInfo
+  case mbOpenApiDataFormat of
+    Just (inlinedTypes, dataFormat) ->
+      let
+        schemaInfo =
+          case OA._schemaNullable schema of
+            Just True -> CGU.nullableTypeInfo baseSchemaInfo
+            _ -> baseSchemaInfo
 
-    codeGenType =
-      CGU.CodeGenType
-        { CGU.codeGenTypeOriginalName = schemaKey
-        , CGU.codeGenTypeName = typeName
-        , CGU.codeGenTypeSchemaInfo = schemaInfo
-        , CGU.codeGenTypeDescription = NET.fromText =<< OA._schemaDescription schema
-        , CGU.codeGenTypeDataFormat = dataFormat
-        }
+        codeGenType =
+          CGU.CodeGenType
+            { CGU.codeGenTypeOriginalName = schemaKey
+            , CGU.codeGenTypeName = typeName
+            , CGU.codeGenTypeSchemaInfo = schemaInfo
+            , CGU.codeGenTypeDescription = NET.fromText =<< OA._schemaDescription schema
+            , CGU.codeGenTypeDataFormat = dataFormat
+            }
 
-    schemaEntry =
-      SchemaEntry
-        { schemaOpenApiSchema = schema
-        , schemaCodeGenType = codeGenType
-        }
+        schemaEntry =
+          SchemaEntry
+            { schemaOpenApiSchema = schema
+            , schemaCodeGenType = codeGenType
+            }
 
-    schemaMap =
-      Map.singleton (CGU.SchemaKey schemaKey) schemaEntry <> inlinedTypes
-
-  pure (schemaMap, schemaInfo)
+        schemaMap =
+          Map.singleton (CGU.SchemaKey schemaKey) schemaEntry <> inlinedTypes
+      in
+        pure $ Just (schemaMap, schemaInfo)
+    Nothing ->
+      pure Nothing
 
 mkOpenApiDataFormat ::
   T.Text ->
   HC.TypeName ->
   OA.Schema ->
-  CGU.CodeGen (SchemaMap, CGU.CodeGenDataFormat)
+  CGU.CodeGen (Maybe (SchemaMap, CGU.CodeGenDataFormat))
 mkOpenApiDataFormat schemaKey typeName schema =
   let
     noRefs mkFormat = do
       dataFormat <- mkFormat
-      pure (Map.empty, dataFormat)
+      pure $ Just (Map.empty, dataFormat)
   in
     case OA._schemaType schema of
       Just OA.OpenApiString -> noRefs $ mkOpenApiStringFormat typeName schema
@@ -873,17 +892,27 @@ mkOpenApiDataFormat schemaKey typeName schema =
       Just OA.OpenApiBoolean -> do
         typeOptions <- CGU.lookupTypeOptions typeName
         noRefs $ pure (CGU.boolFormat typeOptions)
-      Just OA.OpenApiArray -> mkOpenApiArrayFormat schemaKey typeName schema
-      Just OA.OpenApiObject -> mkOpenApiObjectFormatOrAdditionalPropertiesNewtype CGU.Type schemaKey typeName schema
+      Just OA.OpenApiArray ->
+        Just <$> mkOpenApiArrayFormat schemaKey typeName schema
+      Just OA.OpenApiObject ->
+        mkOpenApiObjectFormatOrAdditionalPropertiesNewtype
+          CGU.Type
+          schemaKey
+          typeName
+          schema
       Just OA.OpenApiNull -> do
         typeOptions <- CGU.lookupTypeOptions typeName
         noRefs $ pure (CGU.nullFormat typeOptions)
       Nothing ->
         case OA._schemaOneOf schema of
           Just schemas ->
-            mkOneOf schemaKey schemas
+            Just <$> mkOneOf schemaKey schemas
           Nothing ->
-            mkOpenApiObjectFormatOrAdditionalPropertiesNewtype CGU.Type schemaKey typeName schema
+            mkOpenApiObjectFormatOrAdditionalPropertiesNewtype
+              CGU.Type
+              schemaKey
+              typeName
+              schema
 
 mkOneOf ::
   T.Text ->
@@ -974,7 +1003,7 @@ mkOpenApiObjectFormatOrAdditionalPropertiesNewtype ::
   T.Text ->
   HC.TypeName ->
   OA.Schema ->
-  CGU.CodeGen (SchemaMap, CGU.CodeGenDataFormat)
+  CGU.CodeGen (Maybe (SchemaMap, CGU.CodeGenDataFormat))
 mkOpenApiObjectFormatOrAdditionalPropertiesNewtype section schemaKey typeName schema = do
   if IOHM.null (OA._schemaProperties schema)
     then
@@ -983,19 +1012,14 @@ mkOpenApiObjectFormatOrAdditionalPropertiesNewtype section schemaKey typeName sc
         schemaKey
         typeName
         schema
-    else
-      mkOpenApiObjectFormat
-        section
-        schemaKey
-        typeName
-        schema
+    else Just <$> mkOpenApiObjectFormat section schemaKey typeName schema
 
 mkOpenApiAdditionalPropertiesNewtype ::
   CGU.CodeSection ->
   T.Text ->
   HC.TypeName ->
   OA.Schema ->
-  CGU.CodeGen (SchemaMap, CGU.CodeGenDataFormat)
+  CGU.CodeGen (Maybe (SchemaMap, CGU.CodeGenDataFormat))
 mkOpenApiAdditionalPropertiesNewtype section schemaKey typeName schema = do
   let
     raiseError err =
@@ -1005,21 +1029,25 @@ mkOpenApiAdditionalPropertiesNewtype section schemaKey typeName schema = do
           <> ": "
           <> err
 
-  schemaTypeInfoWithDeps <-
+  mbSchemaTypeInfoWithDeps <-
     mkAdditionalPropertiesMapSchema
       raiseError
       schemaKey
       (mkAdditionalPropertiesInlineItemSchema section)
       (OA._schemaAdditionalProperties schema)
 
-  typeOptions <- CGU.lookupTypeOptions typeName
+  case mbSchemaTypeInfoWithDeps of
+    Just schemaTypeInfoWithDeps -> do
+      typeOptions <- CGU.lookupTypeOptions typeName
 
-  let
-    format =
-      CGU.CodeGenNewType
-        typeOptions
-        (schemaTypeInfoDependent schemaTypeInfoWithDeps)
-  pure (schemaTypeInfoDependencies schemaTypeInfoWithDeps, format)
+      let
+        format =
+          CGU.CodeGenNewType
+            typeOptions
+            (schemaTypeInfoDependent schemaTypeInfoWithDeps)
+      pure $ Just (schemaTypeInfoDependencies schemaTypeInfoWithDeps, format)
+    Nothing ->
+      pure Nothing
 
 mkOpenApiObjectFormat ::
   CGU.CodeSection ->
@@ -1054,12 +1082,11 @@ mkOpenApiObjectFormat section schemaKey typeName schema = do
       Nothing ->
         pure Nothing
       Just additionalProperties ->
-        fmap Just $
-          mkAdditionalPropertiesSchema
-            raiseAdditionalPropsError
-            schemaKey
-            (mkAdditionalPropertiesInlineItemSchema section)
-            (Just additionalProperties)
+        mkAdditionalPropertiesSchema
+          raiseAdditionalPropsError
+          schemaKey
+          (mkAdditionalPropertiesInlineItemSchema section)
+          (Just additionalProperties)
 
   let
     dependencies =
@@ -1229,21 +1256,25 @@ mkAdditionalPropertiesMapSchema ::
   T.Text ->
   (T.Text -> OA.Schema -> CGU.CodeGen SchemaTypeInfoWithDeps) ->
   Maybe OA.AdditionalProperties ->
-  CGU.CodeGen SchemaTypeInfoWithDeps
-mkAdditionalPropertiesMapSchema raiseError schemaKey mkInlineItemSchema mbAdditionalProperties =
-  fmap (fmapSchemaInfoAndDeps $ bimap CGU.mapTypeInfo CGU.CodeGenRefMap) $
+  CGU.CodeGen (Maybe SchemaTypeInfoWithDeps)
+mkAdditionalPropertiesMapSchema raiseError schemaKey mkInlineItemSchema mbAdditionalProperties = do
+  mbSchema <-
     mkAdditionalPropertiesSchema
       raiseError
       schemaKey
       mkInlineItemSchema
       mbAdditionalProperties
 
+  pure
+    . fmap (fmapSchemaInfoAndDeps $ bimap CGU.mapTypeInfo CGU.CodeGenRefMap)
+    $ mbSchema
+
 mkAdditionalPropertiesSchema ::
   (forall a. String -> CGU.CodeGen a) ->
   T.Text ->
   (T.Text -> OA.Schema -> CGU.CodeGen SchemaTypeInfoWithDeps) ->
   Maybe OA.AdditionalProperties ->
-  CGU.CodeGen SchemaTypeInfoWithDeps
+  CGU.CodeGen (Maybe SchemaTypeInfoWithDeps)
 mkAdditionalPropertiesSchema raiseError schemaKey mkInlineItemSchema mbAdditionalProperties =
   case mbAdditionalProperties of
     Nothing ->
@@ -1252,27 +1283,26 @@ mkAdditionalPropertiesSchema raiseError schemaKey mkInlineItemSchema mbAdditiona
       -- defaulting to True, so we handle this the same as if only
       -- additional properties was defined as true.
       pure
+        . Just
         . schemaInfoWithoutDependencies
         $ CGU.anyJSONSchemaTypeInfo
     Just (OA.AdditionalPropertiesAllowed True) ->
       pure
+        . Just
         . schemaInfoWithoutDependencies
         $ CGU.anyJSONSchemaTypeInfo
     Just (OA.AdditionalPropertiesAllowed False) -> do
-      ignoreAdditionalProperties <- asks CGU.ignoreAdditionalProperties
-      if ignoreAdditionalProperties
+      strictAdditionalProperties <- asks CGU.strictAdditionalProperties
+      if strictAdditionalProperties
         then
-          pure
-            . schemaInfoWithoutDependencies
-            $ CGU.anyJSONSchemaTypeInfo
-        else
           raiseError $
             "Schemas for objects with additional properties disallowed are"
               <> " not yet supported. `additionalProperties: false` can be"
-              <> " ignored by setting the `ignoreAdditionalProperties` field"
-              <> " in the Fleece code gen config to false."
+              <> " ignored by overriding the `strictAdditionalProperties`"
+              <> " field in the Fleece code gen config as false."
+        else pure Nothing
     Just (OA.AdditionalPropertiesSchema (OA.Ref ref)) ->
-      pure $
+      pure . Just $
         SchemaTypeInfoWithDeps
           { schemaTypeInfoDependent = Right $ CGU.TypeReference $ OA.getReference ref
           , schemaTypeInfoDependencies = Map.empty
@@ -1282,4 +1312,4 @@ mkAdditionalPropertiesSchema raiseError schemaKey mkInlineItemSchema mbAdditiona
         itemKey =
           schemaKey <> "Item"
       in
-        mkInlineItemSchema itemKey innerSchema
+        Just <$> mkInlineItemSchema itemKey innerSchema


### PR DESCRIPTION
This adds a config field `ignoreAdditionalProperties` which is defaulted to `True`. When code gen encounters `additionalProperties: false`, we now ignore it or produce an error based on the value of that config field.