### PR TITLE
Add typeOptions support for oneOf/Unions

### DIFF
--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats.hs
@@ -15,6 +15,7 @@ import qualified TestCases.Types.DateTimeFormats.DefaultTimeField as DefaultTime
 import qualified TestCases.Types.DateTimeFormats.LocalTimeField as LocalTimeField
 import qualified TestCases.Types.DateTimeFormats.UtcTimeField as UtcTimeField
 import qualified TestCases.Types.DateTimeFormats.ZonedTimeField as ZonedTimeField
+import qualified TestCases.Types.DateTimeFormats.ZonedTimeInUnionField as ZonedTimeInUnionField
 
 data DateTimeFormats = DateTimeFormats
   { zonedTimeField :: Maybe ZonedTimeField.ZonedTimeField
@@ -24,6 +25,7 @@ data DateTimeFormats = DateTimeFormats
   , utcTimeField :: Maybe UtcTimeField.UtcTimeField
   , customZonedTimeField :: Maybe CustomZonedTimeField.CustomZonedTimeField
   , customUtcTimeField :: Maybe CustomUtcTimeField.CustomUtcTimeField
+  , zonedTimeInUnionField :: Maybe ZonedTimeInUnionField.ZonedTimeInUnionField
   }
   deriving (Show)
 
@@ -38,3 +40,4 @@ dateTimeFormatsSchema =
       #+ FC.optional "utcTimeField" utcTimeField UtcTimeField.utcTimeFieldSchema
       #+ FC.optional "customZonedTimeField" customZonedTimeField CustomZonedTimeField.customZonedTimeFieldSchema
       #+ FC.optional "customUtcTimeField" customUtcTimeField CustomUtcTimeField.customUtcTimeFieldSchema
+      #+ FC.optional "zonedTimeInUnionField" zonedTimeInUnionField ZonedTimeInUnionField.zonedTimeInUnionFieldSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats/ZonedTimeInUnionField.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats/ZonedTimeInUnionField.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE DataKinds #-}
+
+module TestCases.Types.DateTimeFormats.ZonedTimeInUnionField
+  ( ZonedTimeInUnionField(..)
+  , zonedTimeInUnionFieldSchema
+  ) where
+
+import qualified Data.Text as T
+import Fleece.Core ((#|))
+import qualified Fleece.Core as FC
+import Prelude (($), Show)
+import qualified Shrubbery as Shrubbery
+import qualified TestCases.Types.ZonedTimeType as ZonedTimeType
+
+newtype ZonedTimeInUnionField = ZonedTimeInUnionField (Shrubbery.Union
+  '[ ZonedTimeType.ZonedTimeType
+   , T.Text
+   ])
+  deriving (Show)
+
+zonedTimeInUnionFieldSchema :: FC.Fleece schema => schema ZonedTimeInUnionField
+zonedTimeInUnionFieldSchema =
+  FC.coerceSchema $
+    FC.unionNamed (FC.qualifiedName "TestCases.Types.DateTimeFormats.ZonedTimeInUnionField" "ZonedTimeInUnionField") $
+      FC.unionMember ZonedTimeType.zonedTimeTypeSchema
+        #| FC.unionMember FC.text

--- a/json-fleece-openapi3/examples/test-cases/codegen.dhall
+++ b/json-fleece-openapi3/examples/test-cases/codegen.dhall
@@ -63,6 +63,12 @@ in
                   , formatSpecifier = Some "local"
                   }
             }
+          , { type = "TestCases.Types.DateTimeFormats.ZonedTimeInUnionField.ZonedTimeInUnionField"
+            , options =
+                CodeGen.TypeOptions::
+                  { deriveClasses = CodeGen.derive [ CodeGen.show ]
+                  }
+            }
           , { type = "TestCases.Types.UtcTimeType.UtcTimeType"
             , options =
                 CodeGen.TypeOptions::

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -93,6 +93,7 @@ library
       TestCases.Types.DateTimeFormats.LocalTimeField
       TestCases.Types.DateTimeFormats.UtcTimeField
       TestCases.Types.DateTimeFormats.ZonedTimeField
+      TestCases.Types.DateTimeFormats.ZonedTimeInUnionField
       TestCases.Types.DefaultTimeType
       TestCases.Types.DerivingNothing
       TestCases.Types.EnumIntParam

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -746,6 +746,11 @@ components:
         customLocalTimeField:
           type: string
           format: date-time
+        zonedTimeInUnionField:
+          oneOf:
+            - $ref: '#/components/schemas/ZonedTimeType'
+            - type: string
+              format: date-time # Bug: This doesn't actually change it from being a Text in the generated code
 
     DefaultTimeType:
       type: string

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -1940,6 +1940,7 @@ extra-source-files:
     examples/test-cases/TestCases/Types/DateTimeFormats/LocalTimeField.hs
     examples/test-cases/TestCases/Types/DateTimeFormats/UtcTimeField.hs
     examples/test-cases/TestCases/Types/DateTimeFormats/ZonedTimeField.hs
+    examples/test-cases/TestCases/Types/DateTimeFormats/ZonedTimeInUnionField.hs
     examples/test-cases/TestCases/Types/DefaultTimeType.hs
     examples/test-cases/TestCases/Types/DerivingNothing.hs
     examples/test-cases/TestCases/Types/EnumIntParam.hs


### PR DESCRIPTION
We noticed that we couldn't adjust the list of derived classes for union types.
If the union contains a `ZonedTime`, this is necessary since `ZonedTime` doesn't
have `Eq`, which is part of the default deriving list.

This PR adds `TypeOptions` to untagged unions (`CodeGenUnion`). It doesn't add
the support for tagged unions, that is left for upcoming work.
It also doesn't fix the `format: date-time` parsing for inline schemas, which
seems broken, as you can see that the new union in the test cases of this PR
contains a `T.Text`, which it shouldn't.
