### PR TITLE
openapi3: Do not make singleton unions

### DIFF
--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/ArrayWithNullableStrings.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/ArrayWithNullableStrings.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.ArrayWithNullableStrings
+  ( ArrayWithNullableStrings(..)
+  , arrayWithNullableStringsSchema
+  ) where
+
+import qualified Fleece.Core as FC
+import Prelude (Either, Eq, Show)
+import qualified TestCases.Types.NullableString as NullableString
+
+newtype ArrayWithNullableStrings = ArrayWithNullableStrings [Either FC.Null NullableString.NullableString]
+  deriving (Show, Eq)
+
+arrayWithNullableStringsSchema :: FC.Fleece schema => schema ArrayWithNullableStrings
+arrayWithNullableStringsSchema =
+  FC.coerceSchema (FC.list (FC.nullable NullableString.nullableStringSchema))

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineNoAdditionalPropertiesWithOneOfNullabilityOutside.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineNoAdditionalPropertiesWithOneOfNullabilityOutside.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.InlineNoAdditionalPropertiesWithOneOfNullabilityOutside
+  ( InlineNoAdditionalPropertiesWithOneOfNullabilityOutside(..)
+  , inlineNoAdditionalPropertiesWithOneOfNullabilityOutsideSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Either, Eq, Show)
+import qualified TestCases.Types.SingletonNullableOneOfRef as SingletonNullableOneOfRef
+
+newtype InlineNoAdditionalPropertiesWithOneOfNullabilityOutside = InlineNoAdditionalPropertiesWithOneOfNullabilityOutside (Map.Map T.Text (Either FC.Null SingletonNullableOneOfRef.SingletonNullableOneOfRef))
+  deriving (Show, Eq)
+
+inlineNoAdditionalPropertiesWithOneOfNullabilityOutsideSchema :: FC.Fleece schema => schema InlineNoAdditionalPropertiesWithOneOfNullabilityOutside
+inlineNoAdditionalPropertiesWithOneOfNullabilityOutsideSchema =
+  FC.coerceSchema (FC.map (FC.nullable SingletonNullableOneOfRef.singletonNullableOneOfRefSchema))

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineYesAdditionalPropertiesWithOneOfNullablityInside.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineYesAdditionalPropertiesWithOneOfNullablityInside.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.InlineYesAdditionalPropertiesWithOneOfNullablityInside
+  ( InlineYesAdditionalPropertiesWithOneOfNullablityInside(..)
+  , inlineYesAdditionalPropertiesWithOneOfNullablityInsideSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Fleece.Core ((#*), (#+))
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Maybe, Show)
+import qualified TestCases.Types.InlineYesAdditionalPropertiesWithOneOfNullablityInside.Foobar as Foobar
+import qualified TestCases.Types.InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem as InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem
+
+data InlineYesAdditionalPropertiesWithOneOfNullablityInside = InlineYesAdditionalPropertiesWithOneOfNullablityInside
+  { foobar :: Maybe Foobar.Foobar
+  , additionalProperties :: (Map.Map T.Text InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem.InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem)
+  }
+  deriving (Eq, Show)
+
+inlineYesAdditionalPropertiesWithOneOfNullablityInsideSchema :: FC.Fleece schema => schema InlineYesAdditionalPropertiesWithOneOfNullablityInside
+inlineYesAdditionalPropertiesWithOneOfNullablityInsideSchema =
+  FC.object $
+    FC.constructor InlineYesAdditionalPropertiesWithOneOfNullablityInside
+      #+ FC.optional "foobar" foobar Foobar.foobarSchema
+      #* FC.additionalFields additionalProperties InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem.inlineYesAdditionalPropertiesWithOneOfNullablityInsideItemSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineYesAdditionalPropertiesWithOneOfNullablityInside/Foobar.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineYesAdditionalPropertiesWithOneOfNullablityInside/Foobar.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.InlineYesAdditionalPropertiesWithOneOfNullablityInside.Foobar
+  ( Foobar(..)
+  , foobarSchema
+  ) where
+
+import qualified Fleece.Core as FC
+import Prelude (Bool, Eq, Show)
+
+newtype Foobar = Foobar Bool
+  deriving (Show, Eq)
+
+foobarSchema :: FC.Fleece schema => schema Foobar
+foobarSchema =
+  FC.coerceSchema FC.boolean

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem
+  ( InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem(..)
+  , inlineYesAdditionalPropertiesWithOneOfNullablityInsideItemSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem = InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem T.Text
+  deriving (Show, Eq)
+
+inlineYesAdditionalPropertiesWithOneOfNullablityInsideItemSchema :: FC.Fleece schema => schema InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem
+inlineYesAdditionalPropertiesWithOneOfNullablityInsideItemSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineArrayNullableOneOf/MinItemsOneInlineArrayNullableOneOfItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineArrayNullableOneOf/MinItemsOneInlineArrayNullableOneOfItem.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE DataKinds #-}
 
 module TestCases.Types.MinItemsOneInlineArrayNullableOneOf.MinItemsOneInlineArrayNullableOneOfItem
   ( MinItemsOneInlineArrayNullableOneOfItem(..)
@@ -8,16 +7,12 @@ module TestCases.Types.MinItemsOneInlineArrayNullableOneOf.MinItemsOneInlineArra
 
 import qualified Data.List.NonEmpty as NEL
 import qualified Fleece.Core as FC
-import Prelude (($), Bool, Either, Eq, Show)
-import qualified Shrubbery as Shrubbery
+import Prelude (Eq, Show)
+import qualified TestCases.Types.MinItemsOneInlineArrayNullableOneOf.MinItemsOneInlineArrayNullableOneOfItem.MinItemsOneInlineArrayNullableOneOf.MinItemsOneInlineArrayNullableOneOfItemItem as MinItemsOneInlineArrayNullableOneOfItemItem
 
-newtype MinItemsOneInlineArrayNullableOneOfItem = MinItemsOneInlineArrayNullableOneOfItem (Shrubbery.Union
-  '[ Either FC.Null (NEL.NonEmpty Bool)
-   ])
+newtype MinItemsOneInlineArrayNullableOneOfItem = MinItemsOneInlineArrayNullableOneOfItem (NEL.NonEmpty MinItemsOneInlineArrayNullableOneOfItemItem.MinItemsOneInlineArrayNullableOneOfItemItem)
   deriving (Show, Eq)
 
 minItemsOneInlineArrayNullableOneOfItemSchema :: FC.Fleece schema => schema MinItemsOneInlineArrayNullableOneOfItem
 minItemsOneInlineArrayNullableOneOfItemSchema =
-  FC.coerceSchema $
-    FC.unionNamed (FC.qualifiedName "TestCases.Types.MinItemsOneInlineArrayNullableOneOf.MinItemsOneInlineArrayNullableOneOfItem" "MinItemsOneInlineArrayNullableOneOfItem") $
-      FC.unionMember (FC.nullable (FC.nonEmpty FC.boolean))
+  FC.coerceSchema (FC.nonEmpty MinItemsOneInlineArrayNullableOneOfItemItem.minItemsOneInlineArrayNullableOneOfItemItemSchema)

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineArrayNullableOneOf/MinItemsOneInlineArrayNullableOneOfItem/MinItemsOneInlineArrayNullableOneOf/MinItemsOneInlineArrayNullableOneOfItemItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineArrayNullableOneOf/MinItemsOneInlineArrayNullableOneOfItem/MinItemsOneInlineArrayNullableOneOf/MinItemsOneInlineArrayNullableOneOfItemItem.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MinItemsOneInlineArrayNullableOneOf.MinItemsOneInlineArrayNullableOneOfItem.MinItemsOneInlineArrayNullableOneOf.MinItemsOneInlineArrayNullableOneOfItemItem
+  ( MinItemsOneInlineArrayNullableOneOfItemItem(..)
+  , minItemsOneInlineArrayNullableOneOfItemItemSchema
+  ) where
+
+import qualified Fleece.Core as FC
+import Prelude (Bool, Eq, Show)
+
+newtype MinItemsOneInlineArrayNullableOneOfItemItem = MinItemsOneInlineArrayNullableOneOfItemItem Bool
+  deriving (Show, Eq)
+
+minItemsOneInlineArrayNullableOneOfItemItemSchema :: FC.Fleece schema => schema MinItemsOneInlineArrayNullableOneOfItemItem
+minItemsOneInlineArrayNullableOneOfItemItemSchema =
+  FC.coerceSchema FC.boolean

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineArrayOneOf/MinItemsOneInlineArrayOneOfItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineArrayOneOf/MinItemsOneInlineArrayOneOfItem.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE DataKinds #-}
 
 module TestCases.Types.MinItemsOneInlineArrayOneOf.MinItemsOneInlineArrayOneOfItem
   ( MinItemsOneInlineArrayOneOfItem(..)
@@ -8,16 +7,12 @@ module TestCases.Types.MinItemsOneInlineArrayOneOf.MinItemsOneInlineArrayOneOfIt
 
 import qualified Data.List.NonEmpty as NEL
 import qualified Fleece.Core as FC
-import Prelude (($), Bool, Eq, Show)
-import qualified Shrubbery as Shrubbery
+import Prelude (Eq, Show)
+import qualified TestCases.Types.MinItemsOneInlineArrayOneOf.MinItemsOneInlineArrayOneOfItem.MinItemsOneInlineArrayOneOf.MinItemsOneInlineArrayOneOfItemItem as MinItemsOneInlineArrayOneOfItemItem
 
-newtype MinItemsOneInlineArrayOneOfItem = MinItemsOneInlineArrayOneOfItem (Shrubbery.Union
-  '[ (NEL.NonEmpty Bool)
-   ])
+newtype MinItemsOneInlineArrayOneOfItem = MinItemsOneInlineArrayOneOfItem (NEL.NonEmpty MinItemsOneInlineArrayOneOfItemItem.MinItemsOneInlineArrayOneOfItemItem)
   deriving (Show, Eq)
 
 minItemsOneInlineArrayOneOfItemSchema :: FC.Fleece schema => schema MinItemsOneInlineArrayOneOfItem
 minItemsOneInlineArrayOneOfItemSchema =
-  FC.coerceSchema $
-    FC.unionNamed (FC.qualifiedName "TestCases.Types.MinItemsOneInlineArrayOneOf.MinItemsOneInlineArrayOneOfItem" "MinItemsOneInlineArrayOneOfItem") $
-      FC.unionMember (FC.nonEmpty FC.boolean)
+  FC.coerceSchema (FC.nonEmpty MinItemsOneInlineArrayOneOfItemItem.minItemsOneInlineArrayOneOfItemItemSchema)

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineArrayOneOf/MinItemsOneInlineArrayOneOfItem/MinItemsOneInlineArrayOneOf/MinItemsOneInlineArrayOneOfItemItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineArrayOneOf/MinItemsOneInlineArrayOneOfItem/MinItemsOneInlineArrayOneOf/MinItemsOneInlineArrayOneOfItemItem.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MinItemsOneInlineArrayOneOf.MinItemsOneInlineArrayOneOfItem.MinItemsOneInlineArrayOneOf.MinItemsOneInlineArrayOneOfItemItem
+  ( MinItemsOneInlineArrayOneOfItemItem(..)
+  , minItemsOneInlineArrayOneOfItemItemSchema
+  ) where
+
+import qualified Fleece.Core as FC
+import Prelude (Bool, Eq, Show)
+
+newtype MinItemsOneInlineArrayOneOfItemItem = MinItemsOneInlineArrayOneOfItemItem Bool
+  deriving (Show, Eq)
+
+minItemsOneInlineArrayOneOfItemItemSchema :: FC.Fleece schema => schema MinItemsOneInlineArrayOneOfItemItem
+minItemsOneInlineArrayOneOfItemItemSchema =
+  FC.coerceSchema FC.boolean

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineObjectOneOf/SomeArrayItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineObjectOneOf/SomeArrayItem.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE DataKinds #-}
 
 module TestCases.Types.MinItemsOneInlineObjectOneOf.SomeArrayItem
   ( SomeArrayItem(..)
@@ -8,16 +7,12 @@ module TestCases.Types.MinItemsOneInlineObjectOneOf.SomeArrayItem
 
 import qualified Data.List.NonEmpty as NEL
 import qualified Fleece.Core as FC
-import Prelude (($), Bool, Eq, Show)
-import qualified Shrubbery as Shrubbery
+import Prelude (Eq, Show)
+import qualified TestCases.Types.MinItemsOneInlineObjectOneOf.SomeArrayItem.MinItemsOneInlineObjectOneOf.SomeArrayItemItem as SomeArrayItemItem
 
-newtype SomeArrayItem = SomeArrayItem (Shrubbery.Union
-  '[ (NEL.NonEmpty Bool)
-   ])
+newtype SomeArrayItem = SomeArrayItem (NEL.NonEmpty SomeArrayItemItem.SomeArrayItemItem)
   deriving (Show, Eq)
 
 someArrayItemSchema :: FC.Fleece schema => schema SomeArrayItem
 someArrayItemSchema =
-  FC.coerceSchema $
-    FC.unionNamed (FC.qualifiedName "TestCases.Types.MinItemsOneInlineObjectOneOf.SomeArrayItem" "SomeArrayItem") $
-      FC.unionMember (FC.nonEmpty FC.boolean)
+  FC.coerceSchema (FC.nonEmpty SomeArrayItemItem.someArrayItemItemSchema)

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineObjectOneOf/SomeArrayItem/MinItemsOneInlineObjectOneOf/SomeArrayItemItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/MinItemsOneInlineObjectOneOf/SomeArrayItem/MinItemsOneInlineObjectOneOf/SomeArrayItemItem.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.MinItemsOneInlineObjectOneOf.SomeArrayItem.MinItemsOneInlineObjectOneOf.SomeArrayItemItem
+  ( SomeArrayItemItem(..)
+  , someArrayItemItemSchema
+  ) where
+
+import qualified Fleece.Core as FC
+import Prelude (Bool, Eq, Show)
+
+newtype SomeArrayItemItem = SomeArrayItemItem Bool
+  deriving (Show, Eq)
+
+someArrayItemItemSchema :: FC.Fleece schema => schema SomeArrayItemItem
+someArrayItemItemSchema =
+  FC.coerceSchema FC.boolean

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/NullableString.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/NullableString.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.NullableString
+  ( NullableString(..)
+  , nullableStringSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype NullableString = NullableString T.Text
+  deriving (Show, Eq)
+
+nullableStringSchema :: FC.Fleece schema => schema NullableString
+nullableStringSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/SingletonNonNullableOneOfRef.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/SingletonNonNullableOneOfRef.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.SingletonNonNullableOneOfRef
+  ( SingletonNonNullableOneOfRef(..)
+  , singletonNonNullableOneOfRefSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype SingletonNonNullableOneOfRef = SingletonNonNullableOneOfRef T.Text
+  deriving (Show, Eq)
+
+singletonNonNullableOneOfRefSchema :: FC.Fleece schema => schema SingletonNonNullableOneOfRef
+singletonNonNullableOneOfRefSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/SingletonNullableOneOfPrimitive.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/SingletonNullableOneOfPrimitive.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.SingletonNullableOneOfPrimitive
+  ( SingletonNullableOneOfPrimitive(..)
+  , singletonNullableOneOfPrimitiveSchema
+  ) where
+
+import qualified Fleece.Core as FC
+import Prelude (Bool, Eq, Show)
+
+newtype SingletonNullableOneOfPrimitive = SingletonNullableOneOfPrimitive Bool
+  deriving (Show, Eq)
+
+singletonNullableOneOfPrimitiveSchema :: FC.Fleece schema => schema SingletonNullableOneOfPrimitive
+singletonNullableOneOfPrimitiveSchema =
+  FC.coerceSchema FC.boolean

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/SingletonNullableOneOfRef.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/SingletonNullableOneOfRef.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.SingletonNullableOneOfRef
+  ( SingletonNullableOneOfRef(..)
+  , singletonNullableOneOfRefSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype SingletonNullableOneOfRef = SingletonNullableOneOfRef T.Text
+  deriving (Show, Eq)
+
+singletonNullableOneOfRefSchema :: FC.Fleece schema => schema SingletonNullableOneOfRef
+singletonNullableOneOfRefSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/TopLevelOneOfOneOption.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/TopLevelOneOfOneOption.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE DataKinds #-}
 
 module TestCases.Types.TopLevelOneOfOneOption
   ( TopLevelOneOfOneOption(..)
@@ -8,16 +7,11 @@ module TestCases.Types.TopLevelOneOfOneOption
 
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Eq, Show)
-import qualified Shrubbery as Shrubbery
+import Prelude (Eq, Show)
 
-newtype TopLevelOneOfOneOption = TopLevelOneOfOneOption (Shrubbery.Union
-  '[ T.Text
-   ])
+newtype TopLevelOneOfOneOption = TopLevelOneOfOneOption T.Text
   deriving (Show, Eq)
 
 topLevelOneOfOneOptionSchema :: FC.Fleece schema => schema TopLevelOneOfOneOption
 topLevelOneOfOneOptionSchema =
-  FC.coerceSchema $
-    FC.unionNamed (FC.qualifiedName "TestCases.Types.TopLevelOneOfOneOption" "TopLevelOneOfOneOption") $
-      FC.unionMember FC.text
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -77,6 +77,7 @@ library
       TestCases.Operations.TestCases.QueryParams.RequiredArrayParam
       TestCases.Operations.TestCases.QueryParams.StringParam
       TestCases.Operations.TestCases.RequestBody
+      TestCases.Types.ArrayWithNullableStrings
       TestCases.Types.AStringType
       TestCases.Types.Bar
       TestCases.Types.Bar.BarName
@@ -113,6 +114,10 @@ library
       TestCases.Types.FieldTestCases.RequiredNullableField
       TestCases.Types.Foo
       TestCases.Types.Foo.Type
+      TestCases.Types.InlineNoAdditionalPropertiesWithOneOfNullabilityOutside
+      TestCases.Types.InlineYesAdditionalPropertiesWithOneOfNullablityInside
+      TestCases.Types.InlineYesAdditionalPropertiesWithOneOfNullablityInside.Foobar
+      TestCases.Types.InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem
       TestCases.Types.JustAdditionalPropertiesNullableBoolean
       TestCases.Types.JustAdditionalPropertiesNullableBooleanItem
       TestCases.Types.JustAdditionalPropertiesNullableBooleanRef
@@ -127,10 +132,13 @@ library
       TestCases.Types.MinItemsOneInline.SomeArrayItem
       TestCases.Types.MinItemsOneInlineArrayNullableOneOf
       TestCases.Types.MinItemsOneInlineArrayNullableOneOf.MinItemsOneInlineArrayNullableOneOfItem
+      TestCases.Types.MinItemsOneInlineArrayNullableOneOf.MinItemsOneInlineArrayNullableOneOfItem.MinItemsOneInlineArrayNullableOneOf.MinItemsOneInlineArrayNullableOneOfItemItem
       TestCases.Types.MinItemsOneInlineArrayOneOf
       TestCases.Types.MinItemsOneInlineArrayOneOf.MinItemsOneInlineArrayOneOfItem
+      TestCases.Types.MinItemsOneInlineArrayOneOf.MinItemsOneInlineArrayOneOfItem.MinItemsOneInlineArrayOneOf.MinItemsOneInlineArrayOneOfItemItem
       TestCases.Types.MinItemsOneInlineObjectOneOf
       TestCases.Types.MinItemsOneInlineObjectOneOf.SomeArrayItem
+      TestCases.Types.MinItemsOneInlineObjectOneOf.SomeArrayItem.MinItemsOneInlineObjectOneOf.SomeArrayItemItem
       TestCases.Types.MixedInAdditionalPropertiesFalse
       TestCases.Types.MixedInAdditionalPropertiesFalse.Bar
       TestCases.Types.MixedInAdditionalPropertiesFalse.Foo
@@ -171,6 +179,7 @@ library
       TestCases.Types.NameConflicts.Type
       TestCases.Types.NameConflicts.Where
       TestCases.Types.NullableBoolean
+      TestCases.Types.NullableString
       TestCases.Types.Num2SchemaStartingWithNumber
       TestCases.Types.ObjectWithDiscriminatedUnionRef
       TestCases.Types.OneOfWithDiscriminator
@@ -178,6 +187,9 @@ library
       TestCases.Types.OneOfWithNullable
       TestCases.Types.ReferenceOneOf
       TestCases.Types.ReferenceOneOfInsideOneOf
+      TestCases.Types.SingletonNonNullableOneOfRef
+      TestCases.Types.SingletonNullableOneOfPrimitive
+      TestCases.Types.SingletonNullableOneOfRef
       TestCases.Types.StringParam
       TestCases.Types.TestCases.InlineObjectWithPropertiesJsonResponse.Response200Body.Baz.Bax
       TestCases.Types.TopLevelArray

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -914,3 +914,41 @@ components:
             minItems: 1
             nullable: true
       minItems: 1
+
+    ArrayWithNullableStrings:
+      type: array
+      items:
+        $ref: '#/components/schemas/NullableString'
+
+    NullableString:
+      nullable: true
+      type: string
+
+    SingletonNullableOneOfPrimitive:
+      nullable: true
+      oneOf:
+        - type: boolean
+
+    SingletonNullableOneOfRef:
+      nullable: true
+      oneOf:
+        - $ref: '#/components/schemas/AStringType'
+
+    SingletonNonNullableOneOfRef:
+      oneOf:
+        - $ref: '#/components/schemas/AStringType'
+
+    InlineNo_AdditionalPropertiesWithOneOf_NullabilityOutside:
+      type: object
+      properties: {}
+      additionalProperties:
+        $ref: '#/components/schemas/SingletonNullableOneOfRef'
+
+    InlineYes_AdditionalPropertiesWithOneOf_NullablityInside:
+      type: object
+      properties:
+        foobar:
+          type: boolean
+      additionalProperties:
+        oneOf:
+          - $ref: '#/components/schemas/NullableString'

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-openapi3
-version:        0.4.3.2
+version:        0.4.4.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-openapi3#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -1924,6 +1924,7 @@ extra-source-files:
     examples/test-cases/TestCases/Operations/TestCases/QueryParams/RequiredArrayParam.hs
     examples/test-cases/TestCases/Operations/TestCases/QueryParams/StringParam.hs
     examples/test-cases/TestCases/Operations/TestCases/RequestBody.hs
+    examples/test-cases/TestCases/Types/ArrayWithNullableStrings.hs
     examples/test-cases/TestCases/Types/AStringType.hs
     examples/test-cases/TestCases/Types/Bar.hs
     examples/test-cases/TestCases/Types/Bar/BarName.hs
@@ -1960,6 +1961,10 @@ extra-source-files:
     examples/test-cases/TestCases/Types/FieldTestCases/RequiredNullableField.hs
     examples/test-cases/TestCases/Types/Foo.hs
     examples/test-cases/TestCases/Types/Foo/Type.hs
+    examples/test-cases/TestCases/Types/InlineNoAdditionalPropertiesWithOneOfNullabilityOutside.hs
+    examples/test-cases/TestCases/Types/InlineYesAdditionalPropertiesWithOneOfNullablityInside.hs
+    examples/test-cases/TestCases/Types/InlineYesAdditionalPropertiesWithOneOfNullablityInside/Foobar.hs
+    examples/test-cases/TestCases/Types/InlineYesAdditionalPropertiesWithOneOfNullablityInsideItem.hs
     examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBoolean.hs
     examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBooleanItem.hs
     examples/test-cases/TestCases/Types/JustAdditionalPropertiesNullableBooleanRef.hs
@@ -1974,10 +1979,13 @@ extra-source-files:
     examples/test-cases/TestCases/Types/MinItemsOneInline/SomeArrayItem.hs
     examples/test-cases/TestCases/Types/MinItemsOneInlineArrayNullableOneOf.hs
     examples/test-cases/TestCases/Types/MinItemsOneInlineArrayNullableOneOf/MinItemsOneInlineArrayNullableOneOfItem.hs
+    examples/test-cases/TestCases/Types/MinItemsOneInlineArrayNullableOneOf/MinItemsOneInlineArrayNullableOneOfItem/MinItemsOneInlineArrayNullableOneOf/MinItemsOneInlineArrayNullableOneOfItemItem.hs
     examples/test-cases/TestCases/Types/MinItemsOneInlineArrayOneOf.hs
     examples/test-cases/TestCases/Types/MinItemsOneInlineArrayOneOf/MinItemsOneInlineArrayOneOfItem.hs
+    examples/test-cases/TestCases/Types/MinItemsOneInlineArrayOneOf/MinItemsOneInlineArrayOneOfItem/MinItemsOneInlineArrayOneOf/MinItemsOneInlineArrayOneOfItemItem.hs
     examples/test-cases/TestCases/Types/MinItemsOneInlineObjectOneOf.hs
     examples/test-cases/TestCases/Types/MinItemsOneInlineObjectOneOf/SomeArrayItem.hs
+    examples/test-cases/TestCases/Types/MinItemsOneInlineObjectOneOf/SomeArrayItem/MinItemsOneInlineObjectOneOf/SomeArrayItemItem.hs
     examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse.hs
     examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse/Bar.hs
     examples/test-cases/TestCases/Types/MixedInAdditionalPropertiesFalse/Foo.hs
@@ -2018,6 +2026,7 @@ extra-source-files:
     examples/test-cases/TestCases/Types/NameConflicts/Type.hs
     examples/test-cases/TestCases/Types/NameConflicts/Where.hs
     examples/test-cases/TestCases/Types/NullableBoolean.hs
+    examples/test-cases/TestCases/Types/NullableString.hs
     examples/test-cases/TestCases/Types/Num2SchemaStartingWithNumber.hs
     examples/test-cases/TestCases/Types/ObjectWithDiscriminatedUnionRef.hs
     examples/test-cases/TestCases/Types/OneOfWithDiscriminator.hs
@@ -2025,6 +2034,9 @@ extra-source-files:
     examples/test-cases/TestCases/Types/OneOfWithNullable.hs
     examples/test-cases/TestCases/Types/ReferenceOneOf.hs
     examples/test-cases/TestCases/Types/ReferenceOneOfInsideOneOf.hs
+    examples/test-cases/TestCases/Types/SingletonNonNullableOneOfRef.hs
+    examples/test-cases/TestCases/Types/SingletonNullableOneOfPrimitive.hs
+    examples/test-cases/TestCases/Types/SingletonNullableOneOfRef.hs
     examples/test-cases/TestCases/Types/StringParam.hs
     examples/test-cases/TestCases/Types/TestCases/InlineObjectWithPropertiesJsonResponse/Response200Body/Baz/Bax.hs
     examples/test-cases/TestCases/Types/TopLevelArray.hs

--- a/json-fleece-openapi3/package.yaml
+++ b/json-fleece-openapi3/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-openapi3
-version:             0.4.3.2
+version:             0.4.4.0
 github:              "flipstone/json-fleece/json-fleece-openapi3"
 license:             BSD3
 author:              "Author name here"


### PR DESCRIPTION
Singleton unions are unnecessary, let's just emit the ref if such a
union appears. They are used for nullable properties, for example.
