### PR TITLE
Add JSON decoding failure type with bytes

### DIFF
--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
@@ -748,7 +748,7 @@ generateOperationCode typeMap codeGenOperation = do
       HC.lines
         . (HC.indent 2 beelineOperation :)
         $ fmap (HC.indent 4)
-        $ [ beelineContentTypeDecodingError
+        $ [ fleeceJSONDecodingError
           , pathParamsTypeNameAsCode
           , maybe
               beelineNoQueryParams
@@ -883,7 +883,7 @@ generateOperationCode typeMap codeGenOperation = do
             <> ", "
             <> beelineResponseBodySchema
             <> " "
-            <> beelineContentTypeDecodingError
+            <> fleeceJSONDecodingError
             <> " "
             <> HC.typeNameToCode Nothing responsesTypeName
             <> ")]"
@@ -2055,6 +2055,10 @@ fleeceAesonBeelineConstructor =
     . HC.varNameToCodeDefaultQualification
     . HC.toConstructorVarName "Fleece.Aeson.Beeline" (Just "FA")
 
+fleeceJSONDecodingError :: HC.FromCode c => c
+fleeceJSONDecodingError =
+  fleeceAesonBeelineConstructor "JSONDecodingError"
+
 methodToBeelineFunction :: HC.FromCode c => T.Text -> CodeGen c
 methodToBeelineFunction method =
   fmap beelineRoutingVar $
@@ -2242,10 +2246,6 @@ beelineStatus =
 beelineAnyStatus :: HC.FromCode c => c
 beelineAnyStatus =
   beelineHTTPConstructor "AnyStatus"
-
-beelineContentTypeDecodingError :: HC.FromCode c => c
-beelineContentTypeDecodingError =
-  beelineHTTPConstructor "ContentTypeDecodingError"
 
 beelineStatusRange :: HC.FromCode c => c
 beelineStatusRange =

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Animal.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Animal.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON AnimalFullResponse.animalFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Animal/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Animal/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON AnimalBaseResponse.animalBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Animal/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Animal/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.AnimalBaseResponse as AnimalBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 AnimalBaseResponse.AnimalBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON AnimalBaseResponse.animalBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/AstronomicalObject.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/AstronomicalObject.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON AstronomicalObjectFullResponse.astronomicalObjectFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/AstronomicalObject/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/AstronomicalObject/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON AstronomicalObjectBaseResponse.astronomicalObjectBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/AstronomicalObject/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/AstronomicalObject/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.AstronomicalObjectBaseResponse as AstronomicalOb
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 AstronomicalObjectBaseResponse.AstronomicalObjectBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON AstronomicalObjectBaseResponse.astronomicalObjectBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Book.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Book.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON BookFullResponse.bookFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Book/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Book/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON BookBaseResponse.bookBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Book/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Book/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.BookBaseResponse as BookBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 BookBaseResponse.BookBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON BookBaseResponse.bookBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookCollection.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookCollection.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON BookCollectionFullResponse.bookCollectionFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookCollection/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookCollection/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON BookCollectionBaseResponse.bookCollectionBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookCollection/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookCollection/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.BookCollectionBaseResponse as BookCollectionBase
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 BookCollectionBaseResponse.BookCollectionBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON BookCollectionBaseResponse.bookCollectionBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookSeries.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookSeries.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON BookSeriesFullResponse.bookSeriesFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookSeries/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookSeries/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON BookSeriesBaseResponse.bookSeriesBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookSeries/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/BookSeries/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.BookSeriesBaseResponse as BookSeriesBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 BookSeriesBaseResponse.BookSeriesBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON BookSeriesBaseResponse.bookSeriesBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Character.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Character.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON CharacterFullResponse.characterFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Character/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Character/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON CharacterBaseResponse.characterBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Character/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Character/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.CharacterBaseResponse as CharacterBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 CharacterBaseResponse.CharacterBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON CharacterBaseResponse.characterBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicCollection.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicCollection.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicCollectionFullResponse.comicCollectionFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicCollection/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicCollection/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicCollectionBaseResponse.comicCollectionBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicCollection/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicCollection/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.ComicCollectionBaseResponse as ComicCollectionBa
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 ComicCollectionBaseResponse.ComicCollectionBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicCollectionBaseResponse.comicCollectionBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicSeries.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicSeries.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicSeriesFullResponse.comicSeriesFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicSeries/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicSeries/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicSeriesBaseResponse.comicSeriesBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicSeries/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicSeries/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.ComicSeriesBaseResponse as ComicSeriesBaseRespon
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 ComicSeriesBaseResponse.ComicSeriesBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicSeriesBaseResponse.comicSeriesBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicStrip.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicStrip.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicStripFullResponse.comicStripFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicStrip/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicStrip/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicStripBaseResponse.comicStripBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicStrip/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/ComicStrip/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.ComicStripBaseResponse as ComicStripBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 ComicStripBaseResponse.ComicStripBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicStripBaseResponse.comicStripBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Comics.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Comics.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicsFullResponse.comicsFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Comics/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Comics/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicsBaseResponse.comicsBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Comics/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Comics/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.ComicsBaseResponse as ComicsBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 ComicsBaseResponse.ComicsBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ComicsBaseResponse.comicsBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Company.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Company.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON CompanyFullResponse.companyFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Company/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Company/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON CompanyBaseResponse.companyBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Company/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Company/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.CompanyBaseResponse as CompanyBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 CompanyBaseResponse.CompanyBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON CompanyBaseResponse.companyBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Conflict.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Conflict.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ConflictFullResponse.conflictFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Conflict/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Conflict/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ConflictBaseResponse.conflictBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Conflict/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Conflict/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.ConflictBaseResponse as ConflictBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 ConflictBaseResponse.ConflictBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ConflictBaseResponse.conflictBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Element.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Element.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ElementFullResponse.elementFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Element/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Element/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ElementBaseResponse.elementBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Element/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Element/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.ElementBaseResponse as ElementBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 ElementBaseResponse.ElementBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON ElementBaseResponse.elementBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Episode.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Episode.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON EpisodeFullResponse.episodeFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Episode/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Episode/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON EpisodeBaseResponse.episodeBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Episode/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Episode/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.EpisodeBaseResponse as EpisodeBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 EpisodeBaseResponse.EpisodeBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON EpisodeBaseResponse.episodeBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Food.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Food.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.FoodFullResponse as FoodFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FoodFullResponse.foodFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Food/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Food/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.FoodBaseResponse as FoodBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FoodBaseResponse.foodBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Food/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Food/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.FoodBaseResponse as FoodBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 FoodBaseResponse.FoodBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FoodBaseResponse.foodBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Literature.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Literature.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.LiteratureFullResponse as LiteratureFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON LiteratureFullResponse.literatureFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Literature/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Literature/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.LiteratureBaseResponse as LiteratureBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON LiteratureBaseResponse.literatureBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Literature/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Literature/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.LiteratureBaseResponse as LiteratureBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 LiteratureBaseResponse.LiteratureBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON LiteratureBaseResponse.literatureBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Location.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Location.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.LocationFullResponse as LocationFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON LocationFullResponse.locationFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Location/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Location/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.LocationBaseResponse as LocationBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON LocationBaseResponse.locationBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Location/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Location/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.LocationBaseResponse as LocationBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 LocationBaseResponse.LocationBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON LocationBaseResponse.locationBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Magazine.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Magazine.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.MagazineFullResponse as MagazineFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MagazineFullResponse.magazineFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Magazine/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Magazine/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.MagazineBaseResponse as MagazineBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MagazineBaseResponse.magazineBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Magazine/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Magazine/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.MagazineBaseResponse as MagazineBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 MagazineBaseResponse.MagazineBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MagazineBaseResponse.magazineBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MagazineSeries.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MagazineSeries.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.MagazineSeriesFullResponse as MagazineSeriesFull
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MagazineSeriesFullResponse.magazineSeriesFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MagazineSeries/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MagazineSeries/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.MagazineSeriesBaseResponse as MagazineSeriesBase
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MagazineSeriesBaseResponse.magazineSeriesBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MagazineSeries/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MagazineSeries/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.MagazineSeriesBaseResponse as MagazineSeriesBase
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 MagazineSeriesBaseResponse.MagazineSeriesBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MagazineSeriesBaseResponse.magazineSeriesBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Material.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Material.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.MaterialFullResponse as MaterialFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MaterialFullResponse.materialFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Material/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Material/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.MaterialBaseResponse as MaterialBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MaterialBaseResponse.materialBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Material/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Material/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.MaterialBaseResponse as MaterialBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 MaterialBaseResponse.MaterialBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MaterialBaseResponse.materialBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MedicalCondition.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MedicalCondition.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.MedicalConditionFullResponse as MedicalCondition
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MedicalConditionFullResponse.medicalConditionFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MedicalCondition/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MedicalCondition/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.MedicalConditionBaseResponse as MedicalCondition
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MedicalConditionBaseResponse.medicalConditionBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MedicalCondition/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/MedicalCondition/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.MedicalConditionBaseResponse as MedicalCondition
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 MedicalConditionBaseResponse.MedicalConditionBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MedicalConditionBaseResponse.medicalConditionBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Movie.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Movie.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.MovieFullResponse as MovieFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MovieFullResponse.movieFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Movie/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Movie/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.MovieBaseResponse as MovieBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MovieBaseResponse.movieBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Movie/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Movie/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.MovieBaseResponse as MovieBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 MovieBaseResponse.MovieBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON MovieBaseResponse.movieBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Occupation.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Occupation.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.OccupationFullResponse as OccupationFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON OccupationFullResponse.occupationFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Occupation/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Occupation/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.OccupationBaseResponse as OccupationBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON OccupationBaseResponse.occupationBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Occupation/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Occupation/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.OccupationBaseResponse as OccupationBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 OccupationBaseResponse.OccupationBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON OccupationBaseResponse.occupationBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Organization.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Organization.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.OrganizationFullResponse as OrganizationFullResp
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON OrganizationFullResponse.organizationFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Organization/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Organization/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.OrganizationBaseResponse as OrganizationBaseResp
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON OrganizationBaseResponse.organizationBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Organization/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Organization/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.OrganizationBaseResponse as OrganizationBaseResp
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 OrganizationBaseResponse.OrganizationBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON OrganizationBaseResponse.organizationBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Performer.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Performer.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.PerformerFullResponse as PerformerFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON PerformerFullResponse.performerFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Performer/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Performer/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.PerformerBaseResponse as PerformerBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON PerformerBaseResponse.performerBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Performer/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Performer/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.PerformerBaseResponse as PerformerBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 PerformerBaseResponse.PerformerBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON PerformerBaseResponse.performerBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Season.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Season.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.SeasonFullResponse as SeasonFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SeasonFullResponse.seasonFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Season/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Season/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SeasonBaseResponse as SeasonBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SeasonBaseResponse.seasonBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Season/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Season/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SeasonBaseResponse as SeasonBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 SeasonBaseResponse.SeasonBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SeasonBaseResponse.seasonBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Series.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Series.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.SeriesFullResponse as SeriesFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SeriesFullResponse.seriesFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Series/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Series/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SeriesBaseResponse as SeriesBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SeriesBaseResponse.seriesBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Series/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Series/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SeriesBaseResponse as SeriesBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 SeriesBaseResponse.SeriesBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SeriesBaseResponse.seriesBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Soundtrack.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Soundtrack.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.SoundtrackFullResponse as SoundtrackFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SoundtrackFullResponse.soundtrackFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Soundtrack/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Soundtrack/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SoundtrackBaseResponse as SoundtrackBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SoundtrackBaseResponse.soundtrackBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Soundtrack/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Soundtrack/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SoundtrackBaseResponse as SoundtrackBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 SoundtrackBaseResponse.SoundtrackBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SoundtrackBaseResponse.soundtrackBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Spacecraft.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Spacecraft.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.SpacecraftFullResponse as SpacecraftFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SpacecraftFullResponse.spacecraftFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Spacecraft/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Spacecraft/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SpacecraftBaseResponse as SpacecraftBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SpacecraftBaseResponse.spacecraftBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Spacecraft/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Spacecraft/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SpacecraftBaseResponse as SpacecraftBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 SpacecraftBaseResponse.SpacecraftBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SpacecraftBaseResponse.spacecraftBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/SpacecraftClass.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/SpacecraftClass.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.SpacecraftClassFullResponse as SpacecraftClassFu
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SpacecraftClassFullResponse.spacecraftClassFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/SpacecraftClass/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/SpacecraftClass/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SpacecraftClassBaseResponse as SpacecraftClassBa
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SpacecraftClassBaseResponse.spacecraftClassBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/SpacecraftClass/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/SpacecraftClass/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SpacecraftClassBaseResponse as SpacecraftClassBa
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 SpacecraftClassBaseResponse.SpacecraftClassBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SpacecraftClassBaseResponse.spacecraftClassBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Species.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Species.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.SpeciesFullResponse as SpeciesFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SpeciesFullResponse.speciesFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Species/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Species/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SpeciesBaseResponse as SpeciesBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SpeciesBaseResponse.speciesBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Species/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Species/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.SpeciesBaseResponse as SpeciesBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 SpeciesBaseResponse.SpeciesBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON SpeciesBaseResponse.speciesBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Staff.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Staff.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.StaffFullResponse as StaffFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON StaffFullResponse.staffFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Staff/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Staff/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.StaffBaseResponse as StaffBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON StaffBaseResponse.staffBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Staff/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Staff/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.StaffBaseResponse as StaffBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 StaffBaseResponse.StaffBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON StaffBaseResponse.staffBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Technology.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Technology.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.TechnologyFullResponse as TechnologyFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TechnologyFullResponse.technologyFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Technology/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Technology/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.TechnologyBaseResponse as TechnologyBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TechnologyBaseResponse.technologyBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Technology/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Technology/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.TechnologyBaseResponse as TechnologyBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 TechnologyBaseResponse.TechnologyBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TechnologyBaseResponse.technologyBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Title.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Title.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.TitleFullResponse as TitleFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TitleFullResponse.titleFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Title/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Title/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.TitleBaseResponse as TitleBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TitleBaseResponse.titleBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Title/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Title/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.TitleBaseResponse as TitleBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 TitleBaseResponse.TitleBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TitleBaseResponse.titleBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCard.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCard.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.TradingCardFullResponse as TradingCardFullRespon
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TradingCardFullResponse.tradingCardFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCard/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCard/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.TradingCardBaseResponse as TradingCardBaseRespon
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TradingCardBaseResponse.tradingCardBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCard/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCard/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.TradingCardBaseResponse as TradingCardBaseRespon
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 TradingCardBaseResponse.TradingCardBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TradingCardBaseResponse.tradingCardBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardDeck.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardDeck.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.TradingCardDeckFullResponse as TradingCardDeckFu
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TradingCardDeckFullResponse.tradingCardDeckFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardDeck/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardDeck/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.TradingCardDeckBaseResponse as TradingCardDeckBa
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TradingCardDeckBaseResponse.tradingCardDeckBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardDeck/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardDeck/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.TradingCardDeckBaseResponse as TradingCardDeckBa
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 TradingCardDeckBaseResponse.TradingCardDeckBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TradingCardDeckBaseResponse.tradingCardDeckBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardSet.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardSet.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.TradingCardSetFullResponse as TradingCardSetFull
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TradingCardSetFullResponse.tradingCardSetFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardSet/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardSet/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.TradingCardSetBaseResponse as TradingCardSetBase
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TradingCardSetBaseResponse.tradingCardSetBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardSet/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/TradingCardSet/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.TradingCardSetBaseResponse as TradingCardSetBase
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 TradingCardSetBaseResponse.TradingCardSetBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON TradingCardSetBaseResponse.tradingCardSetBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoGame.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoGame.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.VideoGameFullResponse as VideoGameFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON VideoGameFullResponse.videoGameFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoGame/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoGame/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.VideoGameBaseResponse as VideoGameBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON VideoGameBaseResponse.videoGameBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoGame/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoGame/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.VideoGameBaseResponse as VideoGameBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 VideoGameBaseResponse.VideoGameBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON VideoGameBaseResponse.videoGameBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoRelease.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoRelease.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.VideoReleaseFullResponse as VideoReleaseFullResp
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON VideoReleaseFullResponse.videoReleaseFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoRelease/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoRelease/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.VideoReleaseBaseResponse as VideoReleaseBaseResp
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON VideoReleaseBaseResponse.videoReleaseBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoRelease/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/VideoRelease/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.VideoReleaseBaseResponse as VideoReleaseBaseResp
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 VideoReleaseBaseResponse.VideoReleaseBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON VideoReleaseBaseResponse.videoReleaseBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Weapon.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Weapon.hs
@@ -23,7 +23,7 @@ import qualified StarTrek.Types.WeaponFullResponse as WeaponFullResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON WeaponFullResponse.weaponFullResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Weapon/Search/GET.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Weapon/Search/GET.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.WeaponBaseResponse as WeaponBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -63,7 +63,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON WeaponBaseResponse.weaponBaseResponseSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Weapon/Search/POST.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Operations/Weapon/Search/POST.hs
@@ -24,7 +24,7 @@ import qualified StarTrek.Types.WeaponBaseResponse as WeaponBaseResponse
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -64,7 +64,7 @@ data Responses
   = Response200 WeaponBaseResponse.WeaponBaseResponse
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON WeaponBaseResponse.weaponBaseResponseSchema))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/GetMultiplePathsParams.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/GetMultiplePathsParams.hs
@@ -20,7 +20,7 @@ import qualified TestCases.Types.FieldTestCases as FieldTestCases
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     PathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -51,7 +51,7 @@ data Responses
   = Response200 FieldTestCases.FieldTestCases
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FieldTestCases.fieldTestCasesSchema))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/Num2GetAResultNamedNumberSomething.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/Num2GetAResultNamedNumberSomething.hs
@@ -17,7 +17,7 @@ import qualified TestCases.Types.Num2SchemaStartingWithNumber as Num2SchemaStart
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -40,7 +40,7 @@ data Responses
   = Response200 Num2SchemaStartingWithNumber.Num2SchemaStartingWithNumber
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON Num2SchemaStartingWithNumber.num2SchemaStartingWithNumberSchema))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/ParamSchemaReference.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/ParamSchemaReference.hs
@@ -27,7 +27,7 @@ import qualified TestCases.Types.StringParam as StringParam
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     PathParams
     QueryParams
     H.NoHeaderParams
@@ -69,7 +69,7 @@ data Responses
   = Response200 FieldTestCases.FieldTestCases
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FieldTestCases.fieldTestCasesSchema))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/ParamSchemaReferenceArray.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/ParamSchemaReferenceArray.hs
@@ -22,7 +22,7 @@ import qualified TestCases.Types.StringParam as StringParam
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -56,7 +56,7 @@ data Responses
   = Response200 FieldTestCases.FieldTestCases
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FieldTestCases.fieldTestCasesSchema))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/AnyJsonResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/AnyJsonResponse.hs
@@ -17,7 +17,7 @@ import Prelude (($), Eq, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -40,7 +40,7 @@ data Responses
   = Response201 FC.AnyJSON
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 201, fmap Response201 (H.responseBody FA.JSON FC.anyJSON))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams.hs
@@ -27,7 +27,7 @@ import qualified TestCases.Types.FieldTestCases as FieldTestCases
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     HeaderParams
@@ -71,7 +71,7 @@ data Responses
   = Response200 FieldTestCases.FieldTestCases
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FieldTestCases.fieldTestCasesSchema))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineArrayResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineArrayResponse.hs
@@ -18,7 +18,7 @@ import qualified TestCases.Types.FieldTestCases as FieldTestCases
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -41,7 +41,7 @@ data Responses
   = Response200 [FieldTestCases.FieldTestCases]
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.list FieldTestCases.fieldTestCasesSchema)))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineBooleanResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineBooleanResponse.hs
@@ -17,7 +17,7 @@ import Prelude (($), Bool, Eq, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -40,7 +40,7 @@ data Responses
   = Response200 Bool
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FC.boolean))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumArrayRequestBody.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumArrayRequestBody.hs
@@ -18,7 +18,7 @@ import qualified TestCases.Operations.TestCases.InlineEnumArrayRequestBody.Reque
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -42,7 +42,7 @@ data Responses
   = Response201 H.NoResponseBody
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 201, fmap Response201 (H.noResponseBody))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumResponses.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumResponses.hs
@@ -18,7 +18,7 @@ import qualified TestCases.Operations.TestCases.InlineEnumResponses.Response201B
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -42,7 +42,7 @@ data Responses
   | Response201 Response201Body.Response201Body
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON Response200Body.response200BodySchema))
   , (H.Status 201, fmap Response201 (H.responseBody FA.JSON Response201Body.response201BodySchema))

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineInt32Response.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineInt32Response.hs
@@ -18,7 +18,7 @@ import Prelude (($), Eq, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -41,7 +41,7 @@ data Responses
   = Response200 I.Int32
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FC.int32))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineInt64Response.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineInt64Response.hs
@@ -18,7 +18,7 @@ import Prelude (($), Eq, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -41,7 +41,7 @@ data Responses
   = Response200 I.Int64
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FC.int64))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineIntegerResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineIntegerResponse.hs
@@ -17,7 +17,7 @@ import Prelude (($), Eq, Integer, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -40,7 +40,7 @@ data Responses
   = Response200 Integer
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FC.integer))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineNullableIntegerArrayResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineNullableIntegerArrayResponse.hs
@@ -17,7 +17,7 @@ import Prelude (($), Either, Eq, Integer, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -40,7 +40,7 @@ data Responses
   = Response200 (Either FC.Null [Either FC.Null Integer])
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.nullable (FC.list (FC.nullable FC.integer)))))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineNullableIntegerResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineNullableIntegerResponse.hs
@@ -17,7 +17,7 @@ import Prelude (($), Either, Eq, Integer, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -40,7 +40,7 @@ data Responses
   = Response200 (Either FC.Null Integer)
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.nullable FC.integer)))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectAdditionalPropertiesJsonResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectAdditionalPropertiesJsonResponse.hs
@@ -19,7 +19,7 @@ import Prelude (($), Eq, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -42,7 +42,7 @@ data Responses
   = Response200 (Map.Map T.Text FC.AnyJSON)
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map FC.anyJSON)))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectJsonResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectJsonResponse.hs
@@ -19,7 +19,7 @@ import Prelude (($), Eq, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -42,7 +42,7 @@ data Responses
   = Response200 (Map.Map T.Text FC.AnyJSON)
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map FC.anyJSON)))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringArrayResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringArrayResponse.hs
@@ -19,7 +19,7 @@ import Prelude (($), Eq, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -42,7 +42,7 @@ data Responses
   = Response200 (Map.Map T.Text [T.Text])
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map (FC.list FC.text))))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringRefResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringRefResponse.hs
@@ -20,7 +20,7 @@ import qualified TestCases.Types.AStringType as AStringType
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -43,7 +43,7 @@ data Responses
   = Response200 (Map.Map T.Text AStringType.AStringType)
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map AStringType.aStringTypeSchema)))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectStringResponse.hs
@@ -19,7 +19,7 @@ import Prelude (($), Eq, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -42,7 +42,7 @@ data Responses
   = Response200 (Map.Map T.Text T.Text)
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.map FC.text)))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesAndAdditionalJsonResponse.hs
@@ -17,7 +17,7 @@ import qualified TestCases.Operations.TestCases.InlineObjectWithPropertiesAndAdd
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -40,7 +40,7 @@ data Responses
   = Response200 Response200Body.Response200Body
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON Response200Body.response200BodySchema))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineObjectWithPropertiesJsonResponse.hs
@@ -17,7 +17,7 @@ import qualified TestCases.Operations.TestCases.InlineObjectWithPropertiesJsonRe
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -40,7 +40,7 @@ data Responses
   = Response200 Response200Body.Response200Body
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON Response200Body.response200BodySchema))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineStringResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineStringResponse.hs
@@ -18,7 +18,7 @@ import Prelude (($), Eq, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -41,7 +41,7 @@ data Responses
   = Response200 T.Text
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FC.text))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/MultipleResponsesCodes.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/MultipleResponsesCodes.hs
@@ -17,7 +17,7 @@ import qualified TestCases.Types.FieldTestCases as FieldTestCases
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -42,7 +42,7 @@ data Responses
   | Response422 H.NoResponseBody
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 201, fmap Response201 (H.noResponseBody))
   , (H.Status 422, fmap Response422 (H.noResponseBody))

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/NoContentResponse.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/NoContentResponse.hs
@@ -11,11 +11,12 @@ module TestCases.Operations.TestCases.NoContentResponse
 import qualified Beeline.HTTP.Client as H
 import Beeline.Routing ((/-))
 import qualified Beeline.Routing as R
+import qualified Fleece.Aeson.Beeline as FA
 import Prelude (($), Eq, Show, fmap)
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -38,7 +39,7 @@ data Responses
   = Response201 H.NoResponseBody
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 201, fmap Response201 (H.noResponseBody))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/OperationTypeOptions/PathParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/OperationTypeOptions/PathParam.hs
@@ -15,13 +15,14 @@ import Beeline.HTTP.Client ((?+))
 import qualified Beeline.HTTP.Client as H
 import Beeline.Routing ((/+), (/-))
 import qualified Beeline.Routing as R
+import qualified Fleece.Aeson.Beeline as FA
 import Prelude (($), fmap)
 import qualified TestCases.Operations.TestCases.OperationTypeOptions.PathParam.PathParam as PathParam
 import qualified TestCases.Operations.TestCases.OperationTypeOptions.PathParam.QueryParam as QueryParam
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     PathParams
     QueryParams
     H.NoHeaderParams
@@ -62,7 +63,7 @@ data Responses
   | Response422 H.NoResponseBody
   deriving ()
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 201, fmap Response201 (H.noResponseBody))
   , (H.Status 422, fmap Response422 (H.noResponseBody))

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/ParamRef.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/ParamRef.hs
@@ -14,12 +14,13 @@ import Beeline.HTTP.Client ((?+))
 import qualified Beeline.HTTP.Client as H
 import Beeline.Routing ((/-))
 import qualified Beeline.Routing as R
+import qualified Fleece.Aeson.Beeline as FA
 import Prelude (($), Eq, Show, fmap)
 import qualified TestCases.Operations.TestCases.ParamRef.XSampleHeaderParam as XSampleHeaderParam
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     HeaderParams
@@ -53,7 +54,7 @@ data Responses
   = Response204 H.NoResponseBody
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 204, fmap Response204 (H.noResponseBody))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams.hs
@@ -27,7 +27,7 @@ import qualified TestCases.Types.FieldTestCases as FieldTestCases
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -71,7 +71,7 @@ data Responses
   = Response200 FieldTestCases.FieldTestCases
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON FieldTestCases.fieldTestCasesSchema))
   ]

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/RequestBody.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/RequestBody.hs
@@ -17,7 +17,7 @@ import qualified TestCases.Types.FieldTestCases as FieldTestCases
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -41,7 +41,7 @@ data Responses
   = Response201 FieldTestCases.FieldTestCases
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 201, fmap Response201 (H.responseBody FA.JSON FieldTestCases.fieldTestCasesSchema))
   ]

--- a/json-fleece-swagger2/examples/uber/Uber/Operations/Estimates/Price.hs
+++ b/json-fleece-swagger2/examples/uber/Uber/Operations/Estimates/Price.hs
@@ -26,7 +26,7 @@ import qualified Uber.Types.PriceEstimate as PriceEstimate
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -67,7 +67,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.list PriceEstimate.priceEstimateSchema)))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-swagger2/examples/uber/Uber/Operations/Estimates/Time.hs
+++ b/json-fleece-swagger2/examples/uber/Uber/Operations/Estimates/Time.hs
@@ -26,7 +26,7 @@ import qualified Uber.Types.Product as Product
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -67,7 +67,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.list Product.productSchema)))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-swagger2/examples/uber/Uber/Operations/History.hs
+++ b/json-fleece-swagger2/examples/uber/Uber/Operations/History.hs
@@ -23,7 +23,7 @@ import qualified Uber.Types.Error as Error
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -59,7 +59,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON Activities.activitiesSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-swagger2/examples/uber/Uber/Operations/Me.hs
+++ b/json-fleece-swagger2/examples/uber/Uber/Operations/Me.hs
@@ -18,7 +18,7 @@ import qualified Uber.Types.Profile as Profile
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     H.NoQueryParams
     H.NoHeaderParams
@@ -41,7 +41,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON Profile.profileSchema))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))

--- a/json-fleece-swagger2/examples/uber/Uber/Operations/Products.hs
+++ b/json-fleece-swagger2/examples/uber/Uber/Operations/Products.hs
@@ -24,7 +24,7 @@ import qualified Uber.Types.Product as Product
 
 operation ::
   H.Operation
-    H.ContentTypeDecodingError
+    FA.JSONDecodingError
     H.NoPathParams
     QueryParams
     H.NoHeaderParams
@@ -60,7 +60,7 @@ data Responses
   | OtherResponse Error.Error
   deriving (Eq, Show)
 
-responseSchemas :: [(H.StatusRange, H.ResponseBodySchema H.ContentTypeDecodingError Responses)]
+responseSchemas :: [(H.StatusRange, H.ResponseBodySchema FA.JSONDecodingError Responses)]
 responseSchemas =
   [ (H.Status 200, fmap Response200 (H.responseBody FA.JSON (FC.list Product.productSchema)))
   , (H.AnyStatus, fmap OtherResponse (H.responseBody FA.JSON Error.errorSchema))


### PR DESCRIPTION
Currently, you can't get the body that failed to decode. It would be useful for logging and debugging though. This PR uses a record to keep around the bytestring.
