### PR TITLE
Add {to,from}{Lazy,Strict}Text

### DIFF
--- a/json-fleece-aeson/src/Fleece/Aeson/ToValue.hs
+++ b/json-fleece-aeson/src/Fleece/Aeson/ToValue.hs
@@ -9,21 +9,31 @@
 module Fleece.Aeson.ToValue
   ( ToValue
   , toValue
+  , toLazyText
+  , toStrictText
   ) where
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as AesonKey
+import Data.Aeson.Text (encodeToLazyText)
 import qualified Data.Aeson.Types as AesonTypes
 import qualified Data.ByteString.Lazy as LBS
 import Data.Coerce (coerce)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as Enc
+import qualified Data.Text.Lazy as TL
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import Shrubbery (type (@=))
 import qualified Shrubbery
 
 import qualified Fleece.Core as FC
+
+toLazyText :: ToValue a -> a -> TL.Text
+toLazyText encoder = encodeToLazyText . toValue encoder
+
+toStrictText :: ToValue a -> a -> T.Text
+toStrictText encoder = TL.toStrict . toLazyText encoder
 
 toValue :: ToValue a -> a -> Aeson.Value
 toValue (ToValue _name f) =


### PR DESCRIPTION
Our proprietary codebases have 16 occurances of `Enc.decodeUtf8 . LBS.toStrict
. FA.encode`. This PR adds convenience functions for this, and we avoid
reimplementing this all over the place. This also enables easily swapping out
the implementation for a more efficient one. For example, we can use
`encodeToLazyText` instead of the partial function `decodeUtf8`. This brings us
closer to using linting to prevent the use of partial functions.
