### PR TITLE
Accept aeson-2.2, bytestring-0.12, text-2.1

### DIFF
--- a/json-fleece-aeson-beeline/json-fleece-aeson-beeline.cabal
+++ b/json-fleece-aeson-beeline/json-fleece-aeson-beeline.cabal
@@ -35,7 +35,7 @@ library
   build-depends:
       base >=4.7 && <5
     , beeline-http-client >=0.2 && <0.9
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , http-client ==0.7.*
     , json-fleece-aeson >=0.1 && <0.4
   default-language: Haskell2010

--- a/json-fleece-aeson-beeline/package.yaml
+++ b/json-fleece-aeson-beeline/package.yaml
@@ -51,7 +51,7 @@ library:
   dependencies:
     - json-fleece-aeson >= 0.1 && < 0.4
     - beeline-http-client >= 0.2 && < 0.9
-    - bytestring >= 0.11 && < 0.12
+    - bytestring >= 0.11 && < 0.13
     - http-client >= 0.7 && < 0.8
   exposed-modules:
     - Fleece.Aeson.Beeline

--- a/json-fleece-aeson/json-fleece-aeson.cabal
+++ b/json-fleece-aeson/json-fleece-aeson.cabal
@@ -37,13 +37,13 @@ library
   hs-source-dirs:
       src
   build-depends:
-      aeson >=2.0 && <2.2
+      aeson >=2.0 && <2.3
     , base >=4.7 && <5
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , containers ==0.6.*
     , json-fleece-core ==0.7.*
     , shrubbery ==0.2.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
     , vector >=0.12 && <0.14
   default-language: Haskell2010
   if flag(strict)
@@ -60,9 +60,9 @@ test-suite json-fleece-aeson-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >=2.0 && <2.2
+      aeson >=2.0 && <2.3
     , base >=4.7 && <5
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , containers ==0.6.*
     , hedgehog
     , json-fleece-aeson
@@ -70,7 +70,7 @@ test-suite json-fleece-aeson-test
     , json-fleece-examples
     , scientific >=0.3.7 && <0.4
     , shrubbery ==0.2.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
     , time >=1.11 && <1.13
     , vector >=0.12 && <0.14
   default-language: Haskell2010

--- a/json-fleece-aeson/package.yaml
+++ b/json-fleece-aeson/package.yaml
@@ -17,11 +17,11 @@ description:         Please see the README on GitHub at <https://github.com/gith
 
 dependencies:
 - base >= 4.7 && < 5
-- aeson >= 2.0 && < 2.2
-- bytestring >= 0.11 && < 0.12
+- aeson >= 2.0 && < 2.3
+- bytestring >= 0.11 && < 0.13
 - containers >= 0.6 && < 0.7
 - json-fleece-core >= 0.7 && < 0.8
-- text >= 1.2 && < 2.1
+- text >= 1.2 && < 2.2
 - vector >= 0.12 && < 0.14
 - shrubbery >= 0.2 && < 0.3
 

--- a/json-fleece-codegen-util/json-fleece-codegen-util.cabal
+++ b/json-fleece-codegen-util/json-fleece-codegen-util.cabal
@@ -39,9 +39,9 @@ library
   hs-source-dirs:
       src
   build-depends:
-      aeson >=2.0 && <2.2
+      aeson >=2.0 && <2.3
     , base >=4.7 && <5
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , containers ==0.6.*
     , dhall >=1.41 && <1.43
     , directory ==1.3.*
@@ -51,7 +51,7 @@ library
     , mtl >=2.2 && <2.4
     , non-empty-text ==0.2.*
     , optparse-applicative >=0.17 && <0.19
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
     , text-manipulate ==0.3.*
     , yaml ==0.11.*
   default-language: Haskell2010

--- a/json-fleece-codegen-util/package.yaml
+++ b/json-fleece-codegen-util/package.yaml
@@ -17,8 +17,8 @@ description:         Please see the README on GitHub at <https://github.com/gith
 
 dependencies:
 - base >= 4.7 && < 5
-- aeson >= 2.0 && < 2.2
-- bytestring >= 0.11 && < 0.12
+- aeson >= 2.0 && < 2.3
+- bytestring >= 0.11 && < 0.13
 - containers >= 0.6 && < 0.7
 - dhall >= 1.41 &&  < 1.43
 - directory >= 1.3 && < 1.4
@@ -28,7 +28,7 @@ dependencies:
 - mtl >= 2.2 && < 2.4
 - non-empty-text >= 0.2 && < 0.3
 - optparse-applicative >= 0.17 && < 0.19
-- text >= 1.2 && < 2.1
+- text >= 1.2 && < 2.2
 - text-manipulate >= 0.3 && < 0.4
 - yaml >= 0.11 && < 0.12
 

--- a/json-fleece-core/json-fleece-core.cabal
+++ b/json-fleece-core/json-fleece-core.cabal
@@ -44,7 +44,7 @@ library
     , non-empty-text ==0.2.*
     , scientific >=0.3.7 && <0.4
     , shrubbery ==0.2.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
     , time >=1.11 && <1.13
     , vector >=0.12 && <0.14
   default-language: Haskell2010

--- a/json-fleece-core/package.yaml
+++ b/json-fleece-core/package.yaml
@@ -23,7 +23,7 @@ dependencies:
 - non-empty-text >= 0.2 && < 0.3
 - scientific >= 0.3.7 && < 0.4
 - shrubbery >= 0.2 && < 0.3
-- text >= 1.2 && < 2.1
+- text >= 1.2 && < 2.2
 - time >= 1.11 && < 1.13
 - vector >= 0.12 && < 0.14
 

--- a/json-fleece-examples/json-fleece-examples.cabal
+++ b/json-fleece-examples/json-fleece-examples.cabal
@@ -38,7 +38,7 @@ library
     , json-fleece-core ==0.7.*
     , scientific >=0.3.7 && <0.4
     , shrubbery ==0.2.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010
   if flag(strict)
     ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-unticked-promoted-constructors

--- a/json-fleece-examples/package.yaml
+++ b/json-fleece-examples/package.yaml
@@ -21,7 +21,7 @@ dependencies:
 - json-fleece-core >= 0.7 && < 0.8
 - scientific >= 0.3.7 && < 0.4
 - shrubbery >= 0.2 && < 0.3
-- text >= 1.2 && < 2.1
+- text >= 1.2 && < 2.2
 
 flags:
   strict:

--- a/json-fleece-hermes/json-fleece-hermes.cabal
+++ b/json-fleece-hermes/json-fleece-hermes.cabal
@@ -34,7 +34,7 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , containers ==0.6.*
     , hermes-json ==0.6.*
     , json-fleece-core ==0.7.*
@@ -55,9 +55,9 @@ test-suite json-fleece-hermes-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >=2.0 && <2.2
+      aeson >=2.0 && <2.3
     , base >=4.7 && <5
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , containers ==0.6.*
     , hedgehog
     , json-fleece-core ==0.7.*

--- a/json-fleece-hermes/package.yaml
+++ b/json-fleece-hermes/package.yaml
@@ -17,7 +17,7 @@ description: Please see the README on GitHub at <https://github.com/flipstone/js
 
 dependencies:
 - base >= 4.7 && < 5
-- bytestring >= 0.11 && < 0.12
+- bytestring >= 0.11 && < 0.13
 - json-fleece-core >= 0.7 && < 0.8
 - text >= 2.0 # This could be problematic for anyone using LTS 20 or below
 
@@ -66,7 +66,7 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     dependencies:
-    - aeson >= 2.0 && < 2.2
+    - aeson >= 2.0 && < 2.3
     - containers >= 0.6 && < 0.7
     - json-fleece-hermes
     - json-fleece-examples

--- a/json-fleece-markdown/json-fleece-markdown.cabal
+++ b/json-fleece-markdown/json-fleece-markdown.cabal
@@ -40,7 +40,7 @@ library
     , containers ==0.6.*
     , dlist ==1.0.*
     , json-fleece-core ==0.7.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010
   if flag(strict)
     ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-unticked-promoted-constructors
@@ -61,7 +61,7 @@ test-suite json-fleece-markdown-test
     , json-fleece-core
     , json-fleece-examples
     , json-fleece-markdown
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010
   if flag(strict)
     ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-unticked-promoted-constructors

--- a/json-fleece-markdown/package.yaml
+++ b/json-fleece-markdown/package.yaml
@@ -17,7 +17,7 @@ description:         Please see the README on GitHub at <https://github.com/flip
 
 dependencies:
 - base >= 4.7 && < 5
-- text >= 1.2 && < 2.1
+- text >= 1.2 && < 2.2
 
 flags:
   strict:

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -2054,7 +2054,7 @@ library
   hs-source-dirs:
       src
   build-depends:
-      aeson >=2.0 && <2.2
+      aeson >=2.0 && <2.3
     , base >=4.7 && <5
     , containers ==0.6.*
     , insert-ordered-containers ==0.2.*
@@ -2062,7 +2062,7 @@ library
     , mtl >=2.2 && <2.4
     , non-empty-text ==0.2.*
     , openapi3 ==3.2.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010
   if flag(strict)
     ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-unticked-promoted-constructors
@@ -2096,7 +2096,7 @@ test-suite json-fleece-openapi3-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , file-embed >=0.0.15 && <0.0.17
     , hedgehog
     , json-fleece-codegen-util ==0.11.*

--- a/json-fleece-openapi3/package.yaml
+++ b/json-fleece-openapi3/package.yaml
@@ -60,13 +60,13 @@ library:
   exposed-modules:
     - Fleece.OpenApi3
   dependencies:
-    - aeson >= 2.0 && < 2.2
+    - aeson >= 2.0 && < 2.3
     - insert-ordered-containers >= 0.2 && < 0.3
     - containers >= 0.6 && < 0.7
     - mtl >= 2.2 && < 2.4
     - non-empty-text >= 0.2 && < 0.3
     - openapi3 >= 3.2 && < 3.3
-    - text >= 1.2 && < 2.1
+    - text >= 1.2 && < 2.2
 
 executables:
   fleece-openapi3:
@@ -89,6 +89,6 @@ tests:
     dependencies:
       - json-fleece-openapi3
       - hedgehog
-      - bytestring >= 0.11 && < 0.12
+      - bytestring >= 0.11 && < 0.13
       - file-embed >= 0.0.15 && < 0.0.17
       - yaml >= 0.11 && < 0.12

--- a/json-fleece-pretty-print/json-fleece-pretty-print.cabal
+++ b/json-fleece-pretty-print/json-fleece-pretty-print.cabal
@@ -39,7 +39,7 @@ library
     , json-fleece-core ==0.7.*
     , scientific ==0.3.*
     , shrubbery ==0.2.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010
   if flag(strict)
     ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-unticked-promoted-constructors
@@ -62,7 +62,7 @@ test-suite json-fleece-pretty-print-test
     , json-fleece-examples
     , json-fleece-pretty-print
     , shrubbery ==0.2.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010
   if flag(strict)
     ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-unticked-promoted-constructors

--- a/json-fleece-pretty-print/package.yaml
+++ b/json-fleece-pretty-print/package.yaml
@@ -19,7 +19,7 @@ dependencies:
 - base >= 4.7 && < 5
 - json-fleece-core >= 0.7 && < 0.8
 - shrubbery >= 0.2 && < 0.3
-- text >= 1.2 && < 2.1
+- text >= 1.2 && < 2.2
 
 flags:
   strict:

--- a/json-fleece-swagger2/json-fleece-swagger2.cabal
+++ b/json-fleece-swagger2/json-fleece-swagger2.cabal
@@ -89,7 +89,7 @@ library
     , json-fleece-openapi3 ==0.4.*
     , openapi3 ==3.2.*
     , swagger2 ==2.8.*
-    , text >=1.2 && <2.1
+    , text >=1.2 && <2.2
   default-language: Haskell2010
   if flag(strict)
     ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-unticked-promoted-constructors
@@ -122,9 +122,9 @@ test-suite json-fleece-swagger2-test
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      aeson >=2.0 && <2.2
+      aeson >=2.0 && <2.3
     , base >=4.7 && <5
-    , bytestring ==0.11.*
+    , bytestring >=0.11 && <0.13
     , file-embed >=0.0.15 && <0.0.17
     , hedgehog
     , json-fleece-codegen-util ==0.11.*

--- a/json-fleece-swagger2/package.yaml
+++ b/json-fleece-swagger2/package.yaml
@@ -61,7 +61,7 @@ library:
     - insert-ordered-containers >= 0.2 && < 0.3
     - swagger2 >= 2.8 && < 2.9
     - openapi3 >= 3.2 &&  < 3.3
-    - text >= 1.2 && < 2.1
+    - text >= 1.2 && < 2.2
 
 executables:
   fleece-swagger2:
@@ -84,6 +84,6 @@ tests:
     dependencies:
       - json-fleece-swagger2
       - hedgehog
-      - aeson >= 2.0 && < 2.2
-      - bytestring >= 0.11 && < 0.12
+      - aeson >= 2.0 && < 2.3
+      - bytestring >= 0.11 && < 0.13
       - file-embed >= 0.0.15 && < 0.0.17


### PR DESCRIPTION
For anyone using Stackage Nightly or GHC 9.8 (which [has
bytestring-0.12](https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history)),
it would be nice if they didn't have to use `allow-newer`. We don't have CI
testing for this. But given that we don't have CI testing for the lower bounds
either, I don't think this is too risky, since I have tested it locally.
