### PR TITLE
Document additionalProperties bug, fix parens on mapOf

### DIFF
--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
@@ -440,9 +440,9 @@ mapOf keyName itemName =
   "("
     <> typeNameToCodeDefaultQualification mapType
     <> " "
-    <> keyName
+    <> guardParens keyName
     <> " "
-    <> itemName
+    <> guardParens itemName
     <> ")"
 
 union :: TypeExpression

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBoolean.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBoolean.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.JustAdditionalPropertiesNullableBoolean
+  ( JustAdditionalPropertiesNullableBoolean(..)
+  , justAdditionalPropertiesNullableBooleanSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+import qualified TestCases.Types.JustAdditionalPropertiesNullableBooleanItem as JustAdditionalPropertiesNullableBooleanItem
+
+newtype JustAdditionalPropertiesNullableBoolean = JustAdditionalPropertiesNullableBoolean (Map.Map T.Text JustAdditionalPropertiesNullableBooleanItem.JustAdditionalPropertiesNullableBooleanItem)
+  deriving (Show, Eq)
+
+justAdditionalPropertiesNullableBooleanSchema :: FC.Fleece schema => schema JustAdditionalPropertiesNullableBoolean
+justAdditionalPropertiesNullableBooleanSchema =
+  FC.coerceSchema (FC.map JustAdditionalPropertiesNullableBooleanItem.justAdditionalPropertiesNullableBooleanItemSchema)

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBooleanItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBooleanItem.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.JustAdditionalPropertiesNullableBooleanItem
+  ( JustAdditionalPropertiesNullableBooleanItem(..)
+  , justAdditionalPropertiesNullableBooleanItemSchema
+  ) where
+
+import qualified Fleece.Core as FC
+import Prelude (Bool, Eq, Show)
+
+newtype JustAdditionalPropertiesNullableBooleanItem = JustAdditionalPropertiesNullableBooleanItem Bool
+  deriving (Show, Eq)
+
+justAdditionalPropertiesNullableBooleanItemSchema :: FC.Fleece schema => schema JustAdditionalPropertiesNullableBooleanItem
+justAdditionalPropertiesNullableBooleanItemSchema =
+  FC.coerceSchema FC.boolean

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBooleanRef.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBooleanRef.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.JustAdditionalPropertiesNullableBooleanRef
+  ( JustAdditionalPropertiesNullableBooleanRef(..)
+  , justAdditionalPropertiesNullableBooleanRefSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Either, Eq, Show)
+import qualified TestCases.Types.NullableBoolean as NullableBoolean
+
+newtype JustAdditionalPropertiesNullableBooleanRef = JustAdditionalPropertiesNullableBooleanRef (Map.Map T.Text (Either FC.Null NullableBoolean.NullableBoolean))
+  deriving (Show, Eq)
+
+justAdditionalPropertiesNullableBooleanRefSchema :: FC.Fleece schema => schema JustAdditionalPropertiesNullableBooleanRef
+justAdditionalPropertiesNullableBooleanRefSchema =
+  FC.coerceSchema (FC.map (FC.nullable NullableBoolean.nullableBooleanSchema))

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/NullableBoolean.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/NullableBoolean.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.NullableBoolean
+  ( NullableBoolean(..)
+  , nullableBooleanSchema
+  ) where
+
+import qualified Fleece.Core as FC
+import Prelude (Bool, Eq, Show)
+
+newtype NullableBoolean = NullableBoolean Bool
+  deriving (Show, Eq)
+
+nullableBooleanSchema :: FC.Fleece schema => schema NullableBoolean
+nullableBooleanSchema =
+  FC.coerceSchema FC.boolean

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -104,6 +104,9 @@ library
       TestCases.Types.FieldTestCases.OptionalNullableField
       TestCases.Types.FieldTestCases.RequiredField
       TestCases.Types.FieldTestCases.RequiredNullableField
+      TestCases.Types.JustAdditionalPropertiesNullableBoolean
+      TestCases.Types.JustAdditionalPropertiesNullableBooleanItem
+      TestCases.Types.JustAdditionalPropertiesNullableBooleanRef
       TestCases.Types.JustAdditionalPropertiesSchemaInline
       TestCases.Types.JustAdditionalPropertiesSchemaInlineItem
       TestCases.Types.JustAdditionalPropertiesSchemaRef
@@ -150,6 +153,7 @@ library
       TestCases.Types.NameConflicts.Then
       TestCases.Types.NameConflicts.Type
       TestCases.Types.NameConflicts.Where
+      TestCases.Types.NullableBoolean
       TestCases.Types.Num2SchemaStartingWithNumber
       TestCases.Types.OneOfWithNullable
       TestCases.Types.ReferenceOneOf

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -716,6 +716,24 @@ components:
       description: An object with just additionalProperties = true
       additionalProperties: true
 
+    # This test is broken, since the nullability is not considered
+    JustAdditionalPropertiesNullableBoolean:
+      type: object
+      description: An object with a nullable boolean
+      additionalProperties:
+        type: boolean
+        nullable: true
+
+    JustAdditionalPropertiesNullableBooleanRef:
+      type: object
+      description: An object with a ref to a nullable boolean
+      additionalProperties:
+        $ref: '#/components/schemas/NullableBoolean'
+
+    NullableBoolean:
+      nullable: true
+      type: boolean
+
     JustAdditionalPropertiesSchemaRef:
       type: object
       description: An object with just additionalProperties as a schema ref

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -1951,6 +1951,9 @@ extra-source-files:
     examples/test-cases/TestCases/Types/FieldTestCases/OptionalNullableField.hs
     examples/test-cases/TestCases/Types/FieldTestCases/RequiredField.hs
     examples/test-cases/TestCases/Types/FieldTestCases/RequiredNullableField.hs
+    examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBoolean.hs
+    examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBooleanItem.hs
+    examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBooleanRef.hs
     examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaInline.hs
     examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaInlineItem.hs
     examples/test-cases/TestCases/Types/JustAdditionalPropertiesSchemaRef.hs
@@ -1997,6 +2000,7 @@ extra-source-files:
     examples/test-cases/TestCases/Types/NameConflicts/Then.hs
     examples/test-cases/TestCases/Types/NameConflicts/Type.hs
     examples/test-cases/TestCases/Types/NameConflicts/Where.hs
+    examples/test-cases/TestCases/Types/NullableBoolean.hs
     examples/test-cases/TestCases/Types/Num2SchemaStartingWithNumber.hs
     examples/test-cases/TestCases/Types/OneOfWithNullable.hs
     examples/test-cases/TestCases/Types/ReferenceOneOf.hs


### PR DESCRIPTION
We found an issue with `mapOf`, it didn't add parens when a ref with nullability inside was used.

We also added a test case for nullability on an 'inline' (unnamed) additionalProperty. This nullability is currently discarded.

Co-authored-by: Owen <owen@flipstone.com>
