### PR TITLE
Allow format specifier for all date/time types

### DIFF
--- a/json-fleece-codegen-util/codegen-prelude.dhall
+++ b/json-fleece-codegen-util/codegen-prelude.dhall
@@ -2,9 +2,6 @@ let
   DateTimeFormat = < UTCTime | ZonedTime | LocalTime >
 
 let
-  DateFormat = < ISO8601Date | CustomDate : Text >
-
-let
   DerivableClass = < Show | Eq | Ord | Enum | Bounded >
 
 let
@@ -14,12 +11,12 @@ let
   TypeOptions =
     { Type =
         { dateTimeFormat : DateTimeFormat
-        , dateFormat : DateFormat
+        , formatSpecifier : Optional Text
         , deriveClasses : DeriveClasses
         }
     , default =
         { dateTimeFormat = DateTimeFormat.UTCTime
-        , dateFormat = DateFormat.ISO8601Date
+        , formatSpecifier = None Text
         , deriveClasses = DeriveClasses.Default
         }
     }
@@ -50,7 +47,6 @@ in
   , utcTime = DateTimeFormat.UTCTime
   , zonedTime = DateTimeFormat.ZonedTime
   , localTime = DateTimeFormat.LocalTime
-  , customDate = DateFormat.CustomDate
   , show = DerivableClass.Show
   , eq = DerivableClass.Eq
   , ord = DerivableClass.Ord

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/Config.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/Config.hs
@@ -45,15 +45,11 @@ typeOptionsDecoder =
   Dhall.record $
     CGU.TypeOptions
       <$> Dhall.field "dateTimeFormat" dateTimeFormatDecoder
-      <*> Dhall.field "dateFormat" dateFormatDecoder
+      <*> Dhall.field "formatSpecifier" formatSpecifierDecoder
       <*> Dhall.field "deriveClasses" deriveClassesDecoder
 
-dateFormatDecoder :: Dhall.Decoder CGU.DateFormat
-dateFormatDecoder =
-  Dhall.union
-    ( (fmap (\() -> CGU.ISO8601DateFormat) (Dhall.constructor "ISO8601Date" Dhall.unit))
-        <> (fmap CGU.CustomDateFormat (Dhall.constructor "CustomDate" Dhall.strictText))
-    )
+formatSpecifierDecoder :: Dhall.Decoder (Maybe T.Text)
+formatSpecifierDecoder = Dhall.maybe Dhall.strictText
 
 dateTimeFormatDecoder :: Dhall.Decoder CGU.DateTimeFormat
 dateTimeFormatDecoder =

--- a/json-fleece-core/src/Fleece/Core.hs
+++ b/json-fleece-core/src/Fleece/Core.hs
@@ -68,8 +68,11 @@ module Fleece.Core
   , set
   , string
   , utcTime
+  , utcTimeWithFormat
   , localTime
+  , localTimeWithFormat
   , zonedTime
+  , zonedTimeWithFormat
   , day
   , dayWithFormat
   , boundedIntegralNumber

--- a/json-fleece-core/src/Fleece/Core/Schemas.hs
+++ b/json-fleece-core/src/Fleece/Core/Schemas.hs
@@ -30,10 +30,14 @@ module Fleece.Core.Schemas
   , realFloatNamed
   , string
   , utcTime
+  , utcTimeWithFormat
   , localTime
+  , localTimeWithFormat
   , zonedTime
+  , zonedTimeWithFormat
   , day
   , dayWithFormat
+  , timeWithFormat
   , boundedIntegralNumber
   , boundedIntegralNumberNamed
   , unboundedIntegralNumber
@@ -562,33 +566,45 @@ utcTime :: Fleece schema => schema Time.UTCTime
 utcTime =
   iso8601Formatted "UTCTime" ISO8601.iso8601Format AttoTime.utcTime
 
+utcTimeWithFormat :: Fleece schema => String -> schema Time.UTCTime
+utcTimeWithFormat = timeWithFormat "UTCTime"
+
 localTime :: Fleece schema => schema Time.LocalTime
 localTime =
   iso8601Formatted "LocalTime" ISO8601.iso8601Format AttoTime.localTime
+
+localTimeWithFormat :: Fleece schema => String -> schema Time.LocalTime
+localTimeWithFormat = timeWithFormat "LocalTime"
 
 zonedTime :: Fleece schema => schema Time.ZonedTime
 zonedTime =
   iso8601Formatted "ZonedTime" ISO8601.iso8601Format AttoTime.zonedTime
 
+zonedTimeWithFormat :: Fleece schema => String -> schema Time.ZonedTime
+zonedTimeWithFormat = timeWithFormat "ZonedTime"
+
+day :: Fleece schema => schema Time.Day
+day =
+  iso8601Formatted "Day" ISO8601.iso8601Format AttoTime.day
+
 dayWithFormat :: Fleece schema => String -> schema Time.Day
-dayWithFormat formatString =
+dayWithFormat = timeWithFormat "Day"
+
+timeWithFormat :: (Time.FormatTime t, Time.ParseTime t) => Fleece schema => String -> String -> schema t
+timeWithFormat typeName formatString =
   let
     decode raw =
       case Time.parseTimeM False Time.defaultTimeLocale formatString raw of
         Just success -> Right success
         Nothing ->
           Left $
-            "Invalid date in custom format, format is: " <> formatString
+            "Invalid " <> typeName <> ", custom format is: " <> formatString
   in
     validateNamed
-      (unqualifiedName $ "Day in " <> formatString <> " format")
+      (unqualifiedName $ typeName <> " in " <> formatString <> " format")
       (Time.formatTime Time.defaultTimeLocale formatString)
       decode
       string
-
-day :: Fleece schema => schema Time.Day
-day =
-  iso8601Formatted "Day" ISO8601.iso8601Format AttoTime.day
 
 bareOrJSONString :: Fleece schema => schema a -> schema a
 bareOrJSONString baseSchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats.hs
@@ -8,6 +8,9 @@ module TestCases.Types.DateTimeFormats
 import Fleece.Core ((#+))
 import qualified Fleece.Core as FC
 import Prelude (($), Maybe, Show)
+import qualified TestCases.Types.DateTimeFormats.CustomLocalTimeField as CustomLocalTimeField
+import qualified TestCases.Types.DateTimeFormats.CustomUtcTimeField as CustomUtcTimeField
+import qualified TestCases.Types.DateTimeFormats.CustomZonedTimeField as CustomZonedTimeField
 import qualified TestCases.Types.DateTimeFormats.DefaultTimeField as DefaultTimeField
 import qualified TestCases.Types.DateTimeFormats.LocalTimeField as LocalTimeField
 import qualified TestCases.Types.DateTimeFormats.UtcTimeField as UtcTimeField
@@ -17,7 +20,10 @@ data DateTimeFormats = DateTimeFormats
   { zonedTimeField :: Maybe ZonedTimeField.ZonedTimeField
   , defaultTimeField :: Maybe DefaultTimeField.DefaultTimeField
   , localTimeField :: Maybe LocalTimeField.LocalTimeField
+  , customLocalTimeField :: Maybe CustomLocalTimeField.CustomLocalTimeField
   , utcTimeField :: Maybe UtcTimeField.UtcTimeField
+  , customZonedTimeField :: Maybe CustomZonedTimeField.CustomZonedTimeField
+  , customUtcTimeField :: Maybe CustomUtcTimeField.CustomUtcTimeField
   }
   deriving (Show)
 
@@ -28,4 +34,7 @@ dateTimeFormatsSchema =
       #+ FC.optional "zonedTimeField" zonedTimeField ZonedTimeField.zonedTimeFieldSchema
       #+ FC.optional "defaultTimeField" defaultTimeField DefaultTimeField.defaultTimeFieldSchema
       #+ FC.optional "localTimeField" localTimeField LocalTimeField.localTimeFieldSchema
+      #+ FC.optional "customLocalTimeField" customLocalTimeField CustomLocalTimeField.customLocalTimeFieldSchema
       #+ FC.optional "utcTimeField" utcTimeField UtcTimeField.utcTimeFieldSchema
+      #+ FC.optional "customZonedTimeField" customZonedTimeField CustomZonedTimeField.customZonedTimeFieldSchema
+      #+ FC.optional "customUtcTimeField" customUtcTimeField CustomUtcTimeField.customUtcTimeFieldSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats/CustomLocalTimeField.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats/CustomLocalTimeField.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.DateTimeFormats.CustomLocalTimeField
+  ( CustomLocalTimeField(..)
+  , customLocalTimeFieldSchema
+  ) where
+
+import qualified Data.Time as Time
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype CustomLocalTimeField = CustomLocalTimeField Time.LocalTime
+  deriving (Show, Eq)
+
+customLocalTimeFieldSchema :: FC.Fleece schema => schema CustomLocalTimeField
+customLocalTimeFieldSchema =
+  FC.coerceSchema (FC.localTimeWithFormat "local")

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats/CustomUtcTimeField.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats/CustomUtcTimeField.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.DateTimeFormats.CustomUtcTimeField
+  ( CustomUtcTimeField(..)
+  , customUtcTimeFieldSchema
+  ) where
+
+import qualified Data.Time as Time
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype CustomUtcTimeField = CustomUtcTimeField Time.UTCTime
+  deriving (Show, Eq)
+
+customUtcTimeFieldSchema :: FC.Fleece schema => schema CustomUtcTimeField
+customUtcTimeFieldSchema =
+  FC.coerceSchema (FC.utcTimeWithFormat "utc")

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats/CustomZonedTimeField.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats/CustomZonedTimeField.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.DateTimeFormats.CustomZonedTimeField
+  ( CustomZonedTimeField(..)
+  , customZonedTimeFieldSchema
+  ) where
+
+import qualified Data.Time as Time
+import qualified Fleece.Core as FC
+import Prelude (Show)
+
+newtype CustomZonedTimeField = CustomZonedTimeField Time.ZonedTime
+  deriving (Show)
+
+customZonedTimeFieldSchema :: FC.Fleece schema => schema CustomZonedTimeField
+customZonedTimeFieldSchema =
+  FC.coerceSchema (FC.zonedTimeWithFormat "zoned")

--- a/json-fleece-openapi3/examples/test-cases/codegen.dhall
+++ b/json-fleece-openapi3/examples/test-cases/codegen.dhall
@@ -13,7 +13,7 @@ in
           [ { type = "TestCases.Types.CustomDateFormat.CustomDateFormat"
             , options =
                 CodeGen.TypeOptions::
-                  { dateFormat = CodeGen.customDate "%m/%d/%y"
+                  { formatSpecifier = Some "%m/%d/%y"
                   }
             }
           , { type = "TestCases.Types.DateTimeFormats.DateTimeFormats"
@@ -39,6 +39,28 @@ in
             , options =
                 CodeGen.TypeOptions::
                   { dateTimeFormat = CodeGen.localTime
+                  }
+            }
+          , { type = "TestCases.Types.DateTimeFormats.CustomUtcTimeField.CustomUtcTimeField"
+            , options =
+                CodeGen.TypeOptions::
+                  { dateTimeFormat = CodeGen.utcTime
+                  , formatSpecifier = Some "utc"
+                  }
+            }
+          , { type = "TestCases.Types.DateTimeFormats.CustomZonedTimeField.CustomZonedTimeField"
+            , options =
+                CodeGen.TypeOptions::
+                  { dateTimeFormat = CodeGen.zonedTime
+                  , formatSpecifier = Some "zoned"
+                  , deriveClasses = CodeGen.derive [ CodeGen.show ]
+                  }
+            }
+          , { type = "TestCases.Types.DateTimeFormats.CustomLocalTimeField.CustomLocalTimeField"
+            , options =
+                CodeGen.TypeOptions::
+                  { dateTimeFormat = CodeGen.localTime
+                  , formatSpecifier = Some "local"
                   }
             }
           , { type = "TestCases.Types.UtcTimeType.UtcTimeType"

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -80,6 +80,9 @@ library
       TestCases.Types.AStringType
       TestCases.Types.CustomDateFormat
       TestCases.Types.DateTimeFormats
+      TestCases.Types.DateTimeFormats.CustomLocalTimeField
+      TestCases.Types.DateTimeFormats.CustomUtcTimeField
+      TestCases.Types.DateTimeFormats.CustomZonedTimeField
       TestCases.Types.DateTimeFormats.DefaultTimeField
       TestCases.Types.DateTimeFormats.LocalTimeField
       TestCases.Types.DateTimeFormats.UtcTimeField

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -668,6 +668,15 @@ components:
         localTimeField:
           type: string
           format: date-time
+        customUtcTimeField:
+          type: string
+          format: date-time
+        customZonedTimeField:
+          type: string
+          format: date-time
+        customLocalTimeField:
+          type: string
+          format: date-time
 
     DefaultTimeType:
       type: string

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -1927,6 +1927,9 @@ extra-source-files:
     examples/test-cases/TestCases/Types/AStringType.hs
     examples/test-cases/TestCases/Types/CustomDateFormat.hs
     examples/test-cases/TestCases/Types/DateTimeFormats.hs
+    examples/test-cases/TestCases/Types/DateTimeFormats/CustomLocalTimeField.hs
+    examples/test-cases/TestCases/Types/DateTimeFormats/CustomUtcTimeField.hs
+    examples/test-cases/TestCases/Types/DateTimeFormats/CustomZonedTimeField.hs
     examples/test-cases/TestCases/Types/DateTimeFormats/DefaultTimeField.hs
     examples/test-cases/TestCases/Types/DateTimeFormats/LocalTimeField.hs
     examples/test-cases/TestCases/Types/DateTimeFormats/UtcTimeField.hs

--- a/json-fleece-openapi3/src/Fleece/OpenApi3.hs
+++ b/json-fleece-openapi3/src/Fleece/OpenApi3.hs
@@ -974,9 +974,7 @@ mkOpenApiStringFormat typeName schema = do
       pure $
         case OA._schemaFormat schema of
           Just "date" ->
-            case CGU.dateFormat typeOptions of
-              CGU.ISO8601DateFormat -> CGU.dayFormat typeOptions
-              CGU.CustomDateFormat formatString -> CGU.dayCustomFormat formatString typeOptions
+            CGU.dayFormat typeOptions
           Just "date-time" ->
             case CGU.dateTimeFormat typeOptions of
               CGU.UTCTimeFormat -> CGU.utcTimeFormat typeOptions


### PR DESCRIPTION
Schemas
---

This generalizes the implementation of `dayWithFormat` as a new function called `timeWithFormat`.
To improve usability, I've added less polymorphic versions of it like e.g. `dayWithFormat`, `utcTimeWithFormat` etc.

In codegen
---

The previous DateFormat type is unnecessary because there is only one type to choose for dates: Data.Time.Day.
Now that the `formatSpecifier` is possible for both `date`s and `date-time`s, it has been moved up to the `TypeOptions` record.
