### PR TITLE
Sorts fields in records generated via OpenApi

### DIFF
--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AnimalBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AnimalBase.hs
@@ -17,13 +17,13 @@ import qualified StarTrek.Types.AnimalBase.Name as Name
 import qualified StarTrek.Types.AnimalBase.Uid as Uid
 
 data AnimalBase = AnimalBase
-  { feline :: Maybe Feline.Feline -- ^ Whether it's a feline
-  , avian :: Maybe Avian.Avian -- ^ Whether it's an avian
-  , earthInsect :: Maybe EarthInsect.EarthInsect -- ^ Whether it's an earth insect
-  , uid :: Uid.Uid -- ^ Animal unique ID
-  , name :: Name.Name -- ^ Animal name
-  , earthAnimal :: Maybe EarthAnimal.EarthAnimal -- ^ Whether it's an earth animal
+  { avian :: Maybe Avian.Avian -- ^ Whether it's an avian
   , canine :: Maybe Canine.Canine -- ^ Whether it's a canine
+  , earthAnimal :: Maybe EarthAnimal.EarthAnimal -- ^ Whether it's an earth animal
+  , earthInsect :: Maybe EarthInsect.EarthInsect -- ^ Whether it's an earth insect
+  , feline :: Maybe Feline.Feline -- ^ Whether it's a feline
+  , name :: Name.Name -- ^ Animal name
+  , uid :: Uid.Uid -- ^ Animal unique ID
   }
   deriving (Eq, Show)
 
@@ -31,10 +31,10 @@ animalBaseSchema :: FC.Fleece schema => schema AnimalBase
 animalBaseSchema =
   FC.object $
     FC.constructor AnimalBase
-      #+ FC.optional "feline" feline Feline.felineSchema
       #+ FC.optional "avian" avian Avian.avianSchema
-      #+ FC.optional "earthInsect" earthInsect EarthInsect.earthInsectSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "earthAnimal" earthAnimal EarthAnimal.earthAnimalSchema
       #+ FC.optional "canine" canine Canine.canineSchema
+      #+ FC.optional "earthAnimal" earthAnimal EarthAnimal.earthAnimalSchema
+      #+ FC.optional "earthInsect" earthInsect EarthInsect.earthInsectSchema
+      #+ FC.optional "feline" feline Feline.felineSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AnimalFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AnimalFull.hs
@@ -17,13 +17,13 @@ import qualified StarTrek.Types.AnimalFull.Name as Name
 import qualified StarTrek.Types.AnimalFull.Uid as Uid
 
 data AnimalFull = AnimalFull
-  { feline :: Maybe Feline.Feline -- ^ Whether it's a feline
-  , avian :: Maybe Avian.Avian -- ^ Whether it's an avian
-  , earthInsect :: Maybe EarthInsect.EarthInsect -- ^ Whether it's an earth insect
-  , uid :: Uid.Uid -- ^ Animal unique ID
-  , name :: Name.Name -- ^ Animal name
-  , earthAnimal :: Maybe EarthAnimal.EarthAnimal -- ^ Whether it's an earth animal
+  { avian :: Maybe Avian.Avian -- ^ Whether it's an avian
   , canine :: Maybe Canine.Canine -- ^ Whether it's a canine
+  , earthAnimal :: Maybe EarthAnimal.EarthAnimal -- ^ Whether it's an earth animal
+  , earthInsect :: Maybe EarthInsect.EarthInsect -- ^ Whether it's an earth insect
+  , feline :: Maybe Feline.Feline -- ^ Whether it's a feline
+  , name :: Name.Name -- ^ Animal name
+  , uid :: Uid.Uid -- ^ Animal unique ID
   }
   deriving (Eq, Show)
 
@@ -31,10 +31,10 @@ animalFullSchema :: FC.Fleece schema => schema AnimalFull
 animalFullSchema =
   FC.object $
     FC.constructor AnimalFull
-      #+ FC.optional "feline" feline Feline.felineSchema
       #+ FC.optional "avian" avian Avian.avianSchema
-      #+ FC.optional "earthInsect" earthInsect EarthInsect.earthInsectSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "earthAnimal" earthAnimal EarthAnimal.earthAnimalSchema
       #+ FC.optional "canine" canine Canine.canineSchema
+      #+ FC.optional "earthAnimal" earthAnimal EarthAnimal.earthAnimalSchema
+      #+ FC.optional "earthInsect" earthInsect EarthInsect.earthInsectSchema
+      #+ FC.optional "feline" feline Feline.felineSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AnimalHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AnimalHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.AnimalHeader.Name as Name
 import qualified StarTrek.Types.AnimalHeader.Uid as Uid
 
 data AnimalHeader = AnimalHeader
-  { uid :: Uid.Uid -- ^ Animal unique ID
-  , name :: Name.Name -- ^ Animal name
+  { name :: Name.Name -- ^ Animal name
+  , uid :: Uid.Uid -- ^ Animal unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ animalHeaderSchema :: FC.Fleece schema => schema AnimalHeader
 animalHeaderSchema =
   FC.object $
     FC.constructor AnimalHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AstronomicalObjectBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AstronomicalObjectBase.hs
@@ -14,10 +14,10 @@ import qualified StarTrek.Types.AstronomicalObjectHeader as AstronomicalObjectHe
 import qualified StarTrek.Types.AstronomicalObjectType as AstronomicalObjectType
 
 data AstronomicalObjectBase = AstronomicalObjectBase
-  { location :: Maybe AstronomicalObjectHeader.AstronomicalObjectHeader -- ^ Header astronomical object, embedded in other objects
-  , uid :: Uid.Uid -- ^ Astronomical object's unique ID
+  { astronomicalObjectType :: AstronomicalObjectType.AstronomicalObjectType -- ^ Astronomical object type
+  , location :: Maybe AstronomicalObjectHeader.AstronomicalObjectHeader -- ^ Header astronomical object, embedded in other objects
   , name :: Name.Name -- ^ Astronomical object name
-  , astronomicalObjectType :: AstronomicalObjectType.AstronomicalObjectType -- ^ Astronomical object type
+  , uid :: Uid.Uid -- ^ Astronomical object's unique ID
   }
   deriving (Eq, Show)
 
@@ -25,7 +25,7 @@ astronomicalObjectBaseSchema :: FC.Fleece schema => schema AstronomicalObjectBas
 astronomicalObjectBaseSchema =
   FC.object $
     FC.constructor AstronomicalObjectBase
-      #+ FC.optional "location" location AstronomicalObjectHeader.astronomicalObjectHeaderSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.required "name" name Name.nameSchema
       #+ FC.required "astronomicalObjectType" astronomicalObjectType AstronomicalObjectType.astronomicalObjectTypeSchema
+      #+ FC.optional "location" location AstronomicalObjectHeader.astronomicalObjectHeaderSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AstronomicalObjectFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AstronomicalObjectFull.hs
@@ -14,11 +14,11 @@ import qualified StarTrek.Types.AstronomicalObjectFull.Uid as Uid
 import qualified StarTrek.Types.AstronomicalObjectType as AstronomicalObjectType
 
 data AstronomicalObjectFull = AstronomicalObjectFull
-  { astronomicalObjects :: Maybe [AstronomicalObjectBase.AstronomicalObjectBase] -- ^ Base astronomical object, returned in search results
+  { astronomicalObjectType :: AstronomicalObjectType.AstronomicalObjectType -- ^ Astronomical object type
+  , astronomicalObjects :: Maybe [AstronomicalObjectBase.AstronomicalObjectBase] -- ^ Base astronomical object, returned in search results
   , location :: Maybe AstronomicalObjectBase.AstronomicalObjectBase -- ^ Base astronomical object, returned in search results
-  , uid :: Uid.Uid -- ^ Astronomical object's unique ID
   , name :: Name.Name -- ^ Astronomical object name
-  , astronomicalObjectType :: AstronomicalObjectType.AstronomicalObjectType -- ^ Astronomical object type
+  , uid :: Uid.Uid -- ^ Astronomical object's unique ID
   }
   deriving (Eq, Show)
 
@@ -26,8 +26,8 @@ astronomicalObjectFullSchema :: FC.Fleece schema => schema AstronomicalObjectFul
 astronomicalObjectFullSchema =
   FC.object $
     FC.constructor AstronomicalObjectFull
+      #+ FC.required "astronomicalObjectType" astronomicalObjectType AstronomicalObjectType.astronomicalObjectTypeSchema
       #+ FC.optional "astronomicalObjects" astronomicalObjects (FC.list AstronomicalObjectBase.astronomicalObjectBaseSchema)
       #+ FC.optional "location" location AstronomicalObjectBase.astronomicalObjectBaseSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
-      #+ FC.required "astronomicalObjectType" astronomicalObjectType AstronomicalObjectType.astronomicalObjectTypeSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AstronomicalObjectHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AstronomicalObjectHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.AstronomicalObjectHeader.Name as Name
 import qualified StarTrek.Types.AstronomicalObjectHeader.Uid as Uid
 
 data AstronomicalObjectHeader = AstronomicalObjectHeader
-  { uid :: Uid.Uid -- ^ Astronomical object's unique ID
-  , name :: Name.Name -- ^ Astronomical object name
+  { name :: Name.Name -- ^ Astronomical object name
+  , uid :: Uid.Uid -- ^ Astronomical object's unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ astronomicalObjectHeaderSchema :: FC.Fleece schema => schema AstronomicalObjectH
 astronomicalObjectHeaderSchema =
   FC.object $
     FC.constructor AstronomicalObjectHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookBase.hs
@@ -34,30 +34,30 @@ import qualified StarTrek.Types.BookBase.YearFrom as YearFrom
 import qualified StarTrek.Types.BookBase.YearTo as YearTo
 
 data BookBase = BookBase
-  { biographyBook :: BiographyBook.BiographyBook -- ^ Whether it's a biography book
-  , audiobookPublishedDay :: Maybe AudiobookPublishedDay.AudiobookPublishedDay -- ^ Day the audiobook was published
-  , title :: Title.Title -- ^ Book title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book story
-  , audiobookAbridged :: AudiobookAbridged.AudiobookAbridged -- ^ If it's an audiobook, whether it's been abridged
-  , anthology :: Anthology.Anthology -- ^ Whether it's an anthology
-  , rolePlayingBook :: RolePlayingBook.RolePlayingBook -- ^ Whether it's a role playing book
-  , referenceBook :: ReferenceBook.ReferenceBook -- ^ Whether it's a reference book
-  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the book was published
-  , eBook :: EBook.EBook -- ^ Whether it's an eBook
-  , uid :: Uid.Uid -- ^ Book unique ID
+  { anthology :: Anthology.Anthology -- ^ Whether it's an anthology
   , audiobook :: Audiobook.Audiobook -- ^ Whether it's an audiobook, or has been release as an audiobook in addition to other form
-  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
-  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the book was published
-  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of book story
-  , novel :: Novel.Novel -- ^ Whether it's a novel
-  , audiobookRunTime :: Maybe AudiobookRunTime.AudiobookRunTime -- ^ Audiobook run time, in minutes
-  , novelization :: Novelization.Novelization -- ^ Whether it's a novelization
-  , productionNumber :: Maybe ProductionNumber.ProductionNumber -- ^ Book's production number
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book story
+  , audiobookAbridged :: AudiobookAbridged.AudiobookAbridged -- ^ If it's an audiobook, whether it's been abridged
+  , audiobookPublishedDay :: Maybe AudiobookPublishedDay.AudiobookPublishedDay -- ^ Day the audiobook was published
   , audiobookPublishedMonth :: Maybe AudiobookPublishedMonth.AudiobookPublishedMonth -- ^ Month the audiobook was published
-  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of book story
   , audiobookPublishedYear :: Maybe AudiobookPublishedYear.AudiobookPublishedYear -- ^ Year the audiobook was published
+  , audiobookRunTime :: Maybe AudiobookRunTime.AudiobookRunTime -- ^ Audiobook run time, in minutes
+  , biographyBook :: BiographyBook.BiographyBook -- ^ Whether it's a biography book
+  , eBook :: EBook.EBook -- ^ Whether it's an eBook
+  , novel :: Novel.Novel -- ^ Whether it's a novel
+  , novelization :: Novelization.Novelization -- ^ Whether it's a novelization
+  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
+  , productionNumber :: Maybe ProductionNumber.ProductionNumber -- ^ Book's production number
+  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the book was published
   , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the book was published
+  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the book was published
+  , referenceBook :: ReferenceBook.ReferenceBook -- ^ Whether it's a reference book
+  , rolePlayingBook :: RolePlayingBook.RolePlayingBook -- ^ Whether it's a role playing book
+  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of book story
+  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of book story
+  , title :: Title.Title -- ^ Book title
+  , uid :: Uid.Uid -- ^ Book unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book story
   }
   deriving (Eq, Show)
 
@@ -65,27 +65,27 @@ bookBaseSchema :: FC.Fleece schema => schema BookBase
 bookBaseSchema =
   FC.object $
     FC.constructor BookBase
-      #+ FC.required "biographyBook" biographyBook BiographyBook.biographyBookSchema
-      #+ FC.optional "audiobookPublishedDay" audiobookPublishedDay AudiobookPublishedDay.audiobookPublishedDaySchema
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.required "audiobookAbridged" audiobookAbridged AudiobookAbridged.audiobookAbridgedSchema
       #+ FC.required "anthology" anthology Anthology.anthologySchema
-      #+ FC.required "rolePlayingBook" rolePlayingBook RolePlayingBook.rolePlayingBookSchema
-      #+ FC.required "referenceBook" referenceBook ReferenceBook.referenceBookSchema
-      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
-      #+ FC.required "eBook" eBook EBook.eBookSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "audiobook" audiobook Audiobook.audiobookSchema
-      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
-      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
-      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
-      #+ FC.required "novel" novel Novel.novelSchema
-      #+ FC.optional "audiobookRunTime" audiobookRunTime AudiobookRunTime.audiobookRunTimeSchema
-      #+ FC.required "novelization" novelization Novelization.novelizationSchema
-      #+ FC.optional "productionNumber" productionNumber ProductionNumber.productionNumberSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
+      #+ FC.required "audiobookAbridged" audiobookAbridged AudiobookAbridged.audiobookAbridgedSchema
+      #+ FC.optional "audiobookPublishedDay" audiobookPublishedDay AudiobookPublishedDay.audiobookPublishedDaySchema
       #+ FC.optional "audiobookPublishedMonth" audiobookPublishedMonth AudiobookPublishedMonth.audiobookPublishedMonthSchema
-      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
       #+ FC.optional "audiobookPublishedYear" audiobookPublishedYear AudiobookPublishedYear.audiobookPublishedYearSchema
+      #+ FC.optional "audiobookRunTime" audiobookRunTime AudiobookRunTime.audiobookRunTimeSchema
+      #+ FC.required "biographyBook" biographyBook BiographyBook.biographyBookSchema
+      #+ FC.required "eBook" eBook EBook.eBookSchema
+      #+ FC.required "novel" novel Novel.novelSchema
+      #+ FC.required "novelization" novelization Novelization.novelizationSchema
+      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
+      #+ FC.optional "productionNumber" productionNumber ProductionNumber.productionNumberSchema
+      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
       #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
+      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
+      #+ FC.required "referenceBook" referenceBook ReferenceBook.referenceBookSchema
+      #+ FC.required "rolePlayingBook" rolePlayingBook RolePlayingBook.rolePlayingBookSchema
+      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookCollectionBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookCollectionBase.hs
@@ -20,16 +20,16 @@ import qualified StarTrek.Types.BookCollectionBase.YearFrom as YearFrom
 import qualified StarTrek.Types.BookCollectionBase.YearTo as YearTo
 
 data BookCollectionBase = BookCollectionBase
-  { title :: Maybe Title.Title -- ^ Book collection title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book collection stories
+  { numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
   , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the book collection was published
-  , uid :: Maybe Uid.Uid -- ^ Book collection unique ID
-  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
+  , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the book collection was published
   , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the book collection was published
   , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of book collection stories
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book collection stories
   , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of book collection stories
-  , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the book collection was published
+  , title :: Maybe Title.Title -- ^ Book collection title
+  , uid :: Maybe Uid.Uid -- ^ Book collection unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book collection stories
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book collection stories
   }
   deriving (Eq, Show)
 
@@ -37,13 +37,13 @@ bookCollectionBaseSchema :: FC.Fleece schema => schema BookCollectionBase
 bookCollectionBaseSchema =
   FC.object $
     FC.constructor BookCollectionBase
-      #+ FC.optional "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
-      #+ FC.optional "uid" uid Uid.uidSchema
       #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
+      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
+      #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
       #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
       #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
       #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
-      #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
+      #+ FC.optional "title" title Title.titleSchema
+      #+ FC.optional "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookCollectionFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookCollectionFull.hs
@@ -26,24 +26,24 @@ import qualified StarTrek.Types.Reference as Reference
 import qualified StarTrek.Types.StaffBase as StaffBase
 
 data BookCollectionFull = BookCollectionFull
-  { title :: Maybe Title.Title -- ^ Book collection title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book collection stories
-  , editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , books :: Maybe [BookBase.BookBase] -- ^ Base book, returned in search results
-  , artists :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the book collection was published
-  , uid :: Maybe Uid.Uid -- ^ Book collection unique ID
-  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
+  { artists :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
   , authors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
-  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
-  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the book collection was published
-  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of book collection stories
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book collection stories
-  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of book collection stories
-  , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the book collection was published
   , bookSeries :: Maybe [BookSeriesBase.BookSeriesBase] -- ^ Base book series, returned in search results
+  , books :: Maybe [BookBase.BookBase] -- ^ Base book, returned in search results
+  , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
+  , editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
+  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the book collection was published
+  , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the book collection was published
+  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the book collection was published
+  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
+  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of book collection stories
+  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of book collection stories
+  , title :: Maybe Title.Title -- ^ Book collection title
+  , uid :: Maybe Uid.Uid -- ^ Book collection unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book collection stories
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book collection stories
   }
   deriving (Eq, Show)
 
@@ -51,21 +51,21 @@ bookCollectionFullSchema :: FC.Fleece schema => schema BookCollectionFull
 bookCollectionFullSchema =
   FC.object $
     FC.constructor BookCollectionFull
-      #+ FC.optional "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "editors" editors (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "books" books (FC.list BookBase.bookBaseSchema)
       #+ FC.optional "artists" artists (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
-      #+ FC.optional "uid" uid Uid.uidSchema
-      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
       #+ FC.optional "authors" authors (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
-      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
-      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
-      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
-      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
-      #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
       #+ FC.optional "bookSeries" bookSeries (FC.list BookSeriesBase.bookSeriesBaseSchema)
+      #+ FC.optional "books" books (FC.list BookBase.bookBaseSchema)
+      #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
+      #+ FC.optional "editors" editors (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
+      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
+      #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
+      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
+      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
+      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
+      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.optional "title" title Title.titleSchema
+      #+ FC.optional "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookFull.hs
@@ -40,41 +40,41 @@ import qualified StarTrek.Types.Reference as Reference
 import qualified StarTrek.Types.StaffBase as StaffBase
 
 data BookFull = BookFull
-  { biographyBook :: BiographyBook.BiographyBook -- ^ Whether it's a biography book
-  , audiobookPublishedDay :: Maybe AudiobookPublishedDay.AudiobookPublishedDay -- ^ Day the audiobook was published
-  , title :: Title.Title -- ^ Book title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book story
-  , audiobookAbridged :: AudiobookAbridged.AudiobookAbridged -- ^ If it's an audiobook, whether it's been abridged
-  , anthology :: Anthology.Anthology -- ^ Whether it's an anthology
-  , editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , rolePlayingBook :: RolePlayingBook.RolePlayingBook -- ^ Whether it's a role playing book
-  , referenceBook :: ReferenceBook.ReferenceBook -- ^ Whether it's a reference book
-  , bookCollections :: Maybe [BookCollectionBase.BookCollectionBase] -- ^ Base book collection, returned in search results
+  { anthology :: Anthology.Anthology -- ^ Whether it's an anthology
   , artists :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the book was published
-  , eBook :: EBook.EBook -- ^ Whether it's an e-book
-  , uid :: Uid.Uid -- ^ Book unique ID
   , audiobook :: Audiobook.Audiobook -- ^ Whether it's an audiobook, or has been release as an audiobook in addition to other form
-  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
-  , authors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
-  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
-  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the book was published
-  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of book story
-  , novel :: Novel.Novel -- ^ Whether it's a novel
+  , audiobookAbridged :: AudiobookAbridged.AudiobookAbridged -- ^ If it's an audiobook, whether it's been abridged
   , audiobookNarrators :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , audiobookPublishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
-  , audiobookRunTime :: Maybe AudiobookRunTime.AudiobookRunTime -- ^ Audiobook run time, in minutes
-  , novelization :: Novelization.Novelization -- ^ Whether it's a novelization
-  , productionNumber :: Maybe ProductionNumber.ProductionNumber -- ^ Book production number
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book story
+  , audiobookPublishedDay :: Maybe AudiobookPublishedDay.AudiobookPublishedDay -- ^ Day the audiobook was published
   , audiobookPublishedMonth :: Maybe AudiobookPublishedMonth.AudiobookPublishedMonth -- ^ Month the audiobook was published
-  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of book story
   , audiobookPublishedYear :: Maybe AudiobookPublishedYear.AudiobookPublishedYear -- ^ Year the audiobook was published
+  , audiobookPublishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
   , audiobookReferences :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
-  , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the book was published
+  , audiobookRunTime :: Maybe AudiobookRunTime.AudiobookRunTime -- ^ Audiobook run time, in minutes
+  , authors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , biographyBook :: BiographyBook.BiographyBook -- ^ Whether it's a biography book
+  , bookCollections :: Maybe [BookCollectionBase.BookCollectionBase] -- ^ Base book collection, returned in search results
   , bookSeries :: Maybe [BookSeriesBase.BookSeriesBase] -- ^ Base book series, returned in search results
+  , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
+  , eBook :: EBook.EBook -- ^ Whether it's an e-book
+  , editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , novel :: Novel.Novel -- ^ Whether it's a novel
+  , novelization :: Novelization.Novelization -- ^ Whether it's a novelization
+  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
+  , productionNumber :: Maybe ProductionNumber.ProductionNumber -- ^ Book production number
+  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the book was published
+  , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the book was published
+  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the book was published
+  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  , referenceBook :: ReferenceBook.ReferenceBook -- ^ Whether it's a reference book
+  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
+  , rolePlayingBook :: RolePlayingBook.RolePlayingBook -- ^ Whether it's a role playing book
+  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of book story
+  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of book story
+  , title :: Title.Title -- ^ Book title
+  , uid :: Uid.Uid -- ^ Book unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book story
   }
   deriving (Eq, Show)
 
@@ -82,38 +82,38 @@ bookFullSchema :: FC.Fleece schema => schema BookFull
 bookFullSchema =
   FC.object $
     FC.constructor BookFull
-      #+ FC.required "biographyBook" biographyBook BiographyBook.biographyBookSchema
-      #+ FC.optional "audiobookPublishedDay" audiobookPublishedDay AudiobookPublishedDay.audiobookPublishedDaySchema
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.required "audiobookAbridged" audiobookAbridged AudiobookAbridged.audiobookAbridgedSchema
       #+ FC.required "anthology" anthology Anthology.anthologySchema
-      #+ FC.optional "editors" editors (FC.list StaffBase.staffBaseSchema)
-      #+ FC.required "rolePlayingBook" rolePlayingBook RolePlayingBook.rolePlayingBookSchema
-      #+ FC.required "referenceBook" referenceBook ReferenceBook.referenceBookSchema
-      #+ FC.optional "bookCollections" bookCollections (FC.list BookCollectionBase.bookCollectionBaseSchema)
       #+ FC.optional "artists" artists (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
-      #+ FC.required "eBook" eBook EBook.eBookSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "audiobook" audiobook Audiobook.audiobookSchema
-      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
-      #+ FC.optional "authors" authors (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
-      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
-      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
-      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
-      #+ FC.required "novel" novel Novel.novelSchema
+      #+ FC.required "audiobookAbridged" audiobookAbridged AudiobookAbridged.audiobookAbridgedSchema
       #+ FC.optional "audiobookNarrators" audiobookNarrators (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "audiobookPublishers" audiobookPublishers (FC.list CompanyBase.companyBaseSchema)
-      #+ FC.optional "audiobookRunTime" audiobookRunTime AudiobookRunTime.audiobookRunTimeSchema
-      #+ FC.required "novelization" novelization Novelization.novelizationSchema
-      #+ FC.optional "productionNumber" productionNumber ProductionNumber.productionNumberSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
+      #+ FC.optional "audiobookPublishedDay" audiobookPublishedDay AudiobookPublishedDay.audiobookPublishedDaySchema
       #+ FC.optional "audiobookPublishedMonth" audiobookPublishedMonth AudiobookPublishedMonth.audiobookPublishedMonthSchema
-      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
       #+ FC.optional "audiobookPublishedYear" audiobookPublishedYear AudiobookPublishedYear.audiobookPublishedYearSchema
+      #+ FC.optional "audiobookPublishers" audiobookPublishers (FC.list CompanyBase.companyBaseSchema)
       #+ FC.optional "audiobookReferences" audiobookReferences (FC.list Reference.referenceSchema)
-      #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
+      #+ FC.optional "audiobookRunTime" audiobookRunTime AudiobookRunTime.audiobookRunTimeSchema
+      #+ FC.optional "authors" authors (FC.list StaffBase.staffBaseSchema)
+      #+ FC.required "biographyBook" biographyBook BiographyBook.biographyBookSchema
+      #+ FC.optional "bookCollections" bookCollections (FC.list BookCollectionBase.bookCollectionBaseSchema)
       #+ FC.optional "bookSeries" bookSeries (FC.list BookSeriesBase.bookSeriesBaseSchema)
+      #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
+      #+ FC.required "eBook" eBook EBook.eBookSchema
+      #+ FC.optional "editors" editors (FC.list StaffBase.staffBaseSchema)
+      #+ FC.required "novel" novel Novel.novelSchema
+      #+ FC.required "novelization" novelization Novelization.novelizationSchema
+      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
+      #+ FC.optional "productionNumber" productionNumber ProductionNumber.productionNumberSchema
+      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
+      #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
+      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
+      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
+      #+ FC.required "referenceBook" referenceBook ReferenceBook.referenceBookSchema
+      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
+      #+ FC.required "rolePlayingBook" rolePlayingBook RolePlayingBook.rolePlayingBookSchema
+      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookSeriesBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookSeriesBase.hs
@@ -21,17 +21,17 @@ import qualified StarTrek.Types.BookSeriesBase.YearFrom as YearFrom
 import qualified StarTrek.Types.BookSeriesBase.YearTo as YearTo
 
 data BookSeriesBase = BookSeriesBase
-  { title :: Title.Title -- ^ Book series title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book series stories
-  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the book series was published
-  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the book series was published
-  , uid :: Uid.Uid -- ^ Book series unique ID
-  , numberOfBooks :: Maybe NumberOfBooks.NumberOfBooks -- ^ Number of pages
+  { eBookSeries :: Maybe EBookSeries.EBookSeries -- ^ Whether it's a e-book series
   , miniseries :: Maybe Miniseries.Miniseries -- ^ Whether it's a miniseries
+  , numberOfBooks :: Maybe NumberOfBooks.NumberOfBooks -- ^ Number of pages
+  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the book series was published
   , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the book series was published
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book series stories
+  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the book series was published
   , publishedYearTo :: Maybe PublishedYearTo.PublishedYearTo -- ^ Year to which the book series was published
-  , eBookSeries :: Maybe EBookSeries.EBookSeries -- ^ Whether it's a e-book series
+  , title :: Title.Title -- ^ Book series title
+  , uid :: Uid.Uid -- ^ Book series unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book series stories
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book series stories
   }
   deriving (Eq, Show)
 
@@ -39,14 +39,14 @@ bookSeriesBaseSchema :: FC.Fleece schema => schema BookSeriesBase
 bookSeriesBaseSchema =
   FC.object $
     FC.constructor BookSeriesBase
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
-      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "numberOfBooks" numberOfBooks NumberOfBooks.numberOfBooksSchema
-      #+ FC.optional "miniseries" miniseries Miniseries.miniseriesSchema
-      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
-      #+ FC.optional "publishedYearTo" publishedYearTo PublishedYearTo.publishedYearToSchema
       #+ FC.optional "eBookSeries" eBookSeries EBookSeries.eBookSeriesSchema
+      #+ FC.optional "miniseries" miniseries Miniseries.miniseriesSchema
+      #+ FC.optional "numberOfBooks" numberOfBooks NumberOfBooks.numberOfBooksSchema
+      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
+      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
+      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
+      #+ FC.optional "publishedYearTo" publishedYearTo PublishedYearTo.publishedYearToSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookSeriesBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookSeriesBaseResponse.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data BookSeriesBaseResponse = BookSeriesBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
+  { bookSeries :: Maybe [BookSeriesBase.BookSeriesBase] -- ^ Base book series, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
-  , bookSeries :: Maybe [BookSeriesBase.BookSeriesBase] -- ^ Base book series, returned in search results
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ bookSeriesBaseResponseSchema :: FC.Fleece schema => schema BookSeriesBaseRespons
 bookSeriesBaseResponseSchema =
   FC.object $
     FC.constructor BookSeriesBaseResponse
+      #+ FC.optional "bookSeries" bookSeries (FC.list BookSeriesBase.bookSeriesBaseSchema)
       #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
-      #+ FC.optional "bookSeries" bookSeries (FC.list BookSeriesBase.bookSeriesBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookSeriesFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BookSeriesFull.hs
@@ -24,21 +24,21 @@ import qualified StarTrek.Types.BookSeriesFull.YearTo as YearTo
 import qualified StarTrek.Types.CompanyBase as CompanyBase
 
 data BookSeriesFull = BookSeriesFull
-  { title :: Title.Title -- ^ Book series title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book series stories
-  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the book series was published
-  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the book series was published
-  , books :: Maybe [BookBase.BookBase] -- ^ Base book, returned in search results
+  { books :: Maybe [BookBase.BookBase] -- ^ Base book, returned in search results
   , childSeries :: Maybe [BookSeriesBase.BookSeriesBase] -- ^ Base book series, returned in search results
-  , uid :: Uid.Uid -- ^ Book series unique ID
-  , numberOfBooks :: Maybe NumberOfBooks.NumberOfBooks -- ^ Number of books in book series
-  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
-  , miniseries :: Maybe Miniseries.Miniseries -- ^ Whether it's a miniseries
-  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the book series was published
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book series stories
-  , publishedYearTo :: Maybe PublishedYearTo.PublishedYearTo -- ^ Year to which the book series was published
-  , parentSeries :: Maybe [BookSeriesBase.BookSeriesBase] -- ^ Base book series, returned in search results
   , eBookSeries :: Maybe EBookSeries.EBookSeries -- ^ Whether it's a e-book series
+  , miniseries :: Maybe Miniseries.Miniseries -- ^ Whether it's a miniseries
+  , numberOfBooks :: Maybe NumberOfBooks.NumberOfBooks -- ^ Number of books in book series
+  , parentSeries :: Maybe [BookSeriesBase.BookSeriesBase] -- ^ Base book series, returned in search results
+  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the book series was published
+  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the book series was published
+  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the book series was published
+  , publishedYearTo :: Maybe PublishedYearTo.PublishedYearTo -- ^ Year to which the book series was published
+  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  , title :: Title.Title -- ^ Book series title
+  , uid :: Uid.Uid -- ^ Book series unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of book series stories
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of book series stories
   }
   deriving (Eq, Show)
 
@@ -46,18 +46,18 @@ bookSeriesFullSchema :: FC.Fleece schema => schema BookSeriesFull
 bookSeriesFullSchema =
   FC.object $
     FC.constructor BookSeriesFull
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
-      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
       #+ FC.optional "books" books (FC.list BookBase.bookBaseSchema)
       #+ FC.optional "childSeries" childSeries (FC.list BookSeriesBase.bookSeriesBaseSchema)
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "numberOfBooks" numberOfBooks NumberOfBooks.numberOfBooksSchema
-      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
-      #+ FC.optional "miniseries" miniseries Miniseries.miniseriesSchema
-      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
-      #+ FC.optional "publishedYearTo" publishedYearTo PublishedYearTo.publishedYearToSchema
-      #+ FC.optional "parentSeries" parentSeries (FC.list BookSeriesBase.bookSeriesBaseSchema)
       #+ FC.optional "eBookSeries" eBookSeries EBookSeries.eBookSeriesSchema
+      #+ FC.optional "miniseries" miniseries Miniseries.miniseriesSchema
+      #+ FC.optional "numberOfBooks" numberOfBooks NumberOfBooks.numberOfBooksSchema
+      #+ FC.optional "parentSeries" parentSeries (FC.list BookSeriesBase.bookSeriesBaseSchema)
+      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
+      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
+      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
+      #+ FC.optional "publishedYearTo" publishedYearTo PublishedYearTo.publishedYearToSchema
+      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterBase.hs
@@ -34,30 +34,30 @@ import qualified StarTrek.Types.Gender as Gender
 import qualified StarTrek.Types.MaritalStatus as MaritalStatus
 
 data CharacterBase = CharacterBase
-  { monthOfDeath :: Maybe MonthOfDeath.MonthOfDeath -- ^ Month the character died
-  , mirror :: Maybe Mirror.Mirror -- ^ Whether this character is from mirror universe
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this character is from alternate reality
-  , gender :: Maybe Gender.Gender -- ^ Gender
-  , monthOfBirth :: Maybe MonthOfBirth.MonthOfBirth -- ^ Month the character was born
-  , maritalStatus :: Maybe MaritalStatus.MaritalStatus -- ^ Marital status
-  , hologramActivationDate :: Maybe HologramActivationDate.HologramActivationDate -- ^ Hologram activation date
-  , serialNumber :: Maybe SerialNumber.SerialNumber -- ^ Serial number
-  , height :: Maybe Height.Height -- ^ Height in centimeters
-  , deceased :: Maybe Deceased.Deceased -- ^ Whether this character is deceased
-  , dayOfBirth :: Maybe DayOfBirth.DayOfBirth -- ^ Day the character was born
-  , yearOfBirth :: Maybe YearOfBirth.YearOfBirth -- ^ Year the character was born
-  , dayOfDeath :: Maybe DayOfDeath.DayOfDeath -- ^ Day the character died
-  , weight :: Maybe Weight.Weight -- ^ Weight in kilograms
-  , uid :: Uid.Uid -- ^ Character unique ID
-  , fictionalCharacter :: Maybe FictionalCharacter.FictionalCharacter -- ^ Whether this character is a fictional character (from universe point of view)
-  , hologramStatus :: Maybe HologramStatus.HologramStatus -- ^ Hologram status
-  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place of birth
-  , name :: Name.Name -- ^ Character name
-  , yearOfDeath :: Maybe YearOfDeath.YearOfDeath -- ^ Year the character died
-  , hologramDateStatus :: Maybe HologramDateStatus.HologramDateStatus -- ^ Hologram date status
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this character is from alternate reality
   , bloodType :: Maybe BloodType.BloodType -- ^ Blood type
+  , dayOfBirth :: Maybe DayOfBirth.DayOfBirth -- ^ Day the character was born
+  , dayOfDeath :: Maybe DayOfDeath.DayOfDeath -- ^ Day the character died
+  , deceased :: Maybe Deceased.Deceased -- ^ Whether this character is deceased
+  , fictionalCharacter :: Maybe FictionalCharacter.FictionalCharacter -- ^ Whether this character is a fictional character (from universe point of view)
+  , gender :: Maybe Gender.Gender -- ^ Gender
+  , height :: Maybe Height.Height -- ^ Height in centimeters
   , hologram :: Maybe Hologram.Hologram -- ^ Whether this character is a hologram
+  , hologramActivationDate :: Maybe HologramActivationDate.HologramActivationDate -- ^ Hologram activation date
+  , hologramDateStatus :: Maybe HologramDateStatus.HologramDateStatus -- ^ Hologram date status
+  , hologramStatus :: Maybe HologramStatus.HologramStatus -- ^ Hologram status
+  , maritalStatus :: Maybe MaritalStatus.MaritalStatus -- ^ Marital status
+  , mirror :: Maybe Mirror.Mirror -- ^ Whether this character is from mirror universe
+  , monthOfBirth :: Maybe MonthOfBirth.MonthOfBirth -- ^ Month the character was born
+  , monthOfDeath :: Maybe MonthOfDeath.MonthOfDeath -- ^ Month the character died
+  , name :: Name.Name -- ^ Character name
+  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place of birth
   , placeOfDeath :: Maybe PlaceOfDeath.PlaceOfDeath -- ^ Place of death
+  , serialNumber :: Maybe SerialNumber.SerialNumber -- ^ Serial number
+  , uid :: Uid.Uid -- ^ Character unique ID
+  , weight :: Maybe Weight.Weight -- ^ Weight in kilograms
+  , yearOfBirth :: Maybe YearOfBirth.YearOfBirth -- ^ Year the character was born
+  , yearOfDeath :: Maybe YearOfDeath.YearOfDeath -- ^ Year the character died
   }
   deriving (Eq, Show)
 
@@ -65,27 +65,27 @@ characterBaseSchema :: FC.Fleece schema => schema CharacterBase
 characterBaseSchema =
   FC.object $
     FC.constructor CharacterBase
-      #+ FC.optional "monthOfDeath" monthOfDeath MonthOfDeath.monthOfDeathSchema
-      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
-      #+ FC.optional "gender" gender Gender.genderSchema
-      #+ FC.optional "monthOfBirth" monthOfBirth MonthOfBirth.monthOfBirthSchema
-      #+ FC.optional "maritalStatus" maritalStatus MaritalStatus.maritalStatusSchema
-      #+ FC.optional "hologramActivationDate" hologramActivationDate HologramActivationDate.hologramActivationDateSchema
-      #+ FC.optional "serialNumber" serialNumber SerialNumber.serialNumberSchema
-      #+ FC.optional "height" height Height.heightSchema
-      #+ FC.optional "deceased" deceased Deceased.deceasedSchema
-      #+ FC.optional "dayOfBirth" dayOfBirth DayOfBirth.dayOfBirthSchema
-      #+ FC.optional "yearOfBirth" yearOfBirth YearOfBirth.yearOfBirthSchema
-      #+ FC.optional "dayOfDeath" dayOfDeath DayOfDeath.dayOfDeathSchema
-      #+ FC.optional "weight" weight Weight.weightSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "fictionalCharacter" fictionalCharacter FictionalCharacter.fictionalCharacterSchema
-      #+ FC.optional "hologramStatus" hologramStatus HologramStatus.hologramStatusSchema
-      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "yearOfDeath" yearOfDeath YearOfDeath.yearOfDeathSchema
-      #+ FC.optional "hologramDateStatus" hologramDateStatus HologramDateStatus.hologramDateStatusSchema
       #+ FC.optional "bloodType" bloodType BloodType.bloodTypeSchema
+      #+ FC.optional "dayOfBirth" dayOfBirth DayOfBirth.dayOfBirthSchema
+      #+ FC.optional "dayOfDeath" dayOfDeath DayOfDeath.dayOfDeathSchema
+      #+ FC.optional "deceased" deceased Deceased.deceasedSchema
+      #+ FC.optional "fictionalCharacter" fictionalCharacter FictionalCharacter.fictionalCharacterSchema
+      #+ FC.optional "gender" gender Gender.genderSchema
+      #+ FC.optional "height" height Height.heightSchema
       #+ FC.optional "hologram" hologram Hologram.hologramSchema
+      #+ FC.optional "hologramActivationDate" hologramActivationDate HologramActivationDate.hologramActivationDateSchema
+      #+ FC.optional "hologramDateStatus" hologramDateStatus HologramDateStatus.hologramDateStatusSchema
+      #+ FC.optional "hologramStatus" hologramStatus HologramStatus.hologramStatusSchema
+      #+ FC.optional "maritalStatus" maritalStatus MaritalStatus.maritalStatusSchema
+      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
+      #+ FC.optional "monthOfBirth" monthOfBirth MonthOfBirth.monthOfBirthSchema
+      #+ FC.optional "monthOfDeath" monthOfDeath MonthOfDeath.monthOfDeathSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
       #+ FC.optional "placeOfDeath" placeOfDeath PlaceOfDeath.placeOfDeathSchema
+      #+ FC.optional "serialNumber" serialNumber SerialNumber.serialNumberSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "weight" weight Weight.weightSchema
+      #+ FC.optional "yearOfBirth" yearOfBirth YearOfBirth.yearOfBirthSchema
+      #+ FC.optional "yearOfDeath" yearOfDeath YearOfDeath.yearOfDeathSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data CharacterBaseResponse = CharacterBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
+  { characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ characterBaseResponseSchema :: FC.Fleece schema => schema CharacterBaseResponse
 characterBaseResponseSchema =
   FC.object $
     FC.constructor CharacterBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterFull.hs
@@ -42,38 +42,38 @@ import qualified StarTrek.Types.PerformerBase as PerformerBase
 import qualified StarTrek.Types.TitleBase as TitleBase
 
 data CharacterFull = CharacterFull
-  { monthOfDeath :: Maybe MonthOfDeath.MonthOfDeath -- ^ Month the character died
-  , mirror :: Maybe Mirror.Mirror -- ^ Whether this character is from mirror universe
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this character is from alternate reality
-  , gender :: Maybe Gender.Gender -- ^ Gender
-  , organizations :: Maybe [OrganizationBase.OrganizationBase] -- ^ Base organization, returned in search results
-  , monthOfBirth :: Maybe MonthOfBirth.MonthOfBirth -- ^ Month the character was born
-  , maritalStatus :: Maybe MaritalStatus.MaritalStatus -- ^ Marital status
-  , hologramActivationDate :: Maybe HologramActivationDate.HologramActivationDate -- ^ Hologram activation date
-  , characterRelations :: Maybe [CharacterRelation.CharacterRelation] -- ^ Relation between characters
-  , movies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
-  , serialNumber :: Maybe SerialNumber.SerialNumber -- ^ Serial number
-  , height :: Maybe Height.Height -- ^ Height in centimeters
-  , deceased :: Maybe Deceased.Deceased -- ^ Whether this character is deceased
-  , dayOfBirth :: Maybe DayOfBirth.DayOfBirth -- ^ Day the character was born
-  , yearOfBirth :: Maybe YearOfBirth.YearOfBirth -- ^ Year the character was born
-  , dayOfDeath :: Maybe DayOfDeath.DayOfDeath -- ^ Day the character died
-  , weight :: Maybe Weight.Weight -- ^ Weight in kilograms
-  , uid :: Uid.Uid -- ^ Character unique ID
-  , fictionalCharacter :: Maybe FictionalCharacter.FictionalCharacter -- ^ Whether this character is a fictional character (from universe point of view)
-  , characterSpecies :: Maybe [CharacterSpecies.CharacterSpecies] -- ^ Species a character belongs to
-  , titles :: Maybe [TitleBase.TitleBase] -- ^ Base title, returned in search results
-  , hologramStatus :: Maybe HologramStatus.HologramStatus -- ^ Hologram status
-  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place of birth
-  , name :: Name.Name -- ^ Character name
-  , yearOfDeath :: Maybe YearOfDeath.YearOfDeath -- ^ Year the character died
-  , hologramDateStatus :: Maybe HologramDateStatus.HologramDateStatus -- ^ Hologram date status
-  , episodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this character is from alternate reality
   , bloodType :: Maybe BloodType.BloodType -- ^ Blood type
+  , characterRelations :: Maybe [CharacterRelation.CharacterRelation] -- ^ Relation between characters
+  , characterSpecies :: Maybe [CharacterSpecies.CharacterSpecies] -- ^ Species a character belongs to
+  , dayOfBirth :: Maybe DayOfBirth.DayOfBirth -- ^ Day the character was born
+  , dayOfDeath :: Maybe DayOfDeath.DayOfDeath -- ^ Day the character died
+  , deceased :: Maybe Deceased.Deceased -- ^ Whether this character is deceased
+  , episodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , fictionalCharacter :: Maybe FictionalCharacter.FictionalCharacter -- ^ Whether this character is a fictional character (from universe point of view)
+  , gender :: Maybe Gender.Gender -- ^ Gender
+  , height :: Maybe Height.Height -- ^ Height in centimeters
   , hologram :: Maybe Hologram.Hologram -- ^ Whether this character is a hologram
-  , placeOfDeath :: Maybe PlaceOfDeath.PlaceOfDeath -- ^ Place of death
+  , hologramActivationDate :: Maybe HologramActivationDate.HologramActivationDate -- ^ Hologram activation date
+  , hologramDateStatus :: Maybe HologramDateStatus.HologramDateStatus -- ^ Hologram date status
+  , hologramStatus :: Maybe HologramStatus.HologramStatus -- ^ Hologram status
+  , maritalStatus :: Maybe MaritalStatus.MaritalStatus -- ^ Marital status
+  , mirror :: Maybe Mirror.Mirror -- ^ Whether this character is from mirror universe
+  , monthOfBirth :: Maybe MonthOfBirth.MonthOfBirth -- ^ Month the character was born
+  , monthOfDeath :: Maybe MonthOfDeath.MonthOfDeath -- ^ Month the character died
+  , movies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
+  , name :: Name.Name -- ^ Character name
   , occupations :: Maybe [OccupationBase.OccupationBase] -- ^ Base occupations, returned in search results
+  , organizations :: Maybe [OrganizationBase.OrganizationBase] -- ^ Base organization, returned in search results
   , performers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
+  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place of birth
+  , placeOfDeath :: Maybe PlaceOfDeath.PlaceOfDeath -- ^ Place of death
+  , serialNumber :: Maybe SerialNumber.SerialNumber -- ^ Serial number
+  , titles :: Maybe [TitleBase.TitleBase] -- ^ Base title, returned in search results
+  , uid :: Uid.Uid -- ^ Character unique ID
+  , weight :: Maybe Weight.Weight -- ^ Weight in kilograms
+  , yearOfBirth :: Maybe YearOfBirth.YearOfBirth -- ^ Year the character was born
+  , yearOfDeath :: Maybe YearOfDeath.YearOfDeath -- ^ Year the character died
   }
   deriving (Eq, Show)
 
@@ -81,35 +81,35 @@ characterFullSchema :: FC.Fleece schema => schema CharacterFull
 characterFullSchema =
   FC.object $
     FC.constructor CharacterFull
-      #+ FC.optional "monthOfDeath" monthOfDeath MonthOfDeath.monthOfDeathSchema
-      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
-      #+ FC.optional "gender" gender Gender.genderSchema
-      #+ FC.optional "organizations" organizations (FC.list OrganizationBase.organizationBaseSchema)
-      #+ FC.optional "monthOfBirth" monthOfBirth MonthOfBirth.monthOfBirthSchema
-      #+ FC.optional "maritalStatus" maritalStatus MaritalStatus.maritalStatusSchema
-      #+ FC.optional "hologramActivationDate" hologramActivationDate HologramActivationDate.hologramActivationDateSchema
-      #+ FC.optional "characterRelations" characterRelations (FC.list CharacterRelation.characterRelationSchema)
-      #+ FC.optional "movies" movies (FC.list MovieBase.movieBaseSchema)
-      #+ FC.optional "serialNumber" serialNumber SerialNumber.serialNumberSchema
-      #+ FC.optional "height" height Height.heightSchema
-      #+ FC.optional "deceased" deceased Deceased.deceasedSchema
-      #+ FC.optional "dayOfBirth" dayOfBirth DayOfBirth.dayOfBirthSchema
-      #+ FC.optional "yearOfBirth" yearOfBirth YearOfBirth.yearOfBirthSchema
-      #+ FC.optional "dayOfDeath" dayOfDeath DayOfDeath.dayOfDeathSchema
-      #+ FC.optional "weight" weight Weight.weightSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "fictionalCharacter" fictionalCharacter FictionalCharacter.fictionalCharacterSchema
-      #+ FC.optional "characterSpecies" characterSpecies (FC.list CharacterSpecies.characterSpeciesSchema)
-      #+ FC.optional "titles" titles (FC.list TitleBase.titleBaseSchema)
-      #+ FC.optional "hologramStatus" hologramStatus HologramStatus.hologramStatusSchema
-      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "yearOfDeath" yearOfDeath YearOfDeath.yearOfDeathSchema
-      #+ FC.optional "hologramDateStatus" hologramDateStatus HologramDateStatus.hologramDateStatusSchema
-      #+ FC.optional "episodes" episodes (FC.list EpisodeBase.episodeBaseSchema)
       #+ FC.optional "bloodType" bloodType BloodType.bloodTypeSchema
+      #+ FC.optional "characterRelations" characterRelations (FC.list CharacterRelation.characterRelationSchema)
+      #+ FC.optional "characterSpecies" characterSpecies (FC.list CharacterSpecies.characterSpeciesSchema)
+      #+ FC.optional "dayOfBirth" dayOfBirth DayOfBirth.dayOfBirthSchema
+      #+ FC.optional "dayOfDeath" dayOfDeath DayOfDeath.dayOfDeathSchema
+      #+ FC.optional "deceased" deceased Deceased.deceasedSchema
+      #+ FC.optional "episodes" episodes (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "fictionalCharacter" fictionalCharacter FictionalCharacter.fictionalCharacterSchema
+      #+ FC.optional "gender" gender Gender.genderSchema
+      #+ FC.optional "height" height Height.heightSchema
       #+ FC.optional "hologram" hologram Hologram.hologramSchema
-      #+ FC.optional "placeOfDeath" placeOfDeath PlaceOfDeath.placeOfDeathSchema
+      #+ FC.optional "hologramActivationDate" hologramActivationDate HologramActivationDate.hologramActivationDateSchema
+      #+ FC.optional "hologramDateStatus" hologramDateStatus HologramDateStatus.hologramDateStatusSchema
+      #+ FC.optional "hologramStatus" hologramStatus HologramStatus.hologramStatusSchema
+      #+ FC.optional "maritalStatus" maritalStatus MaritalStatus.maritalStatusSchema
+      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
+      #+ FC.optional "monthOfBirth" monthOfBirth MonthOfBirth.monthOfBirthSchema
+      #+ FC.optional "monthOfDeath" monthOfDeath MonthOfDeath.monthOfDeathSchema
+      #+ FC.optional "movies" movies (FC.list MovieBase.movieBaseSchema)
+      #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "occupations" occupations (FC.list OccupationBase.occupationBaseSchema)
+      #+ FC.optional "organizations" organizations (FC.list OrganizationBase.organizationBaseSchema)
       #+ FC.optional "performers" performers (FC.list PerformerBase.performerBaseSchema)
+      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
+      #+ FC.optional "placeOfDeath" placeOfDeath PlaceOfDeath.placeOfDeathSchema
+      #+ FC.optional "serialNumber" serialNumber SerialNumber.serialNumberSchema
+      #+ FC.optional "titles" titles (FC.list TitleBase.titleBaseSchema)
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "weight" weight Weight.weightSchema
+      #+ FC.optional "yearOfBirth" yearOfBirth YearOfBirth.yearOfBirthSchema
+      #+ FC.optional "yearOfDeath" yearOfDeath YearOfDeath.yearOfDeathSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.CharacterHeader.Name as Name
 import qualified StarTrek.Types.CharacterHeader.Uid as Uid
 
 data CharacterHeader = CharacterHeader
-  { uid :: Uid.Uid -- ^ Character unique ID
-  , name :: Name.Name -- ^ Character name
+  { name :: Name.Name -- ^ Character name
+  , uid :: Uid.Uid -- ^ Character unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ characterHeaderSchema :: FC.Fleece schema => schema CharacterHeader
 characterHeaderSchema =
   FC.object $
     FC.constructor CharacterHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterRelation.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterRelation.hs
@@ -12,9 +12,9 @@ import qualified StarTrek.Types.CharacterHeader as CharacterHeader
 import qualified StarTrek.Types.CharacterRelation.Type as Type
 
 data CharacterRelation = CharacterRelation
-  { target :: Maybe CharacterHeader.CharacterHeader -- ^ Header character, embedded in other objects
+  { source :: Maybe CharacterHeader.CharacterHeader -- ^ Header character, embedded in other objects
+  , target :: Maybe CharacterHeader.CharacterHeader -- ^ Header character, embedded in other objects
   , type_ :: Maybe Type.Type -- ^ Relation type
-  , source :: Maybe CharacterHeader.CharacterHeader -- ^ Header character, embedded in other objects
   }
   deriving (Eq, Show)
 
@@ -22,6 +22,6 @@ characterRelationSchema :: FC.Fleece schema => schema CharacterRelation
 characterRelationSchema =
   FC.object $
     FC.constructor CharacterRelation
+      #+ FC.optional "source" source CharacterHeader.characterHeaderSchema
       #+ FC.optional "target" target CharacterHeader.characterHeaderSchema
       #+ FC.optional "type" type_ Type.typeSchema
-      #+ FC.optional "source" source CharacterHeader.characterHeaderSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterSpecies.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CharacterSpecies.hs
@@ -15,9 +15,9 @@ import qualified StarTrek.Types.CharacterSpecies.Uid as Uid
 
 data CharacterSpecies = CharacterSpecies
   { denominator :: Maybe Denominator.Denominator -- ^ Denominator
-  , uid :: Maybe Uid.Uid -- ^ Entity unique ID
   , name :: Maybe Name.Name -- ^ Species name
   , numerator :: Maybe Numerator.Numerator -- ^ Numerator
+  , uid :: Maybe Uid.Uid -- ^ Entity unique ID
   }
   deriving (Eq, Show)
 
@@ -26,6 +26,6 @@ characterSpeciesSchema =
   FC.object $
     FC.constructor CharacterSpecies
       #+ FC.optional "denominator" denominator Denominator.denominatorSchema
-      #+ FC.optional "uid" uid Uid.uidSchema
       #+ FC.optional "name" name Name.nameSchema
       #+ FC.optional "numerator" numerator Numerator.numeratorSchema
+      #+ FC.optional "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicCollectionBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicCollectionBase.hs
@@ -24,20 +24,20 @@ import qualified StarTrek.Types.ComicCollectionBase.YearFrom as YearFrom
 import qualified StarTrek.Types.ComicCollectionBase.YearTo as YearTo
 
 data ComicCollectionBase = ComicCollectionBase
-  { coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
-  , title :: Title.Title -- ^ Comic collection title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic collection stories
-  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the comic collection was published
+  { coverDay :: Maybe CoverDay.CoverDay -- ^ Cover publication day
+  , coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
   , coverYear :: Maybe CoverYear.CoverYear -- ^ Cover publication year
-  , uid :: Uid.Uid -- ^ Comic collection unique ID
   , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
-  , coverDay :: Maybe CoverDay.CoverDay -- ^ Cover publication day
+  , photonovel :: Maybe Photonovel.Photonovel -- ^ Whether it's a photonovel collection
+  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the comic collection was published
+  , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the comic collection was published
   , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the comic collection was published
   , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of comic collection stories
-  , photonovel :: Maybe Photonovel.Photonovel -- ^ Whether it's a photonovel collection
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic collection stories
   , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of comic collection stories
-  , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the comic collection was published
+  , title :: Title.Title -- ^ Comic collection title
+  , uid :: Uid.Uid -- ^ Comic collection unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic collection stories
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic collection stories
   }
   deriving (Eq, Show)
 
@@ -45,17 +45,17 @@ comicCollectionBaseSchema :: FC.Fleece schema => schema ComicCollectionBase
 comicCollectionBaseSchema =
   FC.object $
     FC.constructor ComicCollectionBase
-      #+ FC.optional "coverMonth" coverMonth CoverMonth.coverMonthSchema
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
-      #+ FC.optional "coverYear" coverYear CoverYear.coverYearSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
       #+ FC.optional "coverDay" coverDay CoverDay.coverDaySchema
+      #+ FC.optional "coverMonth" coverMonth CoverMonth.coverMonthSchema
+      #+ FC.optional "coverYear" coverYear CoverYear.coverYearSchema
+      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
+      #+ FC.optional "photonovel" photonovel Photonovel.photonovelSchema
+      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
+      #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
       #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
       #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
-      #+ FC.optional "photonovel" photonovel Photonovel.photonovelSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
       #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
-      #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicCollectionBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicCollectionBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data ComicCollectionBaseResponse = ComicCollectionBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , comicCollections :: Maybe [ComicCollectionBase.ComicCollectionBase] -- ^ Base comic collection, returned in search results
+  { comicCollections :: Maybe [ComicCollectionBase.ComicCollectionBase] -- ^ Base comic collection, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ comicCollectionBaseResponseSchema :: FC.Fleece schema => schema ComicCollectionB
 comicCollectionBaseResponseSchema =
   FC.object $
     FC.constructor ComicCollectionBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "comicCollections" comicCollections (FC.list ComicCollectionBase.comicCollectionBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicCollectionFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicCollectionFull.hs
@@ -30,29 +30,29 @@ import qualified StarTrek.Types.Reference as Reference
 import qualified StarTrek.Types.StaffBase as StaffBase
 
 data ComicCollectionFull = ComicCollectionFull
-  { coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
-  , title :: Title.Title -- ^ Comic collection title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic collection stories
-  , editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , artists :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , staff :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , comicSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
-  , writers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  { artists :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
   , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the comic collection was published
-  , coverYear :: Maybe CoverYear.CoverYear -- ^ Cover publication year
-  , uid :: Uid.Uid -- ^ Comic collection unique ID
-  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
-  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
-  , coverDay :: Maybe CoverDay.CoverDay -- ^ Cover publication day
-  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
-  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the comic collection was published
-  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of comic collection stories
-  , photonovel :: Maybe Photonovel.Photonovel -- ^ Whether it's a photonovel collection
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic collection stories
-  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of comic collection stories
+  , comicSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
   , comics :: Maybe [ComicsBase.ComicsBase] -- ^ Base comics, returned in search results
+  , coverDay :: Maybe CoverDay.CoverDay -- ^ Cover publication day
+  , coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
+  , coverYear :: Maybe CoverYear.CoverYear -- ^ Cover publication year
+  , editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
+  , photonovel :: Maybe Photonovel.Photonovel -- ^ Whether it's a photonovel collection
+  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the comic collection was published
   , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the comic collection was published
+  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the comic collection was published
+  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
+  , staff :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of comic collection stories
+  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of comic collection stories
+  , title :: Title.Title -- ^ Comic collection title
+  , uid :: Uid.Uid -- ^ Comic collection unique ID
+  , writers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic collection stories
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic collection stories
   }
   deriving (Eq, Show)
 
@@ -60,26 +60,26 @@ comicCollectionFullSchema :: FC.Fleece schema => schema ComicCollectionFull
 comicCollectionFullSchema =
   FC.object $
     FC.constructor ComicCollectionFull
-      #+ FC.optional "coverMonth" coverMonth CoverMonth.coverMonthSchema
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "editors" editors (FC.list StaffBase.staffBaseSchema)
       #+ FC.optional "artists" artists (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "staff" staff (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "comicSeries" comicSeries (FC.list ComicSeriesBase.comicSeriesBaseSchema)
-      #+ FC.optional "writers" writers (FC.list StaffBase.staffBaseSchema)
       #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
-      #+ FC.optional "coverYear" coverYear CoverYear.coverYearSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
-      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
-      #+ FC.optional "coverDay" coverDay CoverDay.coverDaySchema
-      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
-      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
-      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
-      #+ FC.optional "photonovel" photonovel Photonovel.photonovelSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
-      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.optional "comicSeries" comicSeries (FC.list ComicSeriesBase.comicSeriesBaseSchema)
       #+ FC.optional "comics" comics (FC.list ComicsBase.comicsBaseSchema)
+      #+ FC.optional "coverDay" coverDay CoverDay.coverDaySchema
+      #+ FC.optional "coverMonth" coverMonth CoverMonth.coverMonthSchema
+      #+ FC.optional "coverYear" coverYear CoverYear.coverYearSchema
+      #+ FC.optional "editors" editors (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
+      #+ FC.optional "photonovel" photonovel Photonovel.photonovelSchema
+      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
       #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
+      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
+      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
+      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
+      #+ FC.optional "staff" staff (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "writers" writers (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicSeriesBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicSeriesBase.hs
@@ -25,21 +25,21 @@ import qualified StarTrek.Types.ComicSeriesBase.YearFrom as YearFrom
 import qualified StarTrek.Types.ComicSeriesBase.YearTo as YearTo
 
 data ComicSeriesBase = ComicSeriesBase
-  { title :: Title.Title -- ^ Comic series title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic series stories
-  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the comic series was published
-  , photonovelSeries :: Maybe PhotonovelSeries.PhotonovelSeries -- ^ Whether it's a photonovel series
-  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the comic series was published
-  , publishedDayFrom :: Maybe PublishedDayFrom.PublishedDayFrom -- ^ Day from which the comic series was published
-  , uid :: Uid.Uid -- ^ Comic series unique ID
-  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of comic series stories
-  , miniseries :: Maybe Miniseries.Miniseries -- ^ Whether it's a miniseries
-  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the comic series was published
+  { miniseries :: Maybe Miniseries.Miniseries -- ^ Whether it's a miniseries
   , numberOfIssues :: Maybe NumberOfIssues.NumberOfIssues -- ^ Number of issues
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic series stories
+  , photonovelSeries :: Maybe PhotonovelSeries.PhotonovelSeries -- ^ Whether it's a photonovel series
+  , publishedDayFrom :: Maybe PublishedDayFrom.PublishedDayFrom -- ^ Day from which the comic series was published
   , publishedDayTo :: Maybe PublishedDayTo.PublishedDayTo -- ^ Day to which the comic series was published
-  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of comic series stories
+  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the comic series was published
+  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the comic series was published
+  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the comic series was published
   , publishedYearTo :: Maybe PublishedYearTo.PublishedYearTo -- ^ Year to which the comic series was published
+  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of comic series stories
+  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of comic series stories
+  , title :: Title.Title -- ^ Comic series title
+  , uid :: Uid.Uid -- ^ Comic series unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic series stories
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic series stories
   }
   deriving (Eq, Show)
 
@@ -47,18 +47,18 @@ comicSeriesBaseSchema :: FC.Fleece schema => schema ComicSeriesBase
 comicSeriesBaseSchema =
   FC.object $
     FC.constructor ComicSeriesBase
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
-      #+ FC.optional "photonovelSeries" photonovelSeries PhotonovelSeries.photonovelSeriesSchema
-      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
-      #+ FC.optional "publishedDayFrom" publishedDayFrom PublishedDayFrom.publishedDayFromSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
       #+ FC.optional "miniseries" miniseries Miniseries.miniseriesSchema
-      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
       #+ FC.optional "numberOfIssues" numberOfIssues NumberOfIssues.numberOfIssuesSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
+      #+ FC.optional "photonovelSeries" photonovelSeries PhotonovelSeries.photonovelSeriesSchema
+      #+ FC.optional "publishedDayFrom" publishedDayFrom PublishedDayFrom.publishedDayFromSchema
       #+ FC.optional "publishedDayTo" publishedDayTo PublishedDayTo.publishedDayToSchema
-      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
+      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
+      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
       #+ FC.optional "publishedYearTo" publishedYearTo PublishedYearTo.publishedYearToSchema
+      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicSeriesBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicSeriesBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data ComicSeriesBaseResponse = ComicSeriesBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , comicSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
+  { comicSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ comicSeriesBaseResponseSchema :: FC.Fleece schema => schema ComicSeriesBaseRespo
 comicSeriesBaseResponseSchema =
   FC.object $
     FC.constructor ComicSeriesBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "comicSeries" comicSeries (FC.list ComicSeriesBase.comicSeriesBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicSeriesFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicSeriesFull.hs
@@ -28,25 +28,25 @@ import qualified StarTrek.Types.ComicsBase as ComicsBase
 import qualified StarTrek.Types.CompanyBase as CompanyBase
 
 data ComicSeriesFull = ComicSeriesFull
-  { title :: Title.Title -- ^ Comic series title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic series stories
-  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the comic series was published
+  { childSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
+  , comics :: Maybe [ComicsBase.ComicsBase] -- ^ Base comics, returned in search results
+  , miniseries :: Maybe Miniseries.Miniseries -- ^ Whether it's a miniseries
+  , numberOfIssues :: Maybe NumberOfIssues.NumberOfIssues -- ^ Number of issues
+  , parentSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
   , photonovelSeries :: Maybe PhotonovelSeries.PhotonovelSeries -- ^ Whether it's a photonovel series
-  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the comic series was published
   , publishedDayFrom :: Maybe PublishedDayFrom.PublishedDayFrom -- ^ Day from which the comic series was published
-  , childSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
-  , uid :: Uid.Uid -- ^ Comic series unique ID
+  , publishedDayTo :: Maybe PublishedDayTo.PublishedDayTo -- ^ Day to which the comic series was published
+  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the comic series was published
+  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the comic series was published
+  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the comic series was published
+  , publishedYearTo :: Maybe PublishedYearTo.PublishedYearTo -- ^ Year to which the comic series was published
   , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
   , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of comic series stories
-  , miniseries :: Maybe Miniseries.Miniseries -- ^ Whether it's a miniseries
-  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the comic series was published
-  , numberOfIssues :: Maybe NumberOfIssues.NumberOfIssues -- ^ Number of issues
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic series stories
-  , publishedDayTo :: Maybe PublishedDayTo.PublishedDayTo -- ^ Day to which the comic series was published
   , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of comic series stories
-  , publishedYearTo :: Maybe PublishedYearTo.PublishedYearTo -- ^ Year to which the comic series was published
-  , comics :: Maybe [ComicsBase.ComicsBase] -- ^ Base comics, returned in search results
-  , parentSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
+  , title :: Title.Title -- ^ Comic series title
+  , uid :: Uid.Uid -- ^ Comic series unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic series stories
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic series stories
   }
   deriving (Eq, Show)
 
@@ -54,22 +54,22 @@ comicSeriesFullSchema :: FC.Fleece schema => schema ComicSeriesFull
 comicSeriesFullSchema =
   FC.object $
     FC.constructor ComicSeriesFull
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
-      #+ FC.optional "photonovelSeries" photonovelSeries PhotonovelSeries.photonovelSeriesSchema
-      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
-      #+ FC.optional "publishedDayFrom" publishedDayFrom PublishedDayFrom.publishedDayFromSchema
       #+ FC.optional "childSeries" childSeries (FC.list ComicSeriesBase.comicSeriesBaseSchema)
-      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "comics" comics (FC.list ComicsBase.comicsBaseSchema)
+      #+ FC.optional "miniseries" miniseries Miniseries.miniseriesSchema
+      #+ FC.optional "numberOfIssues" numberOfIssues NumberOfIssues.numberOfIssuesSchema
+      #+ FC.optional "parentSeries" parentSeries (FC.list ComicSeriesBase.comicSeriesBaseSchema)
+      #+ FC.optional "photonovelSeries" photonovelSeries PhotonovelSeries.photonovelSeriesSchema
+      #+ FC.optional "publishedDayFrom" publishedDayFrom PublishedDayFrom.publishedDayFromSchema
+      #+ FC.optional "publishedDayTo" publishedDayTo PublishedDayTo.publishedDayToSchema
+      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
+      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
+      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
+      #+ FC.optional "publishedYearTo" publishedYearTo PublishedYearTo.publishedYearToSchema
       #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
       #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
-      #+ FC.optional "miniseries" miniseries Miniseries.miniseriesSchema
-      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
-      #+ FC.optional "numberOfIssues" numberOfIssues NumberOfIssues.numberOfIssuesSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
-      #+ FC.optional "publishedDayTo" publishedDayTo PublishedDayTo.publishedDayToSchema
       #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
-      #+ FC.optional "publishedYearTo" publishedYearTo PublishedYearTo.publishedYearToSchema
-      #+ FC.optional "comics" comics (FC.list ComicsBase.comicsBaseSchema)
-      #+ FC.optional "parentSeries" parentSeries (FC.list ComicSeriesBase.comicSeriesBaseSchema)
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicStripBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicStripBase.hs
@@ -22,18 +22,18 @@ import qualified StarTrek.Types.ComicStripBase.YearFrom as YearFrom
 import qualified StarTrek.Types.ComicStripBase.YearTo as YearTo
 
 data ComicStripBase = ComicStripBase
-  { title :: Title.Title -- ^ Comic strip title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic strip story
+  { numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
   , periodical :: Maybe Periodical.Periodical -- ^ Title of the periodical the comic strip was published in
-  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the comic strip was published
-  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the comic strip was published
   , publishedDayFrom :: Maybe PublishedDayFrom.PublishedDayFrom -- ^ Day from which the comic strip was published
-  , uid :: Uid.Uid -- ^ Comic strip unique ID
-  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
-  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the comic strip was published
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic strip story
   , publishedDayTo :: Maybe PublishedDayTo.PublishedDayTo -- ^ Day to which the comic strip was published
+  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the comic strip was published
+  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the comic strip was published
+  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the comic strip was published
   , publishedYearTo :: Maybe PublishedYearTo.PublishedYearTo -- ^ Year to which the comic strip was published
+  , title :: Title.Title -- ^ Comic strip title
+  , uid :: Uid.Uid -- ^ Comic strip unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic strip story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic strip story
   }
   deriving (Eq, Show)
 
@@ -41,15 +41,15 @@ comicStripBaseSchema :: FC.Fleece schema => schema ComicStripBase
 comicStripBaseSchema =
   FC.object $
     FC.constructor ComicStripBase
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "periodical" periodical Periodical.periodicalSchema
-      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
-      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
-      #+ FC.optional "publishedDayFrom" publishedDayFrom PublishedDayFrom.publishedDayFromSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
-      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
+      #+ FC.optional "periodical" periodical Periodical.periodicalSchema
+      #+ FC.optional "publishedDayFrom" publishedDayFrom PublishedDayFrom.publishedDayFromSchema
       #+ FC.optional "publishedDayTo" publishedDayTo PublishedDayTo.publishedDayToSchema
+      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
+      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
+      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
       #+ FC.optional "publishedYearTo" publishedYearTo PublishedYearTo.publishedYearToSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicStripBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicStripBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data ComicStripBaseResponse = ComicStripBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , comicStrips :: Maybe [ComicStripBase.ComicStripBase] -- ^ Base comic strip, returned in search results
+  { comicStrips :: Maybe [ComicStripBase.ComicStripBase] -- ^ Base comic strip, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ comicStripBaseResponseSchema :: FC.Fleece schema => schema ComicStripBaseRespons
 comicStripBaseResponseSchema =
   FC.object $
     FC.constructor ComicStripBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "comicStrips" comicStrips (FC.list ComicStripBase.comicStripBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicStripFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicStripFull.hs
@@ -25,22 +25,22 @@ import qualified StarTrek.Types.ComicStripFull.YearTo as YearTo
 import qualified StarTrek.Types.StaffBase as StaffBase
 
 data ComicStripFull = ComicStripFull
-  { title :: Title.Title -- ^ Comic strip title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic strip stories
-  , periodical :: Maybe Periodical.Periodical -- ^ Title of the periodical the comic strip was published in
-  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the comic strip was published
-  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the comic strip was published
-  , publishedDayFrom :: Maybe PublishedDayFrom.PublishedDayFrom -- ^ Day from which the comic strip was published
-  , artists :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , comicSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
-  , writers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  { artists :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
   , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , uid :: Uid.Uid -- ^ Comic strip unique ID
+  , comicSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
   , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
-  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the comic strip was published
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic strip stories
+  , periodical :: Maybe Periodical.Periodical -- ^ Title of the periodical the comic strip was published in
+  , publishedDayFrom :: Maybe PublishedDayFrom.PublishedDayFrom -- ^ Day from which the comic strip was published
   , publishedDayTo :: Maybe PublishedDayTo.PublishedDayTo -- ^ Day to which the comic strip was published
+  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the comic strip was published
+  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the comic strip was published
+  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the comic strip was published
   , publishedYearTo :: Maybe PublishedYearTo.PublishedYearTo -- ^ Year to which the comic strip was published
+  , title :: Title.Title -- ^ Comic strip title
+  , uid :: Uid.Uid -- ^ Comic strip unique ID
+  , writers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic strip stories
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic strip stories
   }
   deriving (Eq, Show)
 
@@ -48,19 +48,19 @@ comicStripFullSchema :: FC.Fleece schema => schema ComicStripFull
 comicStripFullSchema =
   FC.object $
     FC.constructor ComicStripFull
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "periodical" periodical Periodical.periodicalSchema
-      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
-      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
-      #+ FC.optional "publishedDayFrom" publishedDayFrom PublishedDayFrom.publishedDayFromSchema
       #+ FC.optional "artists" artists (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "comicSeries" comicSeries (FC.list ComicSeriesBase.comicSeriesBaseSchema)
-      #+ FC.optional "writers" writers (FC.list StaffBase.staffBaseSchema)
       #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "comicSeries" comicSeries (FC.list ComicSeriesBase.comicSeriesBaseSchema)
       #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
-      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
+      #+ FC.optional "periodical" periodical Periodical.periodicalSchema
+      #+ FC.optional "publishedDayFrom" publishedDayFrom PublishedDayFrom.publishedDayFromSchema
       #+ FC.optional "publishedDayTo" publishedDayTo PublishedDayTo.publishedDayToSchema
+      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
+      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
+      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
       #+ FC.optional "publishedYearTo" publishedYearTo PublishedYearTo.publishedYearToSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "writers" writers (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicsBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicsBase.hs
@@ -25,21 +25,21 @@ import qualified StarTrek.Types.ComicsBase.YearFrom as YearFrom
 import qualified StarTrek.Types.ComicsBase.YearTo as YearTo
 
 data ComicsBase = ComicsBase
-  { coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
-  , title :: Title.Title -- ^ Comics title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic story
-  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the comics was published
-  , coverYear :: Maybe CoverYear.CoverYear -- ^ Cover publication year
-  , uid :: Uid.Uid -- ^ Comics unique ID
-  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
+  { adaptation :: Maybe Adaptation.Adaptation -- ^ Whether it's an adaptation of an episode or a movie
   , coverDay :: Maybe CoverDay.CoverDay -- ^ Cover publication day
-  , adaptation :: Maybe Adaptation.Adaptation -- ^ Whether it's an adaptation of an episode or a movie
+  , coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
+  , coverYear :: Maybe CoverYear.CoverYear -- ^ Cover publication year
+  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
+  , photonovel :: Maybe Photonovel.Photonovel -- ^ Whether it's a photonovel
+  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the comics was published
+  , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the comics was published
   , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the comics was published
   , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of comic story
-  , photonovel :: Maybe Photonovel.Photonovel -- ^ Whether it's a photonovel
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic story
   , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of comic story
-  , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the comics was published
+  , title :: Title.Title -- ^ Comics title
+  , uid :: Uid.Uid -- ^ Comics unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic story
   }
   deriving (Eq, Show)
 
@@ -47,18 +47,18 @@ comicsBaseSchema :: FC.Fleece schema => schema ComicsBase
 comicsBaseSchema =
   FC.object $
     FC.constructor ComicsBase
-      #+ FC.optional "coverMonth" coverMonth CoverMonth.coverMonthSchema
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
-      #+ FC.optional "coverYear" coverYear CoverYear.coverYearSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
-      #+ FC.optional "coverDay" coverDay CoverDay.coverDaySchema
       #+ FC.optional "adaptation" adaptation Adaptation.adaptationSchema
+      #+ FC.optional "coverDay" coverDay CoverDay.coverDaySchema
+      #+ FC.optional "coverMonth" coverMonth CoverMonth.coverMonthSchema
+      #+ FC.optional "coverYear" coverYear CoverYear.coverYearSchema
+      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
+      #+ FC.optional "photonovel" photonovel Photonovel.photonovelSchema
+      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
+      #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
       #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
       #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
-      #+ FC.optional "photonovel" photonovel Photonovel.photonovelSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
       #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
-      #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicsBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicsBaseResponse.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data ComicsBaseResponse = ComicsBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
+  { comics :: Maybe [ComicsBase.ComicsBase] -- ^ Base comics, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
-  , comics :: Maybe [ComicsBase.ComicsBase] -- ^ Base comics, returned in search results
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ comicsBaseResponseSchema :: FC.Fleece schema => schema ComicsBaseResponse
 comicsBaseResponseSchema =
   FC.object $
     FC.constructor ComicsBaseResponse
+      #+ FC.optional "comics" comics (FC.list ComicsBase.comicsBaseSchema)
       #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
-      #+ FC.optional "comics" comics (FC.list ComicsBase.comicsBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicsFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ComicsFull.hs
@@ -31,30 +31,30 @@ import qualified StarTrek.Types.Reference as Reference
 import qualified StarTrek.Types.StaffBase as StaffBase
 
 data ComicsFull = ComicsFull
-  { coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
-  , title :: Title.Title -- ^ Comics title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic  story
-  , editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  { adaptation :: Maybe Adaptation.Adaptation -- ^ Whether it's an adaptation of an episode or a movie
   , artists :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , staff :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , comicSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
-  , writers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
   , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the comics was published
-  , coverYear :: Maybe CoverYear.CoverYear -- ^ Cover publication year
-  , uid :: Uid.Uid -- ^ Comics unique ID
-  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
   , comicCollections :: Maybe [ComicCollectionBase.ComicCollectionBase] -- ^ Base comic collection, returned in search results
-  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
+  , comicSeries :: Maybe [ComicSeriesBase.ComicSeriesBase] -- ^ Base comic series, returned in search results
   , coverDay :: Maybe CoverDay.CoverDay -- ^ Cover publication day
-  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
-  , adaptation :: Maybe Adaptation.Adaptation -- ^ Whether it's an adaptation of an episode or a movie
-  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the comics was published
-  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of comic story
+  , coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
+  , coverYear :: Maybe CoverYear.CoverYear -- ^ Cover publication year
+  , editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
   , photonovel :: Maybe Photonovel.Photonovel -- ^ Whether it's a photonovel
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic story
-  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of comic story
+  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the comics was published
   , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the comics was published
+  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the comics was published
+  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
+  , staff :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of comic story
+  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of comic story
+  , title :: Title.Title -- ^ Comics title
+  , uid :: Uid.Uid -- ^ Comics unique ID
+  , writers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of comic  story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of comic story
   }
   deriving (Eq, Show)
 
@@ -62,27 +62,27 @@ comicsFullSchema :: FC.Fleece schema => schema ComicsFull
 comicsFullSchema =
   FC.object $
     FC.constructor ComicsFull
-      #+ FC.optional "coverMonth" coverMonth CoverMonth.coverMonthSchema
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "editors" editors (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "artists" artists (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "staff" staff (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "comicSeries" comicSeries (FC.list ComicSeriesBase.comicSeriesBaseSchema)
-      #+ FC.optional "writers" writers (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
-      #+ FC.optional "coverYear" coverYear CoverYear.coverYearSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
-      #+ FC.optional "comicCollections" comicCollections (FC.list ComicCollectionBase.comicCollectionBaseSchema)
-      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
-      #+ FC.optional "coverDay" coverDay CoverDay.coverDaySchema
-      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
       #+ FC.optional "adaptation" adaptation Adaptation.adaptationSchema
-      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
-      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "artists" artists (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
+      #+ FC.optional "comicCollections" comicCollections (FC.list ComicCollectionBase.comicCollectionBaseSchema)
+      #+ FC.optional "comicSeries" comicSeries (FC.list ComicSeriesBase.comicSeriesBaseSchema)
+      #+ FC.optional "coverDay" coverDay CoverDay.coverDaySchema
+      #+ FC.optional "coverMonth" coverMonth CoverMonth.coverMonthSchema
+      #+ FC.optional "coverYear" coverYear CoverYear.coverYearSchema
+      #+ FC.optional "editors" editors (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
       #+ FC.optional "photonovel" photonovel Photonovel.photonovelSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
-      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
       #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
+      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
+      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
+      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
+      #+ FC.optional "staff" staff (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "writers" writers (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CompanyBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CompanyBase.hs
@@ -29,25 +29,25 @@ import qualified StarTrek.Types.CompanyBase.Uid as Uid
 import qualified StarTrek.Types.CompanyBase.VideoGameCompany as VideoGameCompany
 
 data CompanyBase = CompanyBase
-  { makeUpEffectsStudio :: Maybe MakeUpEffectsStudio.MakeUpEffectsStudio -- ^ Whether it's a make-up effects studio
-  , mattePaintingCompany :: Maybe MattePaintingCompany.MattePaintingCompany -- ^ Whether it's a matte painting company
-  , specialEffectsCompany :: Maybe SpecialEffectsCompany.SpecialEffectsCompany -- ^ Whether it's a special effects company
-  , productionCompany :: Maybe ProductionCompany.ProductionCompany -- ^ Whether it's a production company
-  , tvAndFilmProductionCompany :: Maybe TvAndFilmProductionCompany.TvAndFilmProductionCompany -- ^ Whether it's a TV and film production company
-  , videoGameCompany :: Maybe VideoGameCompany.VideoGameCompany -- ^ Whether it's a video game company
-  , recordLabel :: Maybe RecordLabel.RecordLabel -- ^ Whether it's a record label
-  , propCompany :: Maybe PropCompany.PropCompany -- ^ Whether it's a prop company
-  , uid :: Uid.Uid -- ^ Company unique ID
+  { broadcaster :: Maybe Broadcaster.Broadcaster -- ^ Whether it's a broadcaster
   , collectibleCompany :: Maybe CollectibleCompany.CollectibleCompany -- ^ Whether it's a collectible company
-  , postProductionCompany :: Maybe PostProductionCompany.PostProductionCompany -- ^ Whether it's a post-production company
-  , distributor :: Maybe Distributor.Distributor -- ^ Whether it's a distributor
-  , gameCompany :: Maybe GameCompany.GameCompany -- ^ Whether it's a game company
-  , digitalVisualEffectsCompany :: Maybe DigitalVisualEffectsCompany.DigitalVisualEffectsCompany -- ^ Whether it's a digital visual effects company
-  , name :: Name.Name -- ^ Company name
   , conglomerate :: Maybe Conglomerate.Conglomerate -- ^ Whether it's a conglomerate
-  , broadcaster :: Maybe Broadcaster.Broadcaster -- ^ Whether it's a broadcaster
+  , digitalVisualEffectsCompany :: Maybe DigitalVisualEffectsCompany.DigitalVisualEffectsCompany -- ^ Whether it's a digital visual effects company
+  , distributor :: Maybe Distributor.Distributor -- ^ Whether it's a distributor
   , filmEquipmentCompany :: Maybe FilmEquipmentCompany.FilmEquipmentCompany -- ^ Whether it's a film equipment company
+  , gameCompany :: Maybe GameCompany.GameCompany -- ^ Whether it's a game company
+  , makeUpEffectsStudio :: Maybe MakeUpEffectsStudio.MakeUpEffectsStudio -- ^ Whether it's a make-up effects studio
+  , mattePaintingCompany :: Maybe MattePaintingCompany.MattePaintingCompany -- ^ Whether it's a matte painting company
   , modelAndMiniatureEffectsCompany :: Maybe ModelAndMiniatureEffectsCompany.ModelAndMiniatureEffectsCompany -- ^ Whether it's a model and miniature effects company
+  , name :: Name.Name -- ^ Company name
+  , postProductionCompany :: Maybe PostProductionCompany.PostProductionCompany -- ^ Whether it's a post-production company
+  , productionCompany :: Maybe ProductionCompany.ProductionCompany -- ^ Whether it's a production company
+  , propCompany :: Maybe PropCompany.PropCompany -- ^ Whether it's a prop company
+  , recordLabel :: Maybe RecordLabel.RecordLabel -- ^ Whether it's a record label
+  , specialEffectsCompany :: Maybe SpecialEffectsCompany.SpecialEffectsCompany -- ^ Whether it's a special effects company
+  , tvAndFilmProductionCompany :: Maybe TvAndFilmProductionCompany.TvAndFilmProductionCompany -- ^ Whether it's a TV and film production company
+  , uid :: Uid.Uid -- ^ Company unique ID
+  , videoGameCompany :: Maybe VideoGameCompany.VideoGameCompany -- ^ Whether it's a video game company
   }
   deriving (Eq, Show)
 
@@ -55,22 +55,22 @@ companyBaseSchema :: FC.Fleece schema => schema CompanyBase
 companyBaseSchema =
   FC.object $
     FC.constructor CompanyBase
+      #+ FC.optional "broadcaster" broadcaster Broadcaster.broadcasterSchema
+      #+ FC.optional "collectibleCompany" collectibleCompany CollectibleCompany.collectibleCompanySchema
+      #+ FC.optional "conglomerate" conglomerate Conglomerate.conglomerateSchema
+      #+ FC.optional "digitalVisualEffectsCompany" digitalVisualEffectsCompany DigitalVisualEffectsCompany.digitalVisualEffectsCompanySchema
+      #+ FC.optional "distributor" distributor Distributor.distributorSchema
+      #+ FC.optional "filmEquipmentCompany" filmEquipmentCompany FilmEquipmentCompany.filmEquipmentCompanySchema
+      #+ FC.optional "gameCompany" gameCompany GameCompany.gameCompanySchema
       #+ FC.optional "makeUpEffectsStudio" makeUpEffectsStudio MakeUpEffectsStudio.makeUpEffectsStudioSchema
       #+ FC.optional "mattePaintingCompany" mattePaintingCompany MattePaintingCompany.mattePaintingCompanySchema
-      #+ FC.optional "specialEffectsCompany" specialEffectsCompany SpecialEffectsCompany.specialEffectsCompanySchema
-      #+ FC.optional "productionCompany" productionCompany ProductionCompany.productionCompanySchema
-      #+ FC.optional "tvAndFilmProductionCompany" tvAndFilmProductionCompany TvAndFilmProductionCompany.tvAndFilmProductionCompanySchema
-      #+ FC.optional "videoGameCompany" videoGameCompany VideoGameCompany.videoGameCompanySchema
-      #+ FC.optional "recordLabel" recordLabel RecordLabel.recordLabelSchema
-      #+ FC.optional "propCompany" propCompany PropCompany.propCompanySchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "collectibleCompany" collectibleCompany CollectibleCompany.collectibleCompanySchema
-      #+ FC.optional "postProductionCompany" postProductionCompany PostProductionCompany.postProductionCompanySchema
-      #+ FC.optional "distributor" distributor Distributor.distributorSchema
-      #+ FC.optional "gameCompany" gameCompany GameCompany.gameCompanySchema
-      #+ FC.optional "digitalVisualEffectsCompany" digitalVisualEffectsCompany DigitalVisualEffectsCompany.digitalVisualEffectsCompanySchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "conglomerate" conglomerate Conglomerate.conglomerateSchema
-      #+ FC.optional "broadcaster" broadcaster Broadcaster.broadcasterSchema
-      #+ FC.optional "filmEquipmentCompany" filmEquipmentCompany FilmEquipmentCompany.filmEquipmentCompanySchema
       #+ FC.optional "modelAndMiniatureEffectsCompany" modelAndMiniatureEffectsCompany ModelAndMiniatureEffectsCompany.modelAndMiniatureEffectsCompanySchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "postProductionCompany" postProductionCompany PostProductionCompany.postProductionCompanySchema
+      #+ FC.optional "productionCompany" productionCompany ProductionCompany.productionCompanySchema
+      #+ FC.optional "propCompany" propCompany PropCompany.propCompanySchema
+      #+ FC.optional "recordLabel" recordLabel RecordLabel.recordLabelSchema
+      #+ FC.optional "specialEffectsCompany" specialEffectsCompany SpecialEffectsCompany.specialEffectsCompanySchema
+      #+ FC.optional "tvAndFilmProductionCompany" tvAndFilmProductionCompany TvAndFilmProductionCompany.tvAndFilmProductionCompanySchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "videoGameCompany" videoGameCompany VideoGameCompany.videoGameCompanySchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CompanyBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CompanyBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data CompanyBaseResponse = CompanyBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , companies :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  { companies :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ companyBaseResponseSchema :: FC.Fleece schema => schema CompanyBaseResponse
 companyBaseResponseSchema =
   FC.object $
     FC.constructor CompanyBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "companies" companies (FC.list CompanyBase.companyBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CompanyFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CompanyFull.hs
@@ -29,25 +29,25 @@ import qualified StarTrek.Types.CompanyFull.Uid as Uid
 import qualified StarTrek.Types.CompanyFull.VideoGameCompany as VideoGameCompany
 
 data CompanyFull = CompanyFull
-  { makeUpEffectsStudio :: Maybe MakeUpEffectsStudio.MakeUpEffectsStudio -- ^ Whether it's a make-up effects studio
-  , mattePaintingCompany :: Maybe MattePaintingCompany.MattePaintingCompany -- ^ Whether it's a matte painting company
-  , specialEffectsCompany :: Maybe SpecialEffectsCompany.SpecialEffectsCompany -- ^ Whether it's a special effects company
-  , productionCompany :: Maybe ProductionCompany.ProductionCompany -- ^ Whether it's a production company
-  , tvAndFilmProductionCompany :: Maybe TvAndFilmProductionCompany.TvAndFilmProductionCompany -- ^ Whether it's a TV and film production company
-  , videoGameCompany :: Maybe VideoGameCompany.VideoGameCompany -- ^ Whether it's a video game company
-  , recordLabel :: Maybe RecordLabel.RecordLabel -- ^ Whether it's a record label
-  , propCompany :: Maybe PropCompany.PropCompany -- ^ Whether it's a prop company
-  , uid :: Uid.Uid -- ^ Company unique ID
+  { broadcaster :: Maybe Broadcaster.Broadcaster -- ^ Whether it's a broadcaster
   , collectibleCompany :: Maybe CollectibleCompany.CollectibleCompany -- ^ Whether it's a collectible company
-  , postProductionCompany :: Maybe PostProductionCompany.PostProductionCompany -- ^ Whether it's a post-production company
-  , distributor :: Maybe Distributor.Distributor -- ^ Whether it's a distributor
-  , gameCompany :: Maybe GameCompany.GameCompany -- ^ Whether it's a game company
-  , digitalVisualEffectsCompany :: Maybe DigitalVisualEffectsCompany.DigitalVisualEffectsCompany -- ^ Whether it's a digital visual effects company
-  , name :: Name.Name -- ^ Company name
   , conglomerate :: Maybe Conglomerate.Conglomerate -- ^ Whether it's a conglomerate
-  , broadcaster :: Maybe Broadcaster.Broadcaster -- ^ Whether it's a broadcaster
+  , digitalVisualEffectsCompany :: Maybe DigitalVisualEffectsCompany.DigitalVisualEffectsCompany -- ^ Whether it's a digital visual effects company
+  , distributor :: Maybe Distributor.Distributor -- ^ Whether it's a distributor
   , filmEquipmentCompany :: Maybe FilmEquipmentCompany.FilmEquipmentCompany -- ^ Whether it's a film equipment company
+  , gameCompany :: Maybe GameCompany.GameCompany -- ^ Whether it's a game company
+  , makeUpEffectsStudio :: Maybe MakeUpEffectsStudio.MakeUpEffectsStudio -- ^ Whether it's a make-up effects studio
+  , mattePaintingCompany :: Maybe MattePaintingCompany.MattePaintingCompany -- ^ Whether it's a matte painting company
   , modelAndMiniatureEffectsCompany :: Maybe ModelAndMiniatureEffectsCompany.ModelAndMiniatureEffectsCompany -- ^ Whether it's a model and miniature effects company
+  , name :: Name.Name -- ^ Company name
+  , postProductionCompany :: Maybe PostProductionCompany.PostProductionCompany -- ^ Whether it's a post-production company
+  , productionCompany :: Maybe ProductionCompany.ProductionCompany -- ^ Whether it's a production company
+  , propCompany :: Maybe PropCompany.PropCompany -- ^ Whether it's a prop company
+  , recordLabel :: Maybe RecordLabel.RecordLabel -- ^ Whether it's a record label
+  , specialEffectsCompany :: Maybe SpecialEffectsCompany.SpecialEffectsCompany -- ^ Whether it's a special effects company
+  , tvAndFilmProductionCompany :: Maybe TvAndFilmProductionCompany.TvAndFilmProductionCompany -- ^ Whether it's a TV and film production company
+  , uid :: Uid.Uid -- ^ Company unique ID
+  , videoGameCompany :: Maybe VideoGameCompany.VideoGameCompany -- ^ Whether it's a video game company
   }
   deriving (Eq, Show)
 
@@ -55,22 +55,22 @@ companyFullSchema :: FC.Fleece schema => schema CompanyFull
 companyFullSchema =
   FC.object $
     FC.constructor CompanyFull
+      #+ FC.optional "broadcaster" broadcaster Broadcaster.broadcasterSchema
+      #+ FC.optional "collectibleCompany" collectibleCompany CollectibleCompany.collectibleCompanySchema
+      #+ FC.optional "conglomerate" conglomerate Conglomerate.conglomerateSchema
+      #+ FC.optional "digitalVisualEffectsCompany" digitalVisualEffectsCompany DigitalVisualEffectsCompany.digitalVisualEffectsCompanySchema
+      #+ FC.optional "distributor" distributor Distributor.distributorSchema
+      #+ FC.optional "filmEquipmentCompany" filmEquipmentCompany FilmEquipmentCompany.filmEquipmentCompanySchema
+      #+ FC.optional "gameCompany" gameCompany GameCompany.gameCompanySchema
       #+ FC.optional "makeUpEffectsStudio" makeUpEffectsStudio MakeUpEffectsStudio.makeUpEffectsStudioSchema
       #+ FC.optional "mattePaintingCompany" mattePaintingCompany MattePaintingCompany.mattePaintingCompanySchema
-      #+ FC.optional "specialEffectsCompany" specialEffectsCompany SpecialEffectsCompany.specialEffectsCompanySchema
-      #+ FC.optional "productionCompany" productionCompany ProductionCompany.productionCompanySchema
-      #+ FC.optional "tvAndFilmProductionCompany" tvAndFilmProductionCompany TvAndFilmProductionCompany.tvAndFilmProductionCompanySchema
-      #+ FC.optional "videoGameCompany" videoGameCompany VideoGameCompany.videoGameCompanySchema
-      #+ FC.optional "recordLabel" recordLabel RecordLabel.recordLabelSchema
-      #+ FC.optional "propCompany" propCompany PropCompany.propCompanySchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "collectibleCompany" collectibleCompany CollectibleCompany.collectibleCompanySchema
-      #+ FC.optional "postProductionCompany" postProductionCompany PostProductionCompany.postProductionCompanySchema
-      #+ FC.optional "distributor" distributor Distributor.distributorSchema
-      #+ FC.optional "gameCompany" gameCompany GameCompany.gameCompanySchema
-      #+ FC.optional "digitalVisualEffectsCompany" digitalVisualEffectsCompany DigitalVisualEffectsCompany.digitalVisualEffectsCompanySchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "conglomerate" conglomerate Conglomerate.conglomerateSchema
-      #+ FC.optional "broadcaster" broadcaster Broadcaster.broadcasterSchema
-      #+ FC.optional "filmEquipmentCompany" filmEquipmentCompany FilmEquipmentCompany.filmEquipmentCompanySchema
       #+ FC.optional "modelAndMiniatureEffectsCompany" modelAndMiniatureEffectsCompany ModelAndMiniatureEffectsCompany.modelAndMiniatureEffectsCompanySchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "postProductionCompany" postProductionCompany PostProductionCompany.postProductionCompanySchema
+      #+ FC.optional "productionCompany" productionCompany ProductionCompany.productionCompanySchema
+      #+ FC.optional "propCompany" propCompany PropCompany.propCompanySchema
+      #+ FC.optional "recordLabel" recordLabel RecordLabel.recordLabelSchema
+      #+ FC.optional "specialEffectsCompany" specialEffectsCompany SpecialEffectsCompany.specialEffectsCompanySchema
+      #+ FC.optional "tvAndFilmProductionCompany" tvAndFilmProductionCompany TvAndFilmProductionCompany.tvAndFilmProductionCompanySchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "videoGameCompany" videoGameCompany VideoGameCompany.videoGameCompanySchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CompanyHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/CompanyHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.CompanyHeader.Name as Name
 import qualified StarTrek.Types.CompanyHeader.Uid as Uid
 
 data CompanyHeader = CompanyHeader
-  { uid :: Uid.Uid -- ^ Company unique ID
-  , name :: Name.Name -- ^ Company title
+  { name :: Name.Name -- ^ Company title
+  , uid :: Uid.Uid -- ^ Company unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ companyHeaderSchema :: FC.Fleece schema => schema CompanyHeader
 companyHeaderSchema =
   FC.object $
     FC.constructor CompanyHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ConflictBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ConflictBase.hs
@@ -19,14 +19,14 @@ import qualified StarTrek.Types.ConflictBase.YearFrom as YearFrom
 import qualified StarTrek.Types.ConflictBase.YearTo as YearTo
 
 data ConflictBase = ConflictBase
-  { yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of the conflict
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this conflict is from alternate reality
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this conflict is from alternate reality
+  , dominionWarBattle :: Maybe DominionWarBattle.DominionWarBattle -- ^ Whether this conflict is a Dominion war battle
+  , earthConflict :: Maybe EarthConflict.EarthConflict -- ^ Whether it was an Earth conflict
   , federationWar :: Maybe FederationWar.FederationWar -- ^ Whether this conflict is part of war involving Federation
   , klingonWar :: Maybe KlingonWar.KlingonWar -- ^ Whether this conflict is part of war involving the Klingons
-  , dominionWarBattle :: Maybe DominionWarBattle.DominionWarBattle -- ^ Whether this conflict is a Dominion war battle
-  , uid :: Uid.Uid -- ^ Conflict unique ID
-  , earthConflict :: Maybe EarthConflict.EarthConflict -- ^ Whether it was an Earth conflict
   , name :: Name.Name -- ^ Conflict name
+  , uid :: Uid.Uid -- ^ Conflict unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of the conflict
   , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of the conflict
   }
   deriving (Eq, Show)
@@ -35,12 +35,12 @@ conflictBaseSchema :: FC.Fleece schema => schema ConflictBase
 conflictBaseSchema =
   FC.object $
     FC.constructor ConflictBase
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
+      #+ FC.optional "dominionWarBattle" dominionWarBattle DominionWarBattle.dominionWarBattleSchema
+      #+ FC.optional "earthConflict" earthConflict EarthConflict.earthConflictSchema
       #+ FC.optional "federationWar" federationWar FederationWar.federationWarSchema
       #+ FC.optional "klingonWar" klingonWar KlingonWar.klingonWarSchema
-      #+ FC.optional "dominionWarBattle" dominionWarBattle DominionWarBattle.dominionWarBattleSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "earthConflict" earthConflict EarthConflict.earthConflictSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
       #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ConflictBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ConflictBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data ConflictBaseResponse = ConflictBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , conflicts :: Maybe [ConflictBase.ConflictBase] -- ^ Base conflict, returned in search results
+  { conflicts :: Maybe [ConflictBase.ConflictBase] -- ^ Base conflict, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ conflictBaseResponseSchema :: FC.Fleece schema => schema ConflictBaseResponse
 conflictBaseResponseSchema =
   FC.object $
     FC.constructor ConflictBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "conflicts" conflicts (FC.list ConflictBase.conflictBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ConflictFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ConflictFull.hs
@@ -22,19 +22,19 @@ import qualified StarTrek.Types.LocationBase as LocationBase
 import qualified StarTrek.Types.OrganizationBase as OrganizationBase
 
 data ConflictFull = ConflictFull
-  { secondSideBelligerents :: Maybe [OrganizationBase.OrganizationBase] -- ^ Base organization, returned in search results
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of the conflict
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this conflict is from alternate reality
-  , firstSideCommanders :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , federationWar :: Maybe FederationWar.FederationWar -- ^ Whether this conflict is a part of war involving Federation
-  , klingonWar :: Maybe KlingonWar.KlingonWar -- ^ Whether this conflict is a part of war involving the Klingons
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this conflict is from alternate reality
   , dominionWarBattle :: Maybe DominionWarBattle.DominionWarBattle -- ^ Whether this conflict is a Dominion war battle
-  , uid :: Uid.Uid -- ^ Conflict unique ID
-  , locations :: Maybe [LocationBase.LocationBase] -- ^ Base location, returned in search results
-  , secondSideCommanders :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
   , earthConflict :: Maybe EarthConflict.EarthConflict -- ^ Whether it is an Earth conflict
+  , federationWar :: Maybe FederationWar.FederationWar -- ^ Whether this conflict is a part of war involving Federation
   , firstSideBelligerents :: Maybe [OrganizationBase.OrganizationBase] -- ^ Base organization, returned in search results
+  , firstSideCommanders :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
+  , klingonWar :: Maybe KlingonWar.KlingonWar -- ^ Whether this conflict is a part of war involving the Klingons
+  , locations :: Maybe [LocationBase.LocationBase] -- ^ Base location, returned in search results
   , name :: Name.Name -- ^ Conflict name
+  , secondSideBelligerents :: Maybe [OrganizationBase.OrganizationBase] -- ^ Base organization, returned in search results
+  , secondSideCommanders :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
+  , uid :: Uid.Uid -- ^ Conflict unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of the conflict
   , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of the conflict
   }
   deriving (Eq, Show)
@@ -43,17 +43,17 @@ conflictFullSchema :: FC.Fleece schema => schema ConflictFull
 conflictFullSchema =
   FC.object $
     FC.constructor ConflictFull
-      #+ FC.optional "secondSideBelligerents" secondSideBelligerents (FC.list OrganizationBase.organizationBaseSchema)
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
-      #+ FC.optional "firstSideCommanders" firstSideCommanders (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.optional "federationWar" federationWar FederationWar.federationWarSchema
-      #+ FC.optional "klingonWar" klingonWar KlingonWar.klingonWarSchema
       #+ FC.optional "dominionWarBattle" dominionWarBattle DominionWarBattle.dominionWarBattleSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "locations" locations (FC.list LocationBase.locationBaseSchema)
-      #+ FC.optional "secondSideCommanders" secondSideCommanders (FC.list CharacterBase.characterBaseSchema)
       #+ FC.optional "earthConflict" earthConflict EarthConflict.earthConflictSchema
+      #+ FC.optional "federationWar" federationWar FederationWar.federationWarSchema
       #+ FC.optional "firstSideBelligerents" firstSideBelligerents (FC.list OrganizationBase.organizationBaseSchema)
+      #+ FC.optional "firstSideCommanders" firstSideCommanders (FC.list CharacterBase.characterBaseSchema)
+      #+ FC.optional "klingonWar" klingonWar KlingonWar.klingonWarSchema
+      #+ FC.optional "locations" locations (FC.list LocationBase.locationBaseSchema)
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "secondSideBelligerents" secondSideBelligerents (FC.list OrganizationBase.organizationBaseSchema)
+      #+ FC.optional "secondSideCommanders" secondSideCommanders (FC.list CharacterBase.characterBaseSchema)
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
       #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ConflictHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ConflictHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.ConflictHeader.Name as Name
 import qualified StarTrek.Types.ConflictHeader.Uid as Uid
 
 data ConflictHeader = ConflictHeader
-  { uid :: Uid.Uid -- ^ Conflict unique ID
-  , name :: Name.Name -- ^ Conflict name
+  { name :: Name.Name -- ^ Conflict name
+  , uid :: Uid.Uid -- ^ Conflict unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ conflictHeaderSchema :: FC.Fleece schema => schema ConflictHeader
 conflictHeaderSchema =
   FC.object $
     FC.constructor ConflictHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ContentLanguage.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ContentLanguage.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.ContentLanguage.Name as Name
 import qualified StarTrek.Types.ContentLanguage.Uid as Uid
 
 data ContentLanguage = ContentLanguage
-  { uid :: Maybe Uid.Uid -- ^ Language unique ID
-  , iso6391Code :: Maybe Iso6391Code.Iso6391Code -- ^ ISO 639-1 code
+  { iso6391Code :: Maybe Iso6391Code.Iso6391Code -- ^ ISO 639-1 code
   , name :: Maybe Name.Name -- ^ Language name
+  , uid :: Maybe Uid.Uid -- ^ Language unique ID
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ contentLanguageSchema :: FC.Fleece schema => schema ContentLanguage
 contentLanguageSchema =
   FC.object $
     FC.constructor ContentLanguage
-      #+ FC.optional "uid" uid Uid.uidSchema
       #+ FC.optional "iso6391Code" iso6391Code Iso6391Code.iso6391CodeSchema
       #+ FC.optional "name" name Name.nameSchema
+      #+ FC.optional "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ContentRating.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ContentRating.hs
@@ -14,8 +14,8 @@ import qualified StarTrek.Types.ContentRatingSystem as ContentRatingSystem
 
 data ContentRating = ContentRating
   { contentRatingSystem :: Maybe ContentRatingSystem.ContentRatingSystem -- ^ Content rating system
-  , uid :: Maybe Uid.Uid -- ^ Rating unique ID
   , rating :: Maybe Rating.Rating -- ^ Rating within specified content rating system
+  , uid :: Maybe Uid.Uid -- ^ Rating unique ID
   }
   deriving (Eq, Show)
 
@@ -24,5 +24,5 @@ contentRatingSchema =
   FC.object $
     FC.constructor ContentRating
       #+ FC.optional "contentRatingSystem" contentRatingSystem ContentRatingSystem.contentRatingSystemSchema
-      #+ FC.optional "uid" uid Uid.uidSchema
       #+ FC.optional "rating" rating Rating.ratingSchema
+      #+ FC.optional "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Country.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Country.hs
@@ -14,8 +14,8 @@ import qualified StarTrek.Types.Country.Uid as Uid
 
 data Country = Country
   { iso31661Alpha2Code :: Maybe Iso31661Alpha2Code.Iso31661Alpha2Code -- ^ ISO 3166-1 alpha-2 code
-  , uid :: Maybe Uid.Uid -- ^ Country unique ID
   , name :: Maybe Name.Name -- ^ Country name
+  , uid :: Maybe Uid.Uid -- ^ Country unique ID
   }
   deriving (Eq, Show)
 
@@ -24,5 +24,5 @@ countrySchema =
   FC.object $
     FC.constructor Country
       #+ FC.optional "iso31661Alpha2Code" iso31661Alpha2Code Iso31661Alpha2Code.iso31661Alpha2CodeSchema
-      #+ FC.optional "uid" uid Uid.uidSchema
       #+ FC.optional "name" name Name.nameSchema
+      #+ FC.optional "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ElementBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ElementBase.hs
@@ -22,18 +22,18 @@ import qualified StarTrek.Types.ElementBase.Uid as Uid
 import qualified StarTrek.Types.ElementBase.WorldSeries as WorldSeries
 
 data ElementBase = ElementBase
-  { atomicWeight :: Maybe AtomicWeight.AtomicWeight -- ^ Element atomic weight
+  { atomicNumber :: Maybe AtomicNumber.AtomicNumber -- ^ Element atomic number
+  , atomicWeight :: Maybe AtomicWeight.AtomicWeight -- ^ Element atomic weight
+  , gammaSeries :: Maybe GammaSeries.GammaSeries -- ^ Whether it belongs to Gamma series
   , hypersonicSeries :: Maybe HypersonicSeries.HypersonicSeries -- ^ Whether it belongs to Hypersonic series
-  , worldSeries :: Maybe WorldSeries.WorldSeries -- ^ Whether it belongs to World series
-  , atomicNumber :: Maybe AtomicNumber.AtomicNumber -- ^ Element atomic number
-  , transonicSeries :: Maybe TransonicSeries.TransonicSeries -- ^ Whether it belongs to Transonic series
-  , symbol :: Maybe Symbol.Symbol -- ^ Element symbol
-  , uid :: Uid.Uid -- ^ Element unique ID
-  , transuranium :: Maybe Transuranium.Transuranium -- ^ Whether it's a transuranium
-  , omegaSeries :: Maybe OmegaSeries.OmegaSeries -- ^ Whether it belongs to Omega series
   , megaSeries :: Maybe MegaSeries.MegaSeries -- ^ Whether it belongs to Mega series
   , name :: Name.Name -- ^ Element name
-  , gammaSeries :: Maybe GammaSeries.GammaSeries -- ^ Whether it belongs to Gamma series
+  , omegaSeries :: Maybe OmegaSeries.OmegaSeries -- ^ Whether it belongs to Omega series
+  , symbol :: Maybe Symbol.Symbol -- ^ Element symbol
+  , transonicSeries :: Maybe TransonicSeries.TransonicSeries -- ^ Whether it belongs to Transonic series
+  , transuranium :: Maybe Transuranium.Transuranium -- ^ Whether it's a transuranium
+  , uid :: Uid.Uid -- ^ Element unique ID
+  , worldSeries :: Maybe WorldSeries.WorldSeries -- ^ Whether it belongs to World series
   }
   deriving (Eq, Show)
 
@@ -41,15 +41,15 @@ elementBaseSchema :: FC.Fleece schema => schema ElementBase
 elementBaseSchema =
   FC.object $
     FC.constructor ElementBase
-      #+ FC.optional "atomicWeight" atomicWeight AtomicWeight.atomicWeightSchema
-      #+ FC.optional "hypersonicSeries" hypersonicSeries HypersonicSeries.hypersonicSeriesSchema
-      #+ FC.optional "worldSeries" worldSeries WorldSeries.worldSeriesSchema
       #+ FC.optional "atomicNumber" atomicNumber AtomicNumber.atomicNumberSchema
-      #+ FC.optional "transonicSeries" transonicSeries TransonicSeries.transonicSeriesSchema
-      #+ FC.optional "symbol" symbol Symbol.symbolSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "transuranium" transuranium Transuranium.transuraniumSchema
-      #+ FC.optional "omegaSeries" omegaSeries OmegaSeries.omegaSeriesSchema
+      #+ FC.optional "atomicWeight" atomicWeight AtomicWeight.atomicWeightSchema
+      #+ FC.optional "gammaSeries" gammaSeries GammaSeries.gammaSeriesSchema
+      #+ FC.optional "hypersonicSeries" hypersonicSeries HypersonicSeries.hypersonicSeriesSchema
       #+ FC.optional "megaSeries" megaSeries MegaSeries.megaSeriesSchema
       #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "gammaSeries" gammaSeries GammaSeries.gammaSeriesSchema
+      #+ FC.optional "omegaSeries" omegaSeries OmegaSeries.omegaSeriesSchema
+      #+ FC.optional "symbol" symbol Symbol.symbolSchema
+      #+ FC.optional "transonicSeries" transonicSeries TransonicSeries.transonicSeriesSchema
+      #+ FC.optional "transuranium" transuranium Transuranium.transuraniumSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "worldSeries" worldSeries WorldSeries.worldSeriesSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ElementBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ElementBaseResponse.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data ElementBaseResponse = ElementBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
+  { elements :: Maybe [ElementBase.ElementBase] -- ^ Base element, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
-  , elements :: Maybe [ElementBase.ElementBase] -- ^ Base element, returned in search results
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ elementBaseResponseSchema :: FC.Fleece schema => schema ElementBaseResponse
 elementBaseResponseSchema =
   FC.object $
     FC.constructor ElementBaseResponse
+      #+ FC.optional "elements" elements (FC.list ElementBase.elementBaseSchema)
       #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
-      #+ FC.optional "elements" elements (FC.list ElementBase.elementBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ElementFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ElementFull.hs
@@ -22,18 +22,18 @@ import qualified StarTrek.Types.ElementFull.Uid as Uid
 import qualified StarTrek.Types.ElementFull.WorldSeries as WorldSeries
 
 data ElementFull = ElementFull
-  { atomicWeight :: Maybe AtomicWeight.AtomicWeight -- ^ Element atomic weight
+  { atomicNumber :: Maybe AtomicNumber.AtomicNumber -- ^ Element atomic number
+  , atomicWeight :: Maybe AtomicWeight.AtomicWeight -- ^ Element atomic weight
+  , gammaSeries :: Maybe GammaSeries.GammaSeries -- ^ Whether it belongs to Gamma series
   , hypersonicSeries :: Maybe HypersonicSeries.HypersonicSeries -- ^ Whether it belongs to Hypersonic series
-  , worldSeries :: Maybe WorldSeries.WorldSeries -- ^ Whether it belongs to World series
-  , atomicNumber :: Maybe AtomicNumber.AtomicNumber -- ^ Element atomic number
-  , transonicSeries :: Maybe TransonicSeries.TransonicSeries -- ^ Whether it belongs to Transonic series
-  , symbol :: Maybe Symbol.Symbol -- ^ Element symbol
-  , uid :: Uid.Uid -- ^ Element unique ID
-  , transuranium :: Maybe Transuranium.Transuranium -- ^ Whether it's a transuranium
-  , omegaSeries :: Maybe OmegaSeries.OmegaSeries -- ^ Whether it belongs to Omega series
   , megaSeries :: Maybe MegaSeries.MegaSeries -- ^ Whether it belongs to Mega series
   , name :: Name.Name -- ^ Element name
-  , gammaSeries :: Maybe GammaSeries.GammaSeries -- ^ Whether it belongs to Gamma series
+  , omegaSeries :: Maybe OmegaSeries.OmegaSeries -- ^ Whether it belongs to Omega series
+  , symbol :: Maybe Symbol.Symbol -- ^ Element symbol
+  , transonicSeries :: Maybe TransonicSeries.TransonicSeries -- ^ Whether it belongs to Transonic series
+  , transuranium :: Maybe Transuranium.Transuranium -- ^ Whether it's a transuranium
+  , uid :: Uid.Uid -- ^ Element unique ID
+  , worldSeries :: Maybe WorldSeries.WorldSeries -- ^ Whether it belongs to World series
   }
   deriving (Eq, Show)
 
@@ -41,15 +41,15 @@ elementFullSchema :: FC.Fleece schema => schema ElementFull
 elementFullSchema =
   FC.object $
     FC.constructor ElementFull
-      #+ FC.optional "atomicWeight" atomicWeight AtomicWeight.atomicWeightSchema
-      #+ FC.optional "hypersonicSeries" hypersonicSeries HypersonicSeries.hypersonicSeriesSchema
-      #+ FC.optional "worldSeries" worldSeries WorldSeries.worldSeriesSchema
       #+ FC.optional "atomicNumber" atomicNumber AtomicNumber.atomicNumberSchema
-      #+ FC.optional "transonicSeries" transonicSeries TransonicSeries.transonicSeriesSchema
-      #+ FC.optional "symbol" symbol Symbol.symbolSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "transuranium" transuranium Transuranium.transuraniumSchema
-      #+ FC.optional "omegaSeries" omegaSeries OmegaSeries.omegaSeriesSchema
+      #+ FC.optional "atomicWeight" atomicWeight AtomicWeight.atomicWeightSchema
+      #+ FC.optional "gammaSeries" gammaSeries GammaSeries.gammaSeriesSchema
+      #+ FC.optional "hypersonicSeries" hypersonicSeries HypersonicSeries.hypersonicSeriesSchema
       #+ FC.optional "megaSeries" megaSeries MegaSeries.megaSeriesSchema
       #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "gammaSeries" gammaSeries GammaSeries.gammaSeriesSchema
+      #+ FC.optional "omegaSeries" omegaSeries OmegaSeries.omegaSeriesSchema
+      #+ FC.optional "symbol" symbol Symbol.symbolSchema
+      #+ FC.optional "transonicSeries" transonicSeries TransonicSeries.transonicSeriesSchema
+      #+ FC.optional "transuranium" transuranium Transuranium.transuraniumSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "worldSeries" worldSeries WorldSeries.worldSeriesSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ElementHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ElementHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.ElementHeader.Name as Name
 import qualified StarTrek.Types.ElementHeader.Uid as Uid
 
 data ElementHeader = ElementHeader
-  { uid :: Uid.Uid -- ^ Element unique ID
-  , name :: Name.Name -- ^ Element name
+  { name :: Name.Name -- ^ Element name
+  , uid :: Uid.Uid -- ^ Element unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ elementHeaderSchema :: FC.Fleece schema => schema ElementHeader
 elementHeaderSchema =
   FC.object $
     FC.constructor ElementHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/EpisodeBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/EpisodeBase.hs
@@ -27,23 +27,23 @@ import qualified StarTrek.Types.SeasonHeader as SeasonHeader
 import qualified StarTrek.Types.SeriesHeader as SeriesHeader
 
 data EpisodeBase = EpisodeBase
-  { title :: Title.Title -- ^ Episode title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of episode story
-  , titleGerman :: Maybe TitleGerman.TitleGerman -- ^ Episode title in German
-  , episodeNumber :: Maybe EpisodeNumber.EpisodeNumber -- ^ Episode number in season
-  , productionSerialNumber :: Maybe ProductionSerialNumber.ProductionSerialNumber -- ^ Production serial number
+  { episodeNumber :: Maybe EpisodeNumber.EpisodeNumber -- ^ Episode number in season
   , featureLength :: Maybe FeatureLength.FeatureLength -- ^ Whether it's a feature length episode
-  , titleItalian :: Maybe TitleItalian.TitleItalian -- ^ Episode title in Italian
-  , season :: Maybe SeasonHeader.SeasonHeader -- ^ Header season, embedded in other objects
   , finalScriptDate :: Maybe FinalScriptDate.FinalScriptDate -- ^ Date the episode script was completed
-  , usAirDate :: Maybe UsAirDate.UsAirDate -- ^ Date the episode was first aired in the United States
-  , uid :: Uid.Uid -- ^ Episode unique ID
-  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of episode story
+  , productionSerialNumber :: Maybe ProductionSerialNumber.ProductionSerialNumber -- ^ Production serial number
+  , season :: Maybe SeasonHeader.SeasonHeader -- ^ Header season, embedded in other objects
   , seasonNumber :: Maybe SeasonNumber.SeasonNumber -- ^ Season number
-  , titleJapanese :: Maybe TitleJapanese.TitleJapanese -- ^ Episode title in Japanese
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of episode story
-  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of episode story
   , series :: Maybe SeriesHeader.SeriesHeader -- ^ Header series, embedded in other objects
+  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of episode story
+  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of episode story
+  , title :: Title.Title -- ^ Episode title
+  , titleGerman :: Maybe TitleGerman.TitleGerman -- ^ Episode title in German
+  , titleItalian :: Maybe TitleItalian.TitleItalian -- ^ Episode title in Italian
+  , titleJapanese :: Maybe TitleJapanese.TitleJapanese -- ^ Episode title in Japanese
+  , uid :: Uid.Uid -- ^ Episode unique ID
+  , usAirDate :: Maybe UsAirDate.UsAirDate -- ^ Date the episode was first aired in the United States
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of episode story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of episode story
   }
   deriving (Eq, Show)
 
@@ -51,20 +51,20 @@ episodeBaseSchema :: FC.Fleece schema => schema EpisodeBase
 episodeBaseSchema =
   FC.object $
     FC.constructor EpisodeBase
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "titleGerman" titleGerman TitleGerman.titleGermanSchema
       #+ FC.optional "episodeNumber" episodeNumber EpisodeNumber.episodeNumberSchema
-      #+ FC.optional "productionSerialNumber" productionSerialNumber ProductionSerialNumber.productionSerialNumberSchema
       #+ FC.optional "featureLength" featureLength FeatureLength.featureLengthSchema
-      #+ FC.optional "titleItalian" titleItalian TitleItalian.titleItalianSchema
-      #+ FC.optional "season" season SeasonHeader.seasonHeaderSchema
       #+ FC.optional "finalScriptDate" finalScriptDate FinalScriptDate.finalScriptDateSchema
-      #+ FC.optional "usAirDate" usAirDate UsAirDate.usAirDateSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "productionSerialNumber" productionSerialNumber ProductionSerialNumber.productionSerialNumberSchema
+      #+ FC.optional "season" season SeasonHeader.seasonHeaderSchema
       #+ FC.optional "seasonNumber" seasonNumber SeasonNumber.seasonNumberSchema
-      #+ FC.optional "titleJapanese" titleJapanese TitleJapanese.titleJapaneseSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
-      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
       #+ FC.optional "series" series SeriesHeader.seriesHeaderSchema
+      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.optional "titleGerman" titleGerman TitleGerman.titleGermanSchema
+      #+ FC.optional "titleItalian" titleItalian TitleItalian.titleItalianSchema
+      #+ FC.optional "titleJapanese" titleJapanese TitleJapanese.titleJapaneseSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "usAirDate" usAirDate UsAirDate.usAirDateSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/EpisodeBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/EpisodeBaseResponse.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data EpisodeBaseResponse = EpisodeBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
+  { episodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
-  , episodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ episodeBaseResponseSchema :: FC.Fleece schema => schema EpisodeBaseResponse
 episodeBaseResponseSchema =
   FC.object $
     FC.constructor EpisodeBaseResponse
+      #+ FC.optional "episodes" episodes (FC.list EpisodeBase.episodeBaseSchema)
       #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
-      #+ FC.optional "episodes" episodes (FC.list EpisodeBase.episodeBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/EpisodeFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/EpisodeFull.hs
@@ -30,31 +30,31 @@ import qualified StarTrek.Types.SeriesBase as SeriesBase
 import qualified StarTrek.Types.StaffBase as StaffBase
 
 data EpisodeFull = EpisodeFull
-  { storyAuthors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , title :: Title.Title -- ^ Episode title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of episode story
-  , titleGerman :: Maybe TitleGerman.TitleGerman -- ^ Episode title in German
-  , episodeNumber :: Maybe EpisodeNumber.EpisodeNumber -- ^ Episode number in season
-  , productionSerialNumber :: Maybe ProductionSerialNumber.ProductionSerialNumber -- ^ Production serial number
-  , featureLength :: Maybe FeatureLength.FeatureLength -- ^ Whether it's a feature length episode
-  , writers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , titleItalian :: Maybe TitleItalian.TitleItalian -- ^ Episode title in Italian
-  , season :: Maybe SeasonBase.SeasonBase -- ^ Base season, returned in search results
+  { characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
   , directors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , episodeNumber :: Maybe EpisodeNumber.EpisodeNumber -- ^ Episode number in season
+  , featureLength :: Maybe FeatureLength.FeatureLength -- ^ Whether it's a feature length episode
   , finalScriptDate :: Maybe FinalScriptDate.FinalScriptDate -- ^ Date the episode script was completed
-  , usAirDate :: Maybe UsAirDate.UsAirDate -- ^ Date the episode was first aired in the United States
-  , uid :: Uid.Uid -- ^ Episode unique ID
+  , performers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
+  , productionSerialNumber :: Maybe ProductionSerialNumber.ProductionSerialNumber -- ^ Production serial number
+  , season :: Maybe SeasonBase.SeasonBase -- ^ Base season, returned in search results
+  , seasonNumber :: Maybe SeasonNumber.SeasonNumber -- ^ Season number
+  , series :: Maybe SeriesBase.SeriesBase -- ^ Base series, returned in search results
   , standInPerformers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
   , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of episode story
+  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of episode story
+  , storyAuthors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
   , stuntPerformers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
   , teleplayAuthors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , seasonNumber :: Maybe SeasonNumber.SeasonNumber -- ^ Season number
+  , title :: Title.Title -- ^ Episode title
+  , titleGerman :: Maybe TitleGerman.TitleGerman -- ^ Episode title in German
+  , titleItalian :: Maybe TitleItalian.TitleItalian -- ^ Episode title in Italian
   , titleJapanese :: Maybe TitleJapanese.TitleJapanese -- ^ Episode title in Japanese
+  , uid :: Uid.Uid -- ^ Episode unique ID
+  , usAirDate :: Maybe UsAirDate.UsAirDate -- ^ Date the episode was first aired in the United States
+  , writers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of episode story
   , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of episode story
-  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of episode story
-  , series :: Maybe SeriesBase.SeriesBase -- ^ Base series, returned in search results
-  , performers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
   }
   deriving (Eq, Show)
 
@@ -62,28 +62,28 @@ episodeFullSchema :: FC.Fleece schema => schema EpisodeFull
 episodeFullSchema =
   FC.object $
     FC.constructor EpisodeFull
-      #+ FC.optional "storyAuthors" storyAuthors (FC.list StaffBase.staffBaseSchema)
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "titleGerman" titleGerman TitleGerman.titleGermanSchema
-      #+ FC.optional "episodeNumber" episodeNumber EpisodeNumber.episodeNumberSchema
-      #+ FC.optional "productionSerialNumber" productionSerialNumber ProductionSerialNumber.productionSerialNumberSchema
-      #+ FC.optional "featureLength" featureLength FeatureLength.featureLengthSchema
-      #+ FC.optional "writers" writers (FC.list StaffBase.staffBaseSchema)
       #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.optional "titleItalian" titleItalian TitleItalian.titleItalianSchema
-      #+ FC.optional "season" season SeasonBase.seasonBaseSchema
       #+ FC.optional "directors" directors (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "episodeNumber" episodeNumber EpisodeNumber.episodeNumberSchema
+      #+ FC.optional "featureLength" featureLength FeatureLength.featureLengthSchema
       #+ FC.optional "finalScriptDate" finalScriptDate FinalScriptDate.finalScriptDateSchema
-      #+ FC.optional "usAirDate" usAirDate UsAirDate.usAirDateSchema
-      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "performers" performers (FC.list PerformerBase.performerBaseSchema)
+      #+ FC.optional "productionSerialNumber" productionSerialNumber ProductionSerialNumber.productionSerialNumberSchema
+      #+ FC.optional "season" season SeasonBase.seasonBaseSchema
+      #+ FC.optional "seasonNumber" seasonNumber SeasonNumber.seasonNumberSchema
+      #+ FC.optional "series" series SeriesBase.seriesBaseSchema
       #+ FC.optional "standInPerformers" standInPerformers (FC.list PerformerBase.performerBaseSchema)
       #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.optional "storyAuthors" storyAuthors (FC.list StaffBase.staffBaseSchema)
       #+ FC.optional "stuntPerformers" stuntPerformers (FC.list PerformerBase.performerBaseSchema)
       #+ FC.optional "teleplayAuthors" teleplayAuthors (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "seasonNumber" seasonNumber SeasonNumber.seasonNumberSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.optional "titleGerman" titleGerman TitleGerman.titleGermanSchema
+      #+ FC.optional "titleItalian" titleItalian TitleItalian.titleItalianSchema
       #+ FC.optional "titleJapanese" titleJapanese TitleJapanese.titleJapaneseSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "usAirDate" usAirDate UsAirDate.usAirDateSchema
+      #+ FC.optional "writers" writers (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
       #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
-      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
-      #+ FC.optional "series" series SeriesBase.seriesBaseSchema
-      #+ FC.optional "performers" performers (FC.list PerformerBase.performerBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Error.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Error.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.Error.Code as Code
 import qualified StarTrek.Types.Error.Message as Message
 
 data Error = Error
-  { message :: Maybe Message.Message -- ^ Error message
-  , code :: Maybe Code.Code -- ^ Error code
+  { code :: Maybe Code.Code -- ^ Error code
+  , message :: Maybe Message.Message -- ^ Error message
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ errorSchema :: FC.Fleece schema => schema Error
 errorSchema =
   FC.object $
     FC.constructor Error
-      #+ FC.optional "message" message Message.messageSchema
       #+ FC.optional "code" code Code.codeSchema
+      #+ FC.optional "message" message Message.messageSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/FoodBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/FoodBase.hs
@@ -22,18 +22,18 @@ import qualified StarTrek.Types.FoodBase.Tea as Tea
 import qualified StarTrek.Types.FoodBase.Uid as Uid
 
 data FoodBase = FoodBase
-  { beverage :: Maybe Beverage.Beverage -- ^ Whether it's a beverage
-  , juice :: Maybe Juice.Juice -- ^ Whether it's a juice
-  , tea :: Maybe Tea.Tea -- ^ Whether it's a tea
-  , earthlyOrigin :: Maybe EarthlyOrigin.EarthlyOrigin -- ^ Whether it's of earthly origin
+  { alcoholicBeverage :: Maybe AlcoholicBeverage.AlcoholicBeverage -- ^ Whether it's an alcoholic beverage
+  , beverage :: Maybe Beverage.Beverage -- ^ Whether it's a beverage
   , dessert :: Maybe Dessert.Dessert -- ^ Whether it's a dessert
-  , sauce :: Maybe Sauce.Sauce -- ^ Whether it's a sauce
-  , uid :: Uid.Uid -- ^ Food unique ID
+  , earthlyOrigin :: Maybe EarthlyOrigin.EarthlyOrigin -- ^ Whether it's of earthly origin
   , fruit :: Maybe Fruit.Fruit -- ^ Whether it's a fruit
-  , name :: Name.Name -- ^ Food name
-  , soup :: Maybe Soup.Soup -- ^ Whether it's a soup
   , herbOrSpice :: Maybe HerbOrSpice.HerbOrSpice -- ^ Whether it's a herb or a spice
-  , alcoholicBeverage :: Maybe AlcoholicBeverage.AlcoholicBeverage -- ^ Whether it's an alcoholic beverage
+  , juice :: Maybe Juice.Juice -- ^ Whether it's a juice
+  , name :: Name.Name -- ^ Food name
+  , sauce :: Maybe Sauce.Sauce -- ^ Whether it's a sauce
+  , soup :: Maybe Soup.Soup -- ^ Whether it's a soup
+  , tea :: Maybe Tea.Tea -- ^ Whether it's a tea
+  , uid :: Uid.Uid -- ^ Food unique ID
   }
   deriving (Eq, Show)
 
@@ -41,15 +41,15 @@ foodBaseSchema :: FC.Fleece schema => schema FoodBase
 foodBaseSchema =
   FC.object $
     FC.constructor FoodBase
-      #+ FC.optional "beverage" beverage Beverage.beverageSchema
-      #+ FC.optional "juice" juice Juice.juiceSchema
-      #+ FC.optional "tea" tea Tea.teaSchema
-      #+ FC.optional "earthlyOrigin" earthlyOrigin EarthlyOrigin.earthlyOriginSchema
-      #+ FC.optional "dessert" dessert Dessert.dessertSchema
-      #+ FC.optional "sauce" sauce Sauce.sauceSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "fruit" fruit Fruit.fruitSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "soup" soup Soup.soupSchema
-      #+ FC.optional "herbOrSpice" herbOrSpice HerbOrSpice.herbOrSpiceSchema
       #+ FC.optional "alcoholicBeverage" alcoholicBeverage AlcoholicBeverage.alcoholicBeverageSchema
+      #+ FC.optional "beverage" beverage Beverage.beverageSchema
+      #+ FC.optional "dessert" dessert Dessert.dessertSchema
+      #+ FC.optional "earthlyOrigin" earthlyOrigin EarthlyOrigin.earthlyOriginSchema
+      #+ FC.optional "fruit" fruit Fruit.fruitSchema
+      #+ FC.optional "herbOrSpice" herbOrSpice HerbOrSpice.herbOrSpiceSchema
+      #+ FC.optional "juice" juice Juice.juiceSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "sauce" sauce Sauce.sauceSchema
+      #+ FC.optional "soup" soup Soup.soupSchema
+      #+ FC.optional "tea" tea Tea.teaSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/FoodBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/FoodBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data FoodBaseResponse = FoodBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , foods :: Maybe [FoodBase.FoodBase] -- ^ Base food, returned in search results
+  { foods :: Maybe [FoodBase.FoodBase] -- ^ Base food, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ foodBaseResponseSchema :: FC.Fleece schema => schema FoodBaseResponse
 foodBaseResponseSchema =
   FC.object $
     FC.constructor FoodBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "foods" foods (FC.list FoodBase.foodBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/FoodFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/FoodFull.hs
@@ -22,18 +22,18 @@ import qualified StarTrek.Types.FoodFull.Tea as Tea
 import qualified StarTrek.Types.FoodFull.Uid as Uid
 
 data FoodFull = FoodFull
-  { beverage :: Maybe Beverage.Beverage -- ^ Whether it's a beverage
-  , juice :: Maybe Juice.Juice -- ^ Whether it's a juice
-  , tea :: Maybe Tea.Tea -- ^ Whether it's a tea
-  , earthlyOrigin :: Maybe EarthlyOrigin.EarthlyOrigin -- ^ Whether it's of earthly origin
+  { alcoholicBeverage :: Maybe AlcoholicBeverage.AlcoholicBeverage -- ^ Whether it's an alcoholic beverage
+  , beverage :: Maybe Beverage.Beverage -- ^ Whether it's a beverage
   , dessert :: Maybe Dessert.Dessert -- ^ Whether it's a dessert
-  , sauce :: Maybe Sauce.Sauce -- ^ Whether it's a sauce
-  , uid :: Uid.Uid -- ^ Food unique ID
+  , earthlyOrigin :: Maybe EarthlyOrigin.EarthlyOrigin -- ^ Whether it's of earthly origin
   , fruit :: Maybe Fruit.Fruit -- ^ Whether it's a fruit
-  , name :: Name.Name -- ^ Food name
-  , soup :: Maybe Soup.Soup -- ^ Whether it's a soup
   , herbOrSpice :: Maybe HerbOrSpice.HerbOrSpice -- ^ Whether it's an herb or a spice
-  , alcoholicBeverage :: Maybe AlcoholicBeverage.AlcoholicBeverage -- ^ Whether it's an alcoholic beverage
+  , juice :: Maybe Juice.Juice -- ^ Whether it's a juice
+  , name :: Name.Name -- ^ Food name
+  , sauce :: Maybe Sauce.Sauce -- ^ Whether it's a sauce
+  , soup :: Maybe Soup.Soup -- ^ Whether it's a soup
+  , tea :: Maybe Tea.Tea -- ^ Whether it's a tea
+  , uid :: Uid.Uid -- ^ Food unique ID
   }
   deriving (Eq, Show)
 
@@ -41,15 +41,15 @@ foodFullSchema :: FC.Fleece schema => schema FoodFull
 foodFullSchema =
   FC.object $
     FC.constructor FoodFull
-      #+ FC.optional "beverage" beverage Beverage.beverageSchema
-      #+ FC.optional "juice" juice Juice.juiceSchema
-      #+ FC.optional "tea" tea Tea.teaSchema
-      #+ FC.optional "earthlyOrigin" earthlyOrigin EarthlyOrigin.earthlyOriginSchema
-      #+ FC.optional "dessert" dessert Dessert.dessertSchema
-      #+ FC.optional "sauce" sauce Sauce.sauceSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "fruit" fruit Fruit.fruitSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "soup" soup Soup.soupSchema
-      #+ FC.optional "herbOrSpice" herbOrSpice HerbOrSpice.herbOrSpiceSchema
       #+ FC.optional "alcoholicBeverage" alcoholicBeverage AlcoholicBeverage.alcoholicBeverageSchema
+      #+ FC.optional "beverage" beverage Beverage.beverageSchema
+      #+ FC.optional "dessert" dessert Dessert.dessertSchema
+      #+ FC.optional "earthlyOrigin" earthlyOrigin EarthlyOrigin.earthlyOriginSchema
+      #+ FC.optional "fruit" fruit Fruit.fruitSchema
+      #+ FC.optional "herbOrSpice" herbOrSpice HerbOrSpice.herbOrSpiceSchema
+      #+ FC.optional "juice" juice Juice.juiceSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "sauce" sauce Sauce.sauceSchema
+      #+ FC.optional "soup" soup Soup.soupSchema
+      #+ FC.optional "tea" tea Tea.teaSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/FoodHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/FoodHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.FoodHeader.Name as Name
 import qualified StarTrek.Types.FoodHeader.Uid as Uid
 
 data FoodHeader = FoodHeader
-  { uid :: Uid.Uid -- ^ Food unique ID
-  , name :: Name.Name -- ^ Food name
+  { name :: Name.Name -- ^ Food name
+  , uid :: Uid.Uid -- ^ Food unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ foodHeaderSchema :: FC.Fleece schema => schema FoodHeader
 foodHeaderSchema =
   FC.object $
     FC.constructor FoodHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Genre.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Genre.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.Genre.Name as Name
 import qualified StarTrek.Types.Genre.Uid as Uid
 
 data Genre = Genre
-  { uid :: Maybe Uid.Uid -- ^ Genre unique ID
-  , name :: Maybe Name.Name -- ^ Genre name
+  { name :: Maybe Name.Name -- ^ Genre name
+  , uid :: Maybe Uid.Uid -- ^ Genre unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ genreSchema :: FC.Fleece schema => schema Genre
 genreSchema =
   FC.object $
     FC.constructor Genre
-      #+ FC.optional "uid" uid Uid.uidSchema
       #+ FC.optional "name" name Name.nameSchema
+      #+ FC.optional "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LiteratureBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LiteratureBase.hs
@@ -18,14 +18,14 @@ import qualified StarTrek.Types.LiteratureBase.Title as Title
 import qualified StarTrek.Types.LiteratureBase.Uid as Uid
 
 data LiteratureBase = LiteratureBase
-  { title :: Title.Title -- ^ Literature title
-  , shakespeareanWork :: Maybe ShakespeareanWork.ShakespeareanWork -- ^ Whether it's a Shakespearean work
-  , earthlyOrigin :: Maybe EarthlyOrigin.EarthlyOrigin -- ^ Whether it's of earthly origin
-  , scientificLiterature :: Maybe ScientificLiterature.ScientificLiterature -- ^ Whether it's a scientific literature
-  , uid :: Uid.Uid -- ^ Literature unique ID
+  { earthlyOrigin :: Maybe EarthlyOrigin.EarthlyOrigin -- ^ Whether it's of earthly origin
   , religiousLiterature :: Maybe ReligiousLiterature.ReligiousLiterature -- ^ Whether it's a religious literature
-  , technicalManual :: Maybe TechnicalManual.TechnicalManual -- ^ Whether it's a technical manual
   , report :: Maybe Report.Report -- ^ Whether it's a report
+  , scientificLiterature :: Maybe ScientificLiterature.ScientificLiterature -- ^ Whether it's a scientific literature
+  , shakespeareanWork :: Maybe ShakespeareanWork.ShakespeareanWork -- ^ Whether it's a Shakespearean work
+  , technicalManual :: Maybe TechnicalManual.TechnicalManual -- ^ Whether it's a technical manual
+  , title :: Title.Title -- ^ Literature title
+  , uid :: Uid.Uid -- ^ Literature unique ID
   }
   deriving (Eq, Show)
 
@@ -33,11 +33,11 @@ literatureBaseSchema :: FC.Fleece schema => schema LiteratureBase
 literatureBaseSchema =
   FC.object $
     FC.constructor LiteratureBase
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "shakespeareanWork" shakespeareanWork ShakespeareanWork.shakespeareanWorkSchema
       #+ FC.optional "earthlyOrigin" earthlyOrigin EarthlyOrigin.earthlyOriginSchema
-      #+ FC.optional "scientificLiterature" scientificLiterature ScientificLiterature.scientificLiteratureSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "religiousLiterature" religiousLiterature ReligiousLiterature.religiousLiteratureSchema
-      #+ FC.optional "technicalManual" technicalManual TechnicalManual.technicalManualSchema
       #+ FC.optional "report" report Report.reportSchema
+      #+ FC.optional "scientificLiterature" scientificLiterature ScientificLiterature.scientificLiteratureSchema
+      #+ FC.optional "shakespeareanWork" shakespeareanWork ShakespeareanWork.shakespeareanWorkSchema
+      #+ FC.optional "technicalManual" technicalManual TechnicalManual.technicalManualSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LiteratureBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LiteratureBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data LiteratureBaseResponse = LiteratureBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , literature :: Maybe [LiteratureBase.LiteratureBase] -- ^ Base literature, returned in search results
+  { literature :: Maybe [LiteratureBase.LiteratureBase] -- ^ Base literature, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ literatureBaseResponseSchema :: FC.Fleece schema => schema LiteratureBaseRespons
 literatureBaseResponseSchema =
   FC.object $
     FC.constructor LiteratureBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "literature" literature (FC.list LiteratureBase.literatureBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LiteratureFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LiteratureFull.hs
@@ -18,14 +18,14 @@ import qualified StarTrek.Types.LiteratureFull.Title as Title
 import qualified StarTrek.Types.LiteratureFull.Uid as Uid
 
 data LiteratureFull = LiteratureFull
-  { title :: Title.Title -- ^ Literature title
-  , shakespeareanWork :: Maybe ShakespeareanWork.ShakespeareanWork -- ^ Whether it's a Shakespearean work
-  , earthlyOrigin :: Maybe EarthlyOrigin.EarthlyOrigin -- ^ Whether it's of earthly origin
-  , scientificLiterature :: Maybe ScientificLiterature.ScientificLiterature -- ^ Whether it's a scientific literature
-  , uid :: Uid.Uid -- ^ Literature unique ID
+  { earthlyOrigin :: Maybe EarthlyOrigin.EarthlyOrigin -- ^ Whether it's of earthly origin
   , religiousLiterature :: Maybe ReligiousLiterature.ReligiousLiterature -- ^ Whether it's a religious literature
-  , technicalManual :: Maybe TechnicalManual.TechnicalManual -- ^ Whether it's a technical manual
   , report :: Maybe Report.Report -- ^ Whether it's a report
+  , scientificLiterature :: Maybe ScientificLiterature.ScientificLiterature -- ^ Whether it's a scientific literature
+  , shakespeareanWork :: Maybe ShakespeareanWork.ShakespeareanWork -- ^ Whether it's a Shakespearean work
+  , technicalManual :: Maybe TechnicalManual.TechnicalManual -- ^ Whether it's a technical manual
+  , title :: Title.Title -- ^ Literature title
+  , uid :: Uid.Uid -- ^ Literature unique ID
   }
   deriving (Eq, Show)
 
@@ -33,11 +33,11 @@ literatureFullSchema :: FC.Fleece schema => schema LiteratureFull
 literatureFullSchema =
   FC.object $
     FC.constructor LiteratureFull
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "shakespeareanWork" shakespeareanWork ShakespeareanWork.shakespeareanWorkSchema
       #+ FC.optional "earthlyOrigin" earthlyOrigin EarthlyOrigin.earthlyOriginSchema
-      #+ FC.optional "scientificLiterature" scientificLiterature ScientificLiterature.scientificLiteratureSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "religiousLiterature" religiousLiterature ReligiousLiterature.religiousLiteratureSchema
-      #+ FC.optional "technicalManual" technicalManual TechnicalManual.technicalManualSchema
       #+ FC.optional "report" report Report.reportSchema
+      #+ FC.optional "scientificLiterature" scientificLiterature ScientificLiterature.scientificLiteratureSchema
+      #+ FC.optional "shakespeareanWork" shakespeareanWork ShakespeareanWork.shakespeareanWorkSchema
+      #+ FC.optional "technicalManual" technicalManual TechnicalManual.technicalManualSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LocationBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LocationBase.hs
@@ -35,31 +35,31 @@ import qualified StarTrek.Types.LocationBase.Uid as Uid
 import qualified StarTrek.Types.LocationBase.UsSettlement as UsSettlement
 
 data LocationBase = LocationBase
-  { usSettlement :: Maybe UsSettlement.UsSettlement -- ^ Whether it's a US settlement
-  , buildingInterior :: Maybe BuildingInterior.BuildingInterior -- ^ Whether it's a building interior
-  , subnationalEntity :: Maybe SubnationalEntity.SubnationalEntity -- ^ Whether it's a subnational entity
-  , landmark :: Maybe Landmark.Landmark -- ^ Whether it's a landmark
-  , geographicalLocation :: Maybe GeographicalLocation.GeographicalLocation -- ^ Whether it's a geographical location
-  , mirror :: Maybe Mirror.Mirror -- ^ Whether this location is from mirror universe
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this location is from alternate reality
-  , structure :: Maybe Structure.Structure -- ^ Whether it's a structure
-  , landform :: Maybe Landform.Landform -- ^ Whether it's a landform
-  , religiousLocation :: Maybe ReligiousLocation.ReligiousLocation -- ^ Whether it's a religious location
-  , school :: Maybe School.School -- ^ Whether it's a school
-  , ds9Establishment :: Maybe Ds9Establishment.Ds9Establishment -- ^ Whether it's a DS9 establishment
-  , establishment :: Maybe Establishment.Establishment -- ^ Whether it's a establishment
-  , shipyard :: Maybe Shipyard.Shipyard -- ^ Whether it's a shipyard
-  , country :: Maybe Country.Country -- ^ Whether it's a country
-  , fictionalLocation :: Maybe FictionalLocation.FictionalLocation -- ^ Whether it's a fictional location
-  , uid :: Uid.Uid -- ^ Location unique ID
-  , colony :: Maybe Colony.Colony -- ^ Whether it's a colony
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this location is from alternate reality
   , bajoranSettlement :: Maybe BajoranSettlement.BajoranSettlement -- ^ Whether it's a Bajoran settlement
-  , settlement :: Maybe Settlement.Settlement -- ^ Whether it's a settlement
-  , name :: Name.Name -- ^ Location name
   , bodyOfWater :: Maybe BodyOfWater.BodyOfWater -- ^ Whether it's a body of water
-  , road :: Maybe Road.Road -- ^ Whether it's a road
-  , medicalEstablishment :: Maybe MedicalEstablishment.MedicalEstablishment -- ^ Whether it's a medical establishment
+  , buildingInterior :: Maybe BuildingInterior.BuildingInterior -- ^ Whether it's a building interior
+  , colony :: Maybe Colony.Colony -- ^ Whether it's a colony
+  , country :: Maybe Country.Country -- ^ Whether it's a country
+  , ds9Establishment :: Maybe Ds9Establishment.Ds9Establishment -- ^ Whether it's a DS9 establishment
   , earthlyLocation :: Maybe EarthlyLocation.EarthlyLocation -- ^ Whether it's an earthly location
+  , establishment :: Maybe Establishment.Establishment -- ^ Whether it's a establishment
+  , fictionalLocation :: Maybe FictionalLocation.FictionalLocation -- ^ Whether it's a fictional location
+  , geographicalLocation :: Maybe GeographicalLocation.GeographicalLocation -- ^ Whether it's a geographical location
+  , landform :: Maybe Landform.Landform -- ^ Whether it's a landform
+  , landmark :: Maybe Landmark.Landmark -- ^ Whether it's a landmark
+  , medicalEstablishment :: Maybe MedicalEstablishment.MedicalEstablishment -- ^ Whether it's a medical establishment
+  , mirror :: Maybe Mirror.Mirror -- ^ Whether this location is from mirror universe
+  , name :: Name.Name -- ^ Location name
+  , religiousLocation :: Maybe ReligiousLocation.ReligiousLocation -- ^ Whether it's a religious location
+  , road :: Maybe Road.Road -- ^ Whether it's a road
+  , school :: Maybe School.School -- ^ Whether it's a school
+  , settlement :: Maybe Settlement.Settlement -- ^ Whether it's a settlement
+  , shipyard :: Maybe Shipyard.Shipyard -- ^ Whether it's a shipyard
+  , structure :: Maybe Structure.Structure -- ^ Whether it's a structure
+  , subnationalEntity :: Maybe SubnationalEntity.SubnationalEntity -- ^ Whether it's a subnational entity
+  , uid :: Uid.Uid -- ^ Location unique ID
+  , usSettlement :: Maybe UsSettlement.UsSettlement -- ^ Whether it's a US settlement
   }
   deriving (Eq, Show)
 
@@ -67,28 +67,28 @@ locationBaseSchema :: FC.Fleece schema => schema LocationBase
 locationBaseSchema =
   FC.object $
     FC.constructor LocationBase
-      #+ FC.optional "usSettlement" usSettlement UsSettlement.usSettlementSchema
-      #+ FC.optional "buildingInterior" buildingInterior BuildingInterior.buildingInteriorSchema
-      #+ FC.optional "subnationalEntity" subnationalEntity SubnationalEntity.subnationalEntitySchema
-      #+ FC.optional "landmark" landmark Landmark.landmarkSchema
-      #+ FC.optional "geographicalLocation" geographicalLocation GeographicalLocation.geographicalLocationSchema
-      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
-      #+ FC.optional "structure" structure Structure.structureSchema
-      #+ FC.optional "landform" landform Landform.landformSchema
-      #+ FC.optional "religiousLocation" religiousLocation ReligiousLocation.religiousLocationSchema
-      #+ FC.optional "school" school School.schoolSchema
-      #+ FC.optional "ds9Establishment" ds9Establishment Ds9Establishment.ds9EstablishmentSchema
-      #+ FC.optional "establishment" establishment Establishment.establishmentSchema
-      #+ FC.optional "shipyard" shipyard Shipyard.shipyardSchema
-      #+ FC.optional "country" country Country.countrySchema
-      #+ FC.optional "fictionalLocation" fictionalLocation FictionalLocation.fictionalLocationSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "colony" colony Colony.colonySchema
       #+ FC.optional "bajoranSettlement" bajoranSettlement BajoranSettlement.bajoranSettlementSchema
-      #+ FC.optional "settlement" settlement Settlement.settlementSchema
-      #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "bodyOfWater" bodyOfWater BodyOfWater.bodyOfWaterSchema
-      #+ FC.optional "road" road Road.roadSchema
-      #+ FC.optional "medicalEstablishment" medicalEstablishment MedicalEstablishment.medicalEstablishmentSchema
+      #+ FC.optional "buildingInterior" buildingInterior BuildingInterior.buildingInteriorSchema
+      #+ FC.optional "colony" colony Colony.colonySchema
+      #+ FC.optional "country" country Country.countrySchema
+      #+ FC.optional "ds9Establishment" ds9Establishment Ds9Establishment.ds9EstablishmentSchema
       #+ FC.optional "earthlyLocation" earthlyLocation EarthlyLocation.earthlyLocationSchema
+      #+ FC.optional "establishment" establishment Establishment.establishmentSchema
+      #+ FC.optional "fictionalLocation" fictionalLocation FictionalLocation.fictionalLocationSchema
+      #+ FC.optional "geographicalLocation" geographicalLocation GeographicalLocation.geographicalLocationSchema
+      #+ FC.optional "landform" landform Landform.landformSchema
+      #+ FC.optional "landmark" landmark Landmark.landmarkSchema
+      #+ FC.optional "medicalEstablishment" medicalEstablishment MedicalEstablishment.medicalEstablishmentSchema
+      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "religiousLocation" religiousLocation ReligiousLocation.religiousLocationSchema
+      #+ FC.optional "road" road Road.roadSchema
+      #+ FC.optional "school" school School.schoolSchema
+      #+ FC.optional "settlement" settlement Settlement.settlementSchema
+      #+ FC.optional "shipyard" shipyard Shipyard.shipyardSchema
+      #+ FC.optional "structure" structure Structure.structureSchema
+      #+ FC.optional "subnationalEntity" subnationalEntity SubnationalEntity.subnationalEntitySchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "usSettlement" usSettlement UsSettlement.usSettlementSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LocationBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LocationBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data LocationBaseResponse = LocationBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , locations :: Maybe [LocationBase.LocationBase] -- ^ Base location, returned in search results
+  { locations :: Maybe [LocationBase.LocationBase] -- ^ Base location, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ locationBaseResponseSchema :: FC.Fleece schema => schema LocationBaseResponse
 locationBaseResponseSchema =
   FC.object $
     FC.constructor LocationBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "locations" locations (FC.list LocationBase.locationBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LocationFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LocationFull.hs
@@ -35,31 +35,31 @@ import qualified StarTrek.Types.LocationFull.Uid as Uid
 import qualified StarTrek.Types.LocationFull.UsSettlement as UsSettlement
 
 data LocationFull = LocationFull
-  { usSettlement :: Maybe UsSettlement.UsSettlement -- ^ Whether it's a US settlement
-  , buildingInterior :: Maybe BuildingInterior.BuildingInterior -- ^ Whether it's a building interior
-  , subnationalEntity :: Maybe SubnationalEntity.SubnationalEntity -- ^ Whether it's a subnational entity
-  , landmark :: Maybe Landmark.Landmark -- ^ Whether it's a landmark
-  , geographicalLocation :: Maybe GeographicalLocation.GeographicalLocation -- ^ Whether it's a geographical location
-  , mirror :: Maybe Mirror.Mirror -- ^ Whether this location is from mirror universe
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this location is from alternate reality
-  , structure :: Maybe Structure.Structure -- ^ Whether it's a structure
-  , landform :: Maybe Landform.Landform -- ^ Whether it's a landform
-  , religiousLocation :: Maybe ReligiousLocation.ReligiousLocation -- ^ Whether it's a religious location
-  , school :: Maybe School.School -- ^ Whether it's a school
-  , ds9Establishment :: Maybe Ds9Establishment.Ds9Establishment -- ^ Whether it's a DS9 establishment
-  , establishment :: Maybe Establishment.Establishment -- ^ Whether it's a establishment
-  , shipyard :: Maybe Shipyard.Shipyard -- ^ Whether it's a shipyard
-  , country :: Maybe Country.Country -- ^ Whether it's a country
-  , fictionalLocation :: Maybe FictionalLocation.FictionalLocation -- ^ Whether it's a fictional location
-  , uid :: Uid.Uid -- ^ Location unique ID
-  , colony :: Maybe Colony.Colony -- ^ Whether it's a colony
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this location is from alternate reality
   , bajoranSettlement :: Maybe BajoranSettlement.BajoranSettlement -- ^ Whether it's a Bajoran settlement
-  , settlement :: Maybe Settlement.Settlement -- ^ Whether it's a settlement
-  , name :: Name.Name -- ^ Location name
   , bodyOfWater :: Maybe BodyOfWater.BodyOfWater -- ^ Whether it's a body of water
-  , road :: Maybe Road.Road -- ^ Whether it's a road
-  , medicalEstablishment :: Maybe MedicalEstablishment.MedicalEstablishment -- ^ Whether it's a medical establishment
+  , buildingInterior :: Maybe BuildingInterior.BuildingInterior -- ^ Whether it's a building interior
+  , colony :: Maybe Colony.Colony -- ^ Whether it's a colony
+  , country :: Maybe Country.Country -- ^ Whether it's a country
+  , ds9Establishment :: Maybe Ds9Establishment.Ds9Establishment -- ^ Whether it's a DS9 establishment
   , earthlyLocation :: Maybe EarthlyLocation.EarthlyLocation -- ^ Whether it's an earthly location
+  , establishment :: Maybe Establishment.Establishment -- ^ Whether it's a establishment
+  , fictionalLocation :: Maybe FictionalLocation.FictionalLocation -- ^ Whether it's a fictional location
+  , geographicalLocation :: Maybe GeographicalLocation.GeographicalLocation -- ^ Whether it's a geographical location
+  , landform :: Maybe Landform.Landform -- ^ Whether it's a landform
+  , landmark :: Maybe Landmark.Landmark -- ^ Whether it's a landmark
+  , medicalEstablishment :: Maybe MedicalEstablishment.MedicalEstablishment -- ^ Whether it's a medical establishment
+  , mirror :: Maybe Mirror.Mirror -- ^ Whether this location is from mirror universe
+  , name :: Name.Name -- ^ Location name
+  , religiousLocation :: Maybe ReligiousLocation.ReligiousLocation -- ^ Whether it's a religious location
+  , road :: Maybe Road.Road -- ^ Whether it's a road
+  , school :: Maybe School.School -- ^ Whether it's a school
+  , settlement :: Maybe Settlement.Settlement -- ^ Whether it's a settlement
+  , shipyard :: Maybe Shipyard.Shipyard -- ^ Whether it's a shipyard
+  , structure :: Maybe Structure.Structure -- ^ Whether it's a structure
+  , subnationalEntity :: Maybe SubnationalEntity.SubnationalEntity -- ^ Whether it's a subnational entity
+  , uid :: Uid.Uid -- ^ Location unique ID
+  , usSettlement :: Maybe UsSettlement.UsSettlement -- ^ Whether it's a US settlement
   }
   deriving (Eq, Show)
 
@@ -67,28 +67,28 @@ locationFullSchema :: FC.Fleece schema => schema LocationFull
 locationFullSchema =
   FC.object $
     FC.constructor LocationFull
-      #+ FC.optional "usSettlement" usSettlement UsSettlement.usSettlementSchema
-      #+ FC.optional "buildingInterior" buildingInterior BuildingInterior.buildingInteriorSchema
-      #+ FC.optional "subnationalEntity" subnationalEntity SubnationalEntity.subnationalEntitySchema
-      #+ FC.optional "landmark" landmark Landmark.landmarkSchema
-      #+ FC.optional "geographicalLocation" geographicalLocation GeographicalLocation.geographicalLocationSchema
-      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
-      #+ FC.optional "structure" structure Structure.structureSchema
-      #+ FC.optional "landform" landform Landform.landformSchema
-      #+ FC.optional "religiousLocation" religiousLocation ReligiousLocation.religiousLocationSchema
-      #+ FC.optional "school" school School.schoolSchema
-      #+ FC.optional "ds9Establishment" ds9Establishment Ds9Establishment.ds9EstablishmentSchema
-      #+ FC.optional "establishment" establishment Establishment.establishmentSchema
-      #+ FC.optional "shipyard" shipyard Shipyard.shipyardSchema
-      #+ FC.optional "country" country Country.countrySchema
-      #+ FC.optional "fictionalLocation" fictionalLocation FictionalLocation.fictionalLocationSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "colony" colony Colony.colonySchema
       #+ FC.optional "bajoranSettlement" bajoranSettlement BajoranSettlement.bajoranSettlementSchema
-      #+ FC.optional "settlement" settlement Settlement.settlementSchema
-      #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "bodyOfWater" bodyOfWater BodyOfWater.bodyOfWaterSchema
-      #+ FC.optional "road" road Road.roadSchema
-      #+ FC.optional "medicalEstablishment" medicalEstablishment MedicalEstablishment.medicalEstablishmentSchema
+      #+ FC.optional "buildingInterior" buildingInterior BuildingInterior.buildingInteriorSchema
+      #+ FC.optional "colony" colony Colony.colonySchema
+      #+ FC.optional "country" country Country.countrySchema
+      #+ FC.optional "ds9Establishment" ds9Establishment Ds9Establishment.ds9EstablishmentSchema
       #+ FC.optional "earthlyLocation" earthlyLocation EarthlyLocation.earthlyLocationSchema
+      #+ FC.optional "establishment" establishment Establishment.establishmentSchema
+      #+ FC.optional "fictionalLocation" fictionalLocation FictionalLocation.fictionalLocationSchema
+      #+ FC.optional "geographicalLocation" geographicalLocation GeographicalLocation.geographicalLocationSchema
+      #+ FC.optional "landform" landform Landform.landformSchema
+      #+ FC.optional "landmark" landmark Landmark.landmarkSchema
+      #+ FC.optional "medicalEstablishment" medicalEstablishment MedicalEstablishment.medicalEstablishmentSchema
+      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "religiousLocation" religiousLocation ReligiousLocation.religiousLocationSchema
+      #+ FC.optional "road" road Road.roadSchema
+      #+ FC.optional "school" school School.schoolSchema
+      #+ FC.optional "settlement" settlement Settlement.settlementSchema
+      #+ FC.optional "shipyard" shipyard Shipyard.shipyardSchema
+      #+ FC.optional "structure" structure Structure.structureSchema
+      #+ FC.optional "subnationalEntity" subnationalEntity SubnationalEntity.subnationalEntitySchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "usSettlement" usSettlement UsSettlement.usSettlementSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LocationHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/LocationHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.LocationHeader.Name as Name
 import qualified StarTrek.Types.LocationHeader.Uid as Uid
 
 data LocationHeader = LocationHeader
-  { uid :: Uid.Uid -- ^ Location unique ID
-  , name :: Name.Name -- ^ Location name
+  { name :: Name.Name -- ^ Location name
+  , uid :: Uid.Uid -- ^ Location unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ locationHeaderSchema :: FC.Fleece schema => schema LocationHeader
 locationHeaderSchema =
   FC.object $
     FC.constructor LocationHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MagazineBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MagazineBase.hs
@@ -20,16 +20,16 @@ import qualified StarTrek.Types.MagazineBase.Title as Title
 import qualified StarTrek.Types.MagazineBase.Uid as Uid
 
 data MagazineBase = MagazineBase
-  { coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
-  , title :: Title.Title -- ^ Magazine title
-  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the magazine was published
+  { coverDay :: Maybe CoverDay.CoverDay -- ^ Cover publication day
+  , coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
   , coverYear :: Maybe CoverYear.CoverYear -- ^ Cover publication year
-  , uid :: Uid.Uid -- ^ Magazine unique ID
-  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
-  , coverDay :: Maybe CoverDay.CoverDay -- ^ Cover publication day
-  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the magazine was published
   , issueNumber :: Maybe IssueNumber.IssueNumber -- ^ Magazine issue number
+  , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
+  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the magazine was published
   , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the magazine was published
+  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the magazine was published
+  , title :: Title.Title -- ^ Magazine title
+  , uid :: Uid.Uid -- ^ Magazine unique ID
   }
   deriving (Eq, Show)
 
@@ -37,13 +37,13 @@ magazineBaseSchema :: FC.Fleece schema => schema MagazineBase
 magazineBaseSchema =
   FC.object $
     FC.constructor MagazineBase
-      #+ FC.optional "coverMonth" coverMonth CoverMonth.coverMonthSchema
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
-      #+ FC.optional "coverYear" coverYear CoverYear.coverYearSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
       #+ FC.optional "coverDay" coverDay CoverDay.coverDaySchema
-      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
+      #+ FC.optional "coverMonth" coverMonth CoverMonth.coverMonthSchema
+      #+ FC.optional "coverYear" coverYear CoverYear.coverYearSchema
       #+ FC.optional "issueNumber" issueNumber IssueNumber.issueNumberSchema
+      #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
+      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
       #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
+      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MagazineFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MagazineFull.hs
@@ -23,19 +23,19 @@ import qualified StarTrek.Types.MagazineSeriesBase as MagazineSeriesBase
 import qualified StarTrek.Types.StaffBase as StaffBase
 
 data MagazineFull = MagazineFull
-  { coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
-  , title :: Title.Title -- ^ Magazine title
-  , editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the magazine was published
+  { coverDay :: Maybe CoverDay.CoverDay -- ^ Cover publication day
+  , coverMonth :: Maybe CoverMonth.CoverMonth -- ^ Cover publication month
   , coverYear :: Maybe CoverYear.CoverYear -- ^ Cover publication year
-  , uid :: Uid.Uid -- ^ Magazine unique ID
+  , editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , issueNumber :: Maybe IssueNumber.IssueNumber -- ^ Magazine issue number
   , magazineSeries :: Maybe [MagazineSeriesBase.MagazineSeriesBase] -- ^ Base magazine series, returned in search results
   , numberOfPages :: Maybe NumberOfPages.NumberOfPages -- ^ Number of pages
-  , coverDay :: Maybe CoverDay.CoverDay -- ^ Cover publication day
-  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
-  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the magazine was published
-  , issueNumber :: Maybe IssueNumber.IssueNumber -- ^ Magazine issue number
+  , publishedDay :: Maybe PublishedDay.PublishedDay -- ^ Day the magazine was published
   , publishedMonth :: Maybe PublishedMonth.PublishedMonth -- ^ Month the magazine was published
+  , publishedYear :: Maybe PublishedYear.PublishedYear -- ^ Year the magazine was published
+  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  , title :: Title.Title -- ^ Magazine title
+  , uid :: Uid.Uid -- ^ Magazine unique ID
   }
   deriving (Eq, Show)
 
@@ -43,16 +43,16 @@ magazineFullSchema :: FC.Fleece schema => schema MagazineFull
 magazineFullSchema =
   FC.object $
     FC.constructor MagazineFull
+      #+ FC.optional "coverDay" coverDay CoverDay.coverDaySchema
       #+ FC.optional "coverMonth" coverMonth CoverMonth.coverMonthSchema
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "editors" editors (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
       #+ FC.optional "coverYear" coverYear CoverYear.coverYearSchema
-      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "editors" editors (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "issueNumber" issueNumber IssueNumber.issueNumberSchema
       #+ FC.optional "magazineSeries" magazineSeries (FC.list MagazineSeriesBase.magazineSeriesBaseSchema)
       #+ FC.optional "numberOfPages" numberOfPages NumberOfPages.numberOfPagesSchema
-      #+ FC.optional "coverDay" coverDay CoverDay.coverDaySchema
-      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
-      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
-      #+ FC.optional "issueNumber" issueNumber IssueNumber.issueNumberSchema
+      #+ FC.optional "publishedDay" publishedDay PublishedDay.publishedDaySchema
       #+ FC.optional "publishedMonth" publishedMonth PublishedMonth.publishedMonthSchema
+      #+ FC.optional "publishedYear" publishedYear PublishedYear.publishedYearSchema
+      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MagazineSeriesBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MagazineSeriesBase.hs
@@ -17,13 +17,13 @@ import qualified StarTrek.Types.MagazineSeriesBase.Title as Title
 import qualified StarTrek.Types.MagazineSeriesBase.Uid as Uid
 
 data MagazineSeriesBase = MagazineSeriesBase
-  { title :: Title.Title -- ^ Magazine series title
+  { numberOfIssues :: Maybe NumberOfIssues.NumberOfIssues -- ^ Number of issues
   , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the magazine series was published
-  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the magazine series was published
-  , uid :: Uid.Uid -- ^ Magazine series unique ID
   , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the magazine series was published
-  , numberOfIssues :: Maybe NumberOfIssues.NumberOfIssues -- ^ Number of issues
+  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the magazine series was published
   , publishedYearTo :: Maybe PublishedYearTo.PublishedYearTo -- ^ Year to which the magazine series was published
+  , title :: Title.Title -- ^ Magazine series title
+  , uid :: Uid.Uid -- ^ Magazine series unique ID
   }
   deriving (Eq, Show)
 
@@ -31,10 +31,10 @@ magazineSeriesBaseSchema :: FC.Fleece schema => schema MagazineSeriesBase
 magazineSeriesBaseSchema =
   FC.object $
     FC.constructor MagazineSeriesBase
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
-      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
       #+ FC.optional "numberOfIssues" numberOfIssues NumberOfIssues.numberOfIssuesSchema
+      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
+      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
+      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
       #+ FC.optional "publishedYearTo" publishedYearTo PublishedYearTo.publishedYearToSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MagazineSeriesBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MagazineSeriesBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data MagazineSeriesBaseResponse = MagazineSeriesBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , magazineSeries :: Maybe [MagazineSeriesBase.MagazineSeriesBase] -- ^ Base magazine series, returned in search results
+  { magazineSeries :: Maybe [MagazineSeriesBase.MagazineSeriesBase] -- ^ Base magazine series, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ magazineSeriesBaseResponseSchema :: FC.Fleece schema => schema MagazineSeriesBas
 magazineSeriesBaseResponseSchema =
   FC.object $
     FC.constructor MagazineSeriesBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "magazineSeries" magazineSeries (FC.list MagazineSeriesBase.magazineSeriesBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MagazineSeriesFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MagazineSeriesFull.hs
@@ -20,16 +20,16 @@ import qualified StarTrek.Types.MagazineSeriesFull.Uid as Uid
 import qualified StarTrek.Types.StaffBase as StaffBase
 
 data MagazineSeriesFull = MagazineSeriesFull
-  { magazines :: Maybe [MagazineBase.MagazineBase] -- ^ Base magazine, returned in search results
-  , title :: Title.Title -- ^ Magazine series title
-  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the magazine series was published
-  , editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the magazine series was published
-  , uid :: Uid.Uid -- ^ Magazine series unique ID
-  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
-  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the magazine series was published
+  { editors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , magazines :: Maybe [MagazineBase.MagazineBase] -- ^ Base magazine, returned in search results
   , numberOfIssues :: Maybe NumberOfIssues.NumberOfIssues -- ^ Number of issues
+  , publishedMonthFrom :: Maybe PublishedMonthFrom.PublishedMonthFrom -- ^ Month from which the magazine series was published
+  , publishedMonthTo :: Maybe PublishedMonthTo.PublishedMonthTo -- ^ Month to which the magazine series was published
+  , publishedYearFrom :: Maybe PublishedYearFrom.PublishedYearFrom -- ^ Year from which the magazine series was published
   , publishedYearTo :: Maybe PublishedYearTo.PublishedYearTo -- ^ Year to which the magazine series was published
+  , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  , title :: Title.Title -- ^ Magazine series title
+  , uid :: Uid.Uid -- ^ Magazine series unique ID
   }
   deriving (Eq, Show)
 
@@ -37,13 +37,13 @@ magazineSeriesFullSchema :: FC.Fleece schema => schema MagazineSeriesFull
 magazineSeriesFullSchema =
   FC.object $
     FC.constructor MagazineSeriesFull
-      #+ FC.optional "magazines" magazines (FC.list MagazineBase.magazineBaseSchema)
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
       #+ FC.optional "editors" editors (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
-      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
+      #+ FC.optional "magazines" magazines (FC.list MagazineBase.magazineBaseSchema)
       #+ FC.optional "numberOfIssues" numberOfIssues NumberOfIssues.numberOfIssuesSchema
+      #+ FC.optional "publishedMonthFrom" publishedMonthFrom PublishedMonthFrom.publishedMonthFromSchema
+      #+ FC.optional "publishedMonthTo" publishedMonthTo PublishedMonthTo.publishedMonthToSchema
+      #+ FC.optional "publishedYearFrom" publishedYearFrom PublishedYearFrom.publishedYearFromSchema
       #+ FC.optional "publishedYearTo" publishedYearTo PublishedYearTo.publishedYearToSchema
+      #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaterialBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaterialBase.hs
@@ -22,18 +22,18 @@ import qualified StarTrek.Types.MaterialBase.PreciousMaterial as PreciousMateria
 import qualified StarTrek.Types.MaterialBase.Uid as Uid
 
 data MaterialBase = MaterialBase
-  { biochemicalCompound :: Maybe BiochemicalCompound.BiochemicalCompound -- ^ Whether it's a biochemical compound
+  { alloyOrComposite :: Maybe AlloyOrComposite.AlloyOrComposite -- ^ Whether it's an alloy or a composite
+  , biochemicalCompound :: Maybe BiochemicalCompound.BiochemicalCompound -- ^ Whether it's a biochemical compound
   , chemicalCompound :: Maybe ChemicalCompound.ChemicalCompound -- ^ Whether it's a chemical compound
   , drug :: Maybe Drug.Drug -- ^ Whether it's a drug
-  , poisonousSubstance :: Maybe PoisonousSubstance.PoisonousSubstance -- ^ Whether it's a poisonous substance
-  , fuel :: Maybe Fuel.Fuel -- ^ Whether it's a fuel
-  , uid :: Uid.Uid -- ^ Material unique ID
-  , mineral :: Maybe Mineral.Mineral -- ^ Whether it's a mineral
-  , alloyOrComposite :: Maybe AlloyOrComposite.AlloyOrComposite -- ^ Whether it's an alloy or a composite
-  , name :: Name.Name -- ^ Material name
   , explosive :: Maybe Explosive.Explosive -- ^ Whether it's an explosive
+  , fuel :: Maybe Fuel.Fuel -- ^ Whether it's a fuel
   , gemstone :: Maybe Gemstone.Gemstone -- ^ Whether it's a gemstone
+  , mineral :: Maybe Mineral.Mineral -- ^ Whether it's a mineral
+  , name :: Name.Name -- ^ Material name
+  , poisonousSubstance :: Maybe PoisonousSubstance.PoisonousSubstance -- ^ Whether it's a poisonous substance
   , preciousMaterial :: Maybe PreciousMaterial.PreciousMaterial -- ^ Whether it's a precious material
+  , uid :: Uid.Uid -- ^ Material unique ID
   }
   deriving (Eq, Show)
 
@@ -41,15 +41,15 @@ materialBaseSchema :: FC.Fleece schema => schema MaterialBase
 materialBaseSchema =
   FC.object $
     FC.constructor MaterialBase
+      #+ FC.optional "alloyOrComposite" alloyOrComposite AlloyOrComposite.alloyOrCompositeSchema
       #+ FC.optional "biochemicalCompound" biochemicalCompound BiochemicalCompound.biochemicalCompoundSchema
       #+ FC.optional "chemicalCompound" chemicalCompound ChemicalCompound.chemicalCompoundSchema
       #+ FC.optional "drug" drug Drug.drugSchema
-      #+ FC.optional "poisonousSubstance" poisonousSubstance PoisonousSubstance.poisonousSubstanceSchema
-      #+ FC.optional "fuel" fuel Fuel.fuelSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "mineral" mineral Mineral.mineralSchema
-      #+ FC.optional "alloyOrComposite" alloyOrComposite AlloyOrComposite.alloyOrCompositeSchema
-      #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "explosive" explosive Explosive.explosiveSchema
+      #+ FC.optional "fuel" fuel Fuel.fuelSchema
       #+ FC.optional "gemstone" gemstone Gemstone.gemstoneSchema
+      #+ FC.optional "mineral" mineral Mineral.mineralSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "poisonousSubstance" poisonousSubstance PoisonousSubstance.poisonousSubstanceSchema
       #+ FC.optional "preciousMaterial" preciousMaterial PreciousMaterial.preciousMaterialSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaterialBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaterialBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data MaterialBaseResponse = MaterialBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , materials :: Maybe [MaterialBase.MaterialBase] -- ^ Base material, returned in search results
+  { materials :: Maybe [MaterialBase.MaterialBase] -- ^ Base material, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ materialBaseResponseSchema :: FC.Fleece schema => schema MaterialBaseResponse
 materialBaseResponseSchema =
   FC.object $
     FC.constructor MaterialBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "materials" materials (FC.list MaterialBase.materialBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaterialFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaterialFull.hs
@@ -22,18 +22,18 @@ import qualified StarTrek.Types.MaterialFull.PreciousMaterial as PreciousMateria
 import qualified StarTrek.Types.MaterialFull.Uid as Uid
 
 data MaterialFull = MaterialFull
-  { biochemicalCompound :: Maybe BiochemicalCompound.BiochemicalCompound -- ^ Whether it's a biochemical compound
+  { alloyOrComposite :: Maybe AlloyOrComposite.AlloyOrComposite -- ^ Whether it's an alloy or a composite
+  , biochemicalCompound :: Maybe BiochemicalCompound.BiochemicalCompound -- ^ Whether it's a biochemical compound
   , chemicalCompound :: Maybe ChemicalCompound.ChemicalCompound -- ^ Whether it's a chemical compound
   , drug :: Maybe Drug.Drug -- ^ Whether it's a drug
-  , poisonousSubstance :: Maybe PoisonousSubstance.PoisonousSubstance -- ^ Whether it's a poisonous substance
-  , fuel :: Maybe Fuel.Fuel -- ^ Whether it's a fuel
-  , uid :: Uid.Uid -- ^ Material unique ID
-  , mineral :: Maybe Mineral.Mineral -- ^ Whether it's a mineral
-  , alloyOrComposite :: Maybe AlloyOrComposite.AlloyOrComposite -- ^ Whether it's an alloy or a composite
-  , name :: Name.Name -- ^ Material name
   , explosive :: Maybe Explosive.Explosive -- ^ Whether it's an explosive
+  , fuel :: Maybe Fuel.Fuel -- ^ Whether it's a fuel
   , gemstone :: Maybe Gemstone.Gemstone -- ^ Whether it's a gemstone
+  , mineral :: Maybe Mineral.Mineral -- ^ Whether it's a mineral
+  , name :: Name.Name -- ^ Material name
+  , poisonousSubstance :: Maybe PoisonousSubstance.PoisonousSubstance -- ^ Whether it's a poisonous substance
   , preciousMaterial :: Maybe PreciousMaterial.PreciousMaterial -- ^ Whether it's a precious material
+  , uid :: Uid.Uid -- ^ Material unique ID
   }
   deriving (Eq, Show)
 
@@ -41,15 +41,15 @@ materialFullSchema :: FC.Fleece schema => schema MaterialFull
 materialFullSchema =
   FC.object $
     FC.constructor MaterialFull
+      #+ FC.optional "alloyOrComposite" alloyOrComposite AlloyOrComposite.alloyOrCompositeSchema
       #+ FC.optional "biochemicalCompound" biochemicalCompound BiochemicalCompound.biochemicalCompoundSchema
       #+ FC.optional "chemicalCompound" chemicalCompound ChemicalCompound.chemicalCompoundSchema
       #+ FC.optional "drug" drug Drug.drugSchema
-      #+ FC.optional "poisonousSubstance" poisonousSubstance PoisonousSubstance.poisonousSubstanceSchema
-      #+ FC.optional "fuel" fuel Fuel.fuelSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "mineral" mineral Mineral.mineralSchema
-      #+ FC.optional "alloyOrComposite" alloyOrComposite AlloyOrComposite.alloyOrCompositeSchema
-      #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "explosive" explosive Explosive.explosiveSchema
+      #+ FC.optional "fuel" fuel Fuel.fuelSchema
       #+ FC.optional "gemstone" gemstone Gemstone.gemstoneSchema
+      #+ FC.optional "mineral" mineral Mineral.mineralSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "poisonousSubstance" poisonousSubstance PoisonousSubstance.poisonousSubstanceSchema
       #+ FC.optional "preciousMaterial" preciousMaterial PreciousMaterial.preciousMaterialSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaterialHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaterialHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.MaterialHeader.Name as Name
 import qualified StarTrek.Types.MaterialHeader.Uid as Uid
 
 data MaterialHeader = MaterialHeader
-  { uid :: Uid.Uid -- ^ Material unique ID
-  , name :: Name.Name -- ^ Material name
+  { name :: Name.Name -- ^ Material name
+  , uid :: Uid.Uid -- ^ Material unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ materialHeaderSchema :: FC.Fleece schema => schema MaterialHeader
 materialHeaderSchema =
   FC.object $
     FC.constructor MaterialHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MedicalConditionBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MedicalConditionBase.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.MedicalConditionBase.PsychologicalCondition as P
 import qualified StarTrek.Types.MedicalConditionBase.Uid as Uid
 
 data MedicalConditionBase = MedicalConditionBase
-  { uid :: Uid.Uid -- ^ Medical condition unique ID
-  , name :: Name.Name -- ^ Medical condition name
+  { name :: Name.Name -- ^ Medical condition name
   , psychologicalCondition :: Maybe PsychologicalCondition.PsychologicalCondition -- ^ Whether it's a psychological condition
+  , uid :: Uid.Uid -- ^ Medical condition unique ID
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ medicalConditionBaseSchema :: FC.Fleece schema => schema MedicalConditionBase
 medicalConditionBaseSchema =
   FC.object $
     FC.constructor MedicalConditionBase
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "psychologicalCondition" psychologicalCondition PsychologicalCondition.psychologicalConditionSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MedicalConditionBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MedicalConditionBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data MedicalConditionBaseResponse = MedicalConditionBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , medicalConditions :: Maybe [MedicalConditionBase.MedicalConditionBase] -- ^ Base medical condition, returned in search results
+  { medicalConditions :: Maybe [MedicalConditionBase.MedicalConditionBase] -- ^ Base medical condition, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ medicalConditionBaseResponseSchema :: FC.Fleece schema => schema MedicalConditio
 medicalConditionBaseResponseSchema =
   FC.object $
     FC.constructor MedicalConditionBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "medicalConditions" medicalConditions (FC.list MedicalConditionBase.medicalConditionBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MedicalConditionFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MedicalConditionFull.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.MedicalConditionFull.PsychologicalCondition as P
 import qualified StarTrek.Types.MedicalConditionFull.Uid as Uid
 
 data MedicalConditionFull = MedicalConditionFull
-  { uid :: Uid.Uid -- ^ Medical condition unique ID
-  , name :: Name.Name -- ^ Medical condition name
+  { name :: Name.Name -- ^ Medical condition name
   , psychologicalCondition :: Maybe PsychologicalCondition.PsychologicalCondition -- ^ Whether it's a psychological condition
+  , uid :: Uid.Uid -- ^ Medical condition unique ID
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ medicalConditionFullSchema :: FC.Fleece schema => schema MedicalConditionFull
 medicalConditionFullSchema =
   FC.object $
     FC.constructor MedicalConditionFull
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "psychologicalCondition" psychologicalCondition PsychologicalCondition.psychologicalConditionSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MedicalConditionHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MedicalConditionHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.MedicalConditionHeader.Name as Name
 import qualified StarTrek.Types.MedicalConditionHeader.Uid as Uid
 
 data MedicalConditionHeader = MedicalConditionHeader
-  { uid :: Uid.Uid -- ^ Medical condition unique ID
-  , name :: Name.Name -- ^ Medical condition name
+  { name :: Name.Name -- ^ Medical condition name
+  , uid :: Uid.Uid -- ^ Medical condition unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ medicalConditionHeaderSchema :: FC.Fleece schema => schema MedicalConditionHeade
 medicalConditionHeaderSchema =
   FC.object $
     FC.constructor MedicalConditionHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MovieBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MovieBase.hs
@@ -28,24 +28,24 @@ import qualified StarTrek.Types.MovieBase.YearTo as YearTo
 import qualified StarTrek.Types.StaffHeader as StaffHeader
 
 data MovieBase = MovieBase
-  { title :: Title.Title -- ^ Movie title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of movie story
-  , titleGerman :: Maybe TitleGerman.TitleGerman -- ^ Movie title in German
-  , titlePolish :: Maybe TitlePolish.TitlePolish -- ^ Movie title in Polish
-  , titleChineseTraditional :: Maybe TitleChineseTraditional.TitleChineseTraditional -- ^ Movie title in Chinese traditional
-  , titleBulgarian :: Maybe TitleBulgarian.TitleBulgarian -- ^ Movie title in Bulgarian
-  , titleItalian :: Maybe TitleItalian.TitleItalian -- ^ Movie title in Italian
-  , titleSerbian :: Maybe TitleSerbian.TitleSerbian -- ^ Movie title in Serbian
-  , uid :: Uid.Uid -- ^ Movie unique ID
-  , titleCatalan :: Maybe TitleCatalan.TitleCatalan -- ^ Movie title in Catalan
+  { mainDirector :: Maybe StaffHeader.StaffHeader -- ^ Header staff, embedded in other objects
   , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of movie story
-  , titleRussian :: Maybe TitleRussian.TitleRussian -- ^ Movie title in Russian
-  , titleJapanese :: Maybe TitleJapanese.TitleJapanese -- ^ Movie title in Japanese
-  , titleSpanish :: Maybe TitleSpanish.TitleSpanish -- ^ Movie title in Spanish
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of movie story
   , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of movie story
-  , mainDirector :: Maybe StaffHeader.StaffHeader -- ^ Header staff, embedded in other objects
+  , title :: Title.Title -- ^ Movie title
+  , titleBulgarian :: Maybe TitleBulgarian.TitleBulgarian -- ^ Movie title in Bulgarian
+  , titleCatalan :: Maybe TitleCatalan.TitleCatalan -- ^ Movie title in Catalan
+  , titleChineseTraditional :: Maybe TitleChineseTraditional.TitleChineseTraditional -- ^ Movie title in Chinese traditional
+  , titleGerman :: Maybe TitleGerman.TitleGerman -- ^ Movie title in German
+  , titleItalian :: Maybe TitleItalian.TitleItalian -- ^ Movie title in Italian
+  , titleJapanese :: Maybe TitleJapanese.TitleJapanese -- ^ Movie title in Japanese
+  , titlePolish :: Maybe TitlePolish.TitlePolish -- ^ Movie title in Polish
+  , titleRussian :: Maybe TitleRussian.TitleRussian -- ^ Movie title in Russian
+  , titleSerbian :: Maybe TitleSerbian.TitleSerbian -- ^ Movie title in Serbian
+  , titleSpanish :: Maybe TitleSpanish.TitleSpanish -- ^ Movie title in Spanish
+  , uid :: Uid.Uid -- ^ Movie unique ID
   , usReleaseDate :: Maybe UsReleaseDate.UsReleaseDate -- ^ Date the movie was first released in the United States
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of movie story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of movie story
   }
   deriving (Eq, Show)
 
@@ -53,21 +53,21 @@ movieBaseSchema :: FC.Fleece schema => schema MovieBase
 movieBaseSchema =
   FC.object $
     FC.constructor MovieBase
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "titleGerman" titleGerman TitleGerman.titleGermanSchema
-      #+ FC.optional "titlePolish" titlePolish TitlePolish.titlePolishSchema
-      #+ FC.optional "titleChineseTraditional" titleChineseTraditional TitleChineseTraditional.titleChineseTraditionalSchema
-      #+ FC.optional "titleBulgarian" titleBulgarian TitleBulgarian.titleBulgarianSchema
-      #+ FC.optional "titleItalian" titleItalian TitleItalian.titleItalianSchema
-      #+ FC.optional "titleSerbian" titleSerbian TitleSerbian.titleSerbianSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "titleCatalan" titleCatalan TitleCatalan.titleCatalanSchema
-      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
-      #+ FC.optional "titleRussian" titleRussian TitleRussian.titleRussianSchema
-      #+ FC.optional "titleJapanese" titleJapanese TitleJapanese.titleJapaneseSchema
-      #+ FC.optional "titleSpanish" titleSpanish TitleSpanish.titleSpanishSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
-      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
       #+ FC.optional "mainDirector" mainDirector StaffHeader.staffHeaderSchema
+      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.optional "titleBulgarian" titleBulgarian TitleBulgarian.titleBulgarianSchema
+      #+ FC.optional "titleCatalan" titleCatalan TitleCatalan.titleCatalanSchema
+      #+ FC.optional "titleChineseTraditional" titleChineseTraditional TitleChineseTraditional.titleChineseTraditionalSchema
+      #+ FC.optional "titleGerman" titleGerman TitleGerman.titleGermanSchema
+      #+ FC.optional "titleItalian" titleItalian TitleItalian.titleItalianSchema
+      #+ FC.optional "titleJapanese" titleJapanese TitleJapanese.titleJapaneseSchema
+      #+ FC.optional "titlePolish" titlePolish TitlePolish.titlePolishSchema
+      #+ FC.optional "titleRussian" titleRussian TitleRussian.titleRussianSchema
+      #+ FC.optional "titleSerbian" titleSerbian TitleSerbian.titleSerbianSchema
+      #+ FC.optional "titleSpanish" titleSpanish TitleSpanish.titleSpanishSchema
+      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "usReleaseDate" usReleaseDate UsReleaseDate.usReleaseDateSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MovieBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MovieBaseResponse.hs
@@ -13,8 +13,8 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data MovieBaseResponse = MovieBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , movies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
+  { movies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
@@ -23,6 +23,6 @@ movieBaseResponseSchema :: FC.Fleece schema => schema MovieBaseResponse
 movieBaseResponseSchema =
   FC.object $
     FC.constructor MovieBaseResponse
-      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "movies" movies (FC.list MovieBase.movieBaseSchema)
+      #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MovieFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MovieFull.hs
@@ -30,34 +30,34 @@ import qualified StarTrek.Types.PerformerBase as PerformerBase
 import qualified StarTrek.Types.StaffBase as StaffBase
 
 data MovieFull = MovieFull
-  { storyAuthors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , title :: Title.Title -- ^ Movie title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of movie story
-  , titleGerman :: Maybe TitleGerman.TitleGerman -- ^ Movie title in German
-  , titlePolish :: Maybe TitlePolish.TitlePolish -- ^ Movie title in Polish
-  , titleChineseTraditional :: Maybe TitleChineseTraditional.TitleChineseTraditional -- ^ Movie title in Chinese traditional
-  , staff :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , titleBulgarian :: Maybe TitleBulgarian.TitleBulgarian -- ^ Movie title in Bulgarian
-  , writers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , titleItalian :: Maybe TitleItalian.TitleItalian -- ^ Movie title in Italian
-  , screenplayAuthors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  { characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
   , directors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , titleSerbian :: Maybe TitleSerbian.TitleSerbian -- ^ Movie title in Serbian
-  , uid :: Uid.Uid -- ^ Movie unique ID
-  , standInPerformers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
-  , titleCatalan :: Maybe TitleCatalan.TitleCatalan -- ^ Movie title in Catalan
-  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of movie story
-  , stuntPerformers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
-  , titleRussian :: Maybe TitleRussian.TitleRussian -- ^ Movie title in Russian
-  , titleJapanese :: Maybe TitleJapanese.TitleJapanese -- ^ Movie title in Japanese
-  , titleSpanish :: Maybe TitleSpanish.TitleSpanish -- ^ Movie title in Spanish
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of movie story
-  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of movie story
-  , producers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , performers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
   , mainDirector :: Maybe StaffBase.StaffBase -- ^ Base staff, returned in search results
+  , performers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
+  , producers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , screenplayAuthors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , staff :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , standInPerformers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
+  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of movie story
+  , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of movie story
+  , storyAuthors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , stuntPerformers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
+  , title :: Title.Title -- ^ Movie title
+  , titleBulgarian :: Maybe TitleBulgarian.TitleBulgarian -- ^ Movie title in Bulgarian
+  , titleCatalan :: Maybe TitleCatalan.TitleCatalan -- ^ Movie title in Catalan
+  , titleChineseTraditional :: Maybe TitleChineseTraditional.TitleChineseTraditional -- ^ Movie title in Chinese traditional
+  , titleGerman :: Maybe TitleGerman.TitleGerman -- ^ Movie title in German
+  , titleItalian :: Maybe TitleItalian.TitleItalian -- ^ Movie title in Italian
+  , titleJapanese :: Maybe TitleJapanese.TitleJapanese -- ^ Movie title in Japanese
+  , titlePolish :: Maybe TitlePolish.TitlePolish -- ^ Movie title in Polish
+  , titleRussian :: Maybe TitleRussian.TitleRussian -- ^ Movie title in Russian
+  , titleSerbian :: Maybe TitleSerbian.TitleSerbian -- ^ Movie title in Serbian
+  , titleSpanish :: Maybe TitleSpanish.TitleSpanish -- ^ Movie title in Spanish
+  , uid :: Uid.Uid -- ^ Movie unique ID
   , usReleaseDate :: Maybe UsReleaseDate.UsReleaseDate -- ^ Date the movie was first released in the United States
+  , writers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of movie story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of movie story
   }
   deriving (Eq, Show)
 
@@ -65,31 +65,31 @@ movieFullSchema :: FC.Fleece schema => schema MovieFull
 movieFullSchema =
   FC.object $
     FC.constructor MovieFull
-      #+ FC.optional "storyAuthors" storyAuthors (FC.list StaffBase.staffBaseSchema)
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "titleGerman" titleGerman TitleGerman.titleGermanSchema
-      #+ FC.optional "titlePolish" titlePolish TitlePolish.titlePolishSchema
-      #+ FC.optional "titleChineseTraditional" titleChineseTraditional TitleChineseTraditional.titleChineseTraditionalSchema
-      #+ FC.optional "staff" staff (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "titleBulgarian" titleBulgarian TitleBulgarian.titleBulgarianSchema
-      #+ FC.optional "writers" writers (FC.list StaffBase.staffBaseSchema)
       #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.optional "titleItalian" titleItalian TitleItalian.titleItalianSchema
-      #+ FC.optional "screenplayAuthors" screenplayAuthors (FC.list StaffBase.staffBaseSchema)
       #+ FC.optional "directors" directors (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "titleSerbian" titleSerbian TitleSerbian.titleSerbianSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "standInPerformers" standInPerformers (FC.list PerformerBase.performerBaseSchema)
-      #+ FC.optional "titleCatalan" titleCatalan TitleCatalan.titleCatalanSchema
-      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
-      #+ FC.optional "stuntPerformers" stuntPerformers (FC.list PerformerBase.performerBaseSchema)
-      #+ FC.optional "titleRussian" titleRussian TitleRussian.titleRussianSchema
-      #+ FC.optional "titleJapanese" titleJapanese TitleJapanese.titleJapaneseSchema
-      #+ FC.optional "titleSpanish" titleSpanish TitleSpanish.titleSpanishSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
-      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
-      #+ FC.optional "producers" producers (FC.list StaffBase.staffBaseSchema)
-      #+ FC.optional "performers" performers (FC.list PerformerBase.performerBaseSchema)
       #+ FC.optional "mainDirector" mainDirector StaffBase.staffBaseSchema
+      #+ FC.optional "performers" performers (FC.list PerformerBase.performerBaseSchema)
+      #+ FC.optional "producers" producers (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "screenplayAuthors" screenplayAuthors (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "staff" staff (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "standInPerformers" standInPerformers (FC.list PerformerBase.performerBaseSchema)
+      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.optional "storyAuthors" storyAuthors (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "stuntPerformers" stuntPerformers (FC.list PerformerBase.performerBaseSchema)
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.optional "titleBulgarian" titleBulgarian TitleBulgarian.titleBulgarianSchema
+      #+ FC.optional "titleCatalan" titleCatalan TitleCatalan.titleCatalanSchema
+      #+ FC.optional "titleChineseTraditional" titleChineseTraditional TitleChineseTraditional.titleChineseTraditionalSchema
+      #+ FC.optional "titleGerman" titleGerman TitleGerman.titleGermanSchema
+      #+ FC.optional "titleItalian" titleItalian TitleItalian.titleItalianSchema
+      #+ FC.optional "titleJapanese" titleJapanese TitleJapanese.titleJapaneseSchema
+      #+ FC.optional "titlePolish" titlePolish TitlePolish.titlePolishSchema
+      #+ FC.optional "titleRussian" titleRussian TitleRussian.titleRussianSchema
+      #+ FC.optional "titleSerbian" titleSerbian TitleSerbian.titleSerbianSchema
+      #+ FC.optional "titleSpanish" titleSpanish TitleSpanish.titleSpanishSchema
+      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "usReleaseDate" usReleaseDate UsReleaseDate.usReleaseDateSchema
+      #+ FC.optional "writers" writers (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OccupationBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OccupationBase.hs
@@ -16,10 +16,10 @@ import qualified StarTrek.Types.OccupationBase.Uid as Uid
 
 data OccupationBase = OccupationBase
   { legalOccupation :: Maybe LegalOccupation.LegalOccupation -- ^ Whether it's a legal occupation
-  , uid :: Uid.Uid -- ^ Occupation unique ID
   , medicalOccupation :: Maybe MedicalOccupation.MedicalOccupation -- ^ Whether it's a medical occupation
   , name :: Name.Name -- ^ Occupation name
   , scientificOccupation :: Maybe ScientificOccupation.ScientificOccupation -- ^ Whether it's a scientific occupation
+  , uid :: Uid.Uid -- ^ Occupation unique ID
   }
   deriving (Eq, Show)
 
@@ -28,7 +28,7 @@ occupationBaseSchema =
   FC.object $
     FC.constructor OccupationBase
       #+ FC.optional "legalOccupation" legalOccupation LegalOccupation.legalOccupationSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "medicalOccupation" medicalOccupation MedicalOccupation.medicalOccupationSchema
       #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "scientificOccupation" scientificOccupation ScientificOccupation.scientificOccupationSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OccupationBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OccupationBaseResponse.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.ResponsePage as ResponsePage
 import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data OccupationBaseResponse = OccupationBaseResponse
-  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
+  { occupations :: Maybe [OccupationBase.OccupationBase] -- ^ Base occupations, returned in search results
+  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
-  , occupations :: Maybe [OccupationBase.OccupationBase] -- ^ Base occupations, returned in search results
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ occupationBaseResponseSchema :: FC.Fleece schema => schema OccupationBaseRespons
 occupationBaseResponseSchema =
   FC.object $
     FC.constructor OccupationBaseResponse
+      #+ FC.optional "occupations" occupations (FC.list OccupationBase.occupationBaseSchema)
       #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
-      #+ FC.optional "occupations" occupations (FC.list OccupationBase.occupationBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OccupationFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OccupationFull.hs
@@ -16,12 +16,12 @@ import qualified StarTrek.Types.OccupationFull.ScientificOccupation as Scientifi
 import qualified StarTrek.Types.OccupationFull.Uid as Uid
 
 data OccupationFull = OccupationFull
-  { legalOccupation :: Maybe LegalOccupation.LegalOccupation -- ^ Whether it's a legal occupation
-  , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , uid :: Uid.Uid -- ^ Occupation unique ID
+  { characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
+  , legalOccupation :: Maybe LegalOccupation.LegalOccupation -- ^ Whether it's a legal occupation
   , medicalOccupation :: Maybe MedicalOccupation.MedicalOccupation -- ^ Whether it's a medical occupation
   , name :: Name.Name -- ^ Occupation name
   , scientificOccupation :: Maybe ScientificOccupation.ScientificOccupation -- ^ Whether it's a scientific occupation
+  , uid :: Uid.Uid -- ^ Occupation unique ID
   }
   deriving (Eq, Show)
 
@@ -29,9 +29,9 @@ occupationFullSchema :: FC.Fleece schema => schema OccupationFull
 occupationFullSchema =
   FC.object $
     FC.constructor OccupationFull
-      #+ FC.optional "legalOccupation" legalOccupation LegalOccupation.legalOccupationSchema
       #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "legalOccupation" legalOccupation LegalOccupation.legalOccupationSchema
       #+ FC.optional "medicalOccupation" medicalOccupation MedicalOccupation.medicalOccupationSchema
       #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "scientificOccupation" scientificOccupation ScientificOccupation.scientificOccupationSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OccupationHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OccupationHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.OccupationHeader.Name as Name
 import qualified StarTrek.Types.OccupationHeader.Uid as Uid
 
 data OccupationHeader = OccupationHeader
-  { uid :: Uid.Uid -- ^ Occupation unique ID
-  , name :: Name.Name -- ^ Occupation name
+  { name :: Name.Name -- ^ Occupation name
+  , uid :: Uid.Uid -- ^ Occupation unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ occupationHeaderSchema :: FC.Fleece schema => schema OccupationHeader
 occupationHeaderSchema =
   FC.object $
     FC.constructor OccupationHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OrganizationBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OrganizationBase.hs
@@ -24,20 +24,20 @@ import qualified StarTrek.Types.OrganizationBase.SportOrganization as SportOrgan
 import qualified StarTrek.Types.OrganizationBase.Uid as Uid
 
 data OrganizationBase = OrganizationBase
-  { mirror :: Maybe Mirror.Mirror -- ^ Whether this organization is from mirror universe
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this location is from alternate reality
-  , intergovernmentalOrganization :: Maybe IntergovernmentalOrganization.IntergovernmentalOrganization -- ^ Whether it's an intergovernmental organization
-  , militaryUnit :: Maybe MilitaryUnit.MilitaryUnit -- ^ Whether it's a military unit
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this location is from alternate reality
   , government :: Maybe Government.Government -- ^ Whether it's a government
-  , sportOrganization :: Maybe SportOrganization.SportOrganization -- ^ Whether it's a sport organization
-  , lawEnforcementAgency :: Maybe LawEnforcementAgency.LawEnforcementAgency -- ^ Whether it's a law enforcement agency
-  , prisonOrPenalColony :: Maybe PrisonOrPenalColony.PrisonOrPenalColony -- ^ Whether it's a prison or penal colony
-  , uid :: Uid.Uid -- ^ Organization unique ID
-  , medicalOrganization :: Maybe MedicalOrganization.MedicalOrganization -- ^ Whether it's a medical organization
   , governmentAgency :: Maybe GovernmentAgency.GovernmentAgency -- ^ Whether it's a government agency
-  , name :: Name.Name -- ^ Organization name
+  , intergovernmentalOrganization :: Maybe IntergovernmentalOrganization.IntergovernmentalOrganization -- ^ Whether it's an intergovernmental organization
+  , lawEnforcementAgency :: Maybe LawEnforcementAgency.LawEnforcementAgency -- ^ Whether it's a law enforcement agency
+  , medicalOrganization :: Maybe MedicalOrganization.MedicalOrganization -- ^ Whether it's a medical organization
   , militaryOrganization :: Maybe MilitaryOrganization.MilitaryOrganization -- ^ Whether it's a military organization
+  , militaryUnit :: Maybe MilitaryUnit.MilitaryUnit -- ^ Whether it's a military unit
+  , mirror :: Maybe Mirror.Mirror -- ^ Whether this organization is from mirror universe
+  , name :: Name.Name -- ^ Organization name
+  , prisonOrPenalColony :: Maybe PrisonOrPenalColony.PrisonOrPenalColony -- ^ Whether it's a prison or penal colony
   , researchOrganization :: Maybe ResearchOrganization.ResearchOrganization -- ^ Whether it's a research organization
+  , sportOrganization :: Maybe SportOrganization.SportOrganization -- ^ Whether it's a sport organization
+  , uid :: Uid.Uid -- ^ Organization unique ID
   }
   deriving (Eq, Show)
 
@@ -45,17 +45,17 @@ organizationBaseSchema :: FC.Fleece schema => schema OrganizationBase
 organizationBaseSchema =
   FC.object $
     FC.constructor OrganizationBase
-      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
-      #+ FC.optional "intergovernmentalOrganization" intergovernmentalOrganization IntergovernmentalOrganization.intergovernmentalOrganizationSchema
-      #+ FC.optional "militaryUnit" militaryUnit MilitaryUnit.militaryUnitSchema
       #+ FC.optional "government" government Government.governmentSchema
-      #+ FC.optional "sportOrganization" sportOrganization SportOrganization.sportOrganizationSchema
-      #+ FC.optional "lawEnforcementAgency" lawEnforcementAgency LawEnforcementAgency.lawEnforcementAgencySchema
-      #+ FC.optional "prisonOrPenalColony" prisonOrPenalColony PrisonOrPenalColony.prisonOrPenalColonySchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "medicalOrganization" medicalOrganization MedicalOrganization.medicalOrganizationSchema
       #+ FC.optional "governmentAgency" governmentAgency GovernmentAgency.governmentAgencySchema
-      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "intergovernmentalOrganization" intergovernmentalOrganization IntergovernmentalOrganization.intergovernmentalOrganizationSchema
+      #+ FC.optional "lawEnforcementAgency" lawEnforcementAgency LawEnforcementAgency.lawEnforcementAgencySchema
+      #+ FC.optional "medicalOrganization" medicalOrganization MedicalOrganization.medicalOrganizationSchema
       #+ FC.optional "militaryOrganization" militaryOrganization MilitaryOrganization.militaryOrganizationSchema
+      #+ FC.optional "militaryUnit" militaryUnit MilitaryUnit.militaryUnitSchema
+      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "prisonOrPenalColony" prisonOrPenalColony PrisonOrPenalColony.prisonOrPenalColonySchema
       #+ FC.optional "researchOrganization" researchOrganization ResearchOrganization.researchOrganizationSchema
+      #+ FC.optional "sportOrganization" sportOrganization SportOrganization.sportOrganizationSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OrganizationFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OrganizationFull.hs
@@ -25,21 +25,21 @@ import qualified StarTrek.Types.OrganizationFull.SportOrganization as SportOrgan
 import qualified StarTrek.Types.OrganizationFull.Uid as Uid
 
 data OrganizationFull = OrganizationFull
-  { mirror :: Maybe Mirror.Mirror -- ^ Whether this organization is from mirror universe
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this organization is from alternate reality
-  , intergovernmentalOrganization :: Maybe IntergovernmentalOrganization.IntergovernmentalOrganization -- ^ Whether it's an intergovernmental organization
-  , militaryUnit :: Maybe MilitaryUnit.MilitaryUnit -- ^ Whether it's a military unit
-  , government :: Maybe Government.Government -- ^ Whether it's a government
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this organization is from alternate reality
   , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , sportOrganization :: Maybe SportOrganization.SportOrganization -- ^ Whether it's a sport organization
-  , lawEnforcementAgency :: Maybe LawEnforcementAgency.LawEnforcementAgency -- ^ Whether it's a law enforcement agency
-  , prisonOrPenalColony :: Maybe PrisonOrPenalColony.PrisonOrPenalColony -- ^ Whether it's a prison or penal colony
-  , uid :: Uid.Uid -- ^ Organization unique ID
-  , medicalOrganization :: Maybe MedicalOrganization.MedicalOrganization -- ^ Whether it's a medical organization
+  , government :: Maybe Government.Government -- ^ Whether it's a government
   , governmentAgency :: Maybe GovernmentAgency.GovernmentAgency -- ^ Whether it's a government agency
-  , name :: Name.Name -- ^ Organization name
+  , intergovernmentalOrganization :: Maybe IntergovernmentalOrganization.IntergovernmentalOrganization -- ^ Whether it's an intergovernmental organization
+  , lawEnforcementAgency :: Maybe LawEnforcementAgency.LawEnforcementAgency -- ^ Whether it's a law enforcement agency
+  , medicalOrganization :: Maybe MedicalOrganization.MedicalOrganization -- ^ Whether it's a medical organization
   , militaryOrganization :: Maybe MilitaryOrganization.MilitaryOrganization -- ^ Whether it's a military organization
+  , militaryUnit :: Maybe MilitaryUnit.MilitaryUnit -- ^ Whether it's a military unit
+  , mirror :: Maybe Mirror.Mirror -- ^ Whether this organization is from mirror universe
+  , name :: Name.Name -- ^ Organization name
+  , prisonOrPenalColony :: Maybe PrisonOrPenalColony.PrisonOrPenalColony -- ^ Whether it's a prison or penal colony
   , researchOrganization :: Maybe ResearchOrganization.ResearchOrganization -- ^ Whether it's a research organization
+  , sportOrganization :: Maybe SportOrganization.SportOrganization -- ^ Whether it's a sport organization
+  , uid :: Uid.Uid -- ^ Organization unique ID
   }
   deriving (Eq, Show)
 
@@ -47,18 +47,18 @@ organizationFullSchema :: FC.Fleece schema => schema OrganizationFull
 organizationFullSchema =
   FC.object $
     FC.constructor OrganizationFull
-      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
-      #+ FC.optional "intergovernmentalOrganization" intergovernmentalOrganization IntergovernmentalOrganization.intergovernmentalOrganizationSchema
-      #+ FC.optional "militaryUnit" militaryUnit MilitaryUnit.militaryUnitSchema
-      #+ FC.optional "government" government Government.governmentSchema
       #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.optional "sportOrganization" sportOrganization SportOrganization.sportOrganizationSchema
-      #+ FC.optional "lawEnforcementAgency" lawEnforcementAgency LawEnforcementAgency.lawEnforcementAgencySchema
-      #+ FC.optional "prisonOrPenalColony" prisonOrPenalColony PrisonOrPenalColony.prisonOrPenalColonySchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "medicalOrganization" medicalOrganization MedicalOrganization.medicalOrganizationSchema
+      #+ FC.optional "government" government Government.governmentSchema
       #+ FC.optional "governmentAgency" governmentAgency GovernmentAgency.governmentAgencySchema
-      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "intergovernmentalOrganization" intergovernmentalOrganization IntergovernmentalOrganization.intergovernmentalOrganizationSchema
+      #+ FC.optional "lawEnforcementAgency" lawEnforcementAgency LawEnforcementAgency.lawEnforcementAgencySchema
+      #+ FC.optional "medicalOrganization" medicalOrganization MedicalOrganization.medicalOrganizationSchema
       #+ FC.optional "militaryOrganization" militaryOrganization MilitaryOrganization.militaryOrganizationSchema
+      #+ FC.optional "militaryUnit" militaryUnit MilitaryUnit.militaryUnitSchema
+      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "prisonOrPenalColony" prisonOrPenalColony PrisonOrPenalColony.prisonOrPenalColonySchema
       #+ FC.optional "researchOrganization" researchOrganization ResearchOrganization.researchOrganizationSchema
+      #+ FC.optional "sportOrganization" sportOrganization SportOrganization.sportOrganizationSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OrganizationHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/OrganizationHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.OrganizationHeader.Name as Name
 import qualified StarTrek.Types.OrganizationHeader.Uid as Uid
 
 data OrganizationHeader = OrganizationHeader
-  { uid :: Uid.Uid -- ^ Organization unique ID
-  , name :: Name.Name -- ^ Organization name
+  { name :: Name.Name -- ^ Organization name
+  , uid :: Uid.Uid -- ^ Organization unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ organizationHeaderSchema :: FC.Fleece schema => schema OrganizationHeader
 organizationHeaderSchema =
   FC.object $
     FC.constructor OrganizationHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/PerformerBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/PerformerBase.hs
@@ -31,27 +31,27 @@ import qualified StarTrek.Types.PerformerBase.VoicePerformer as VoicePerformer
 import qualified StarTrek.Types.PerformerBase.VoyPerformer as VoyPerformer
 
 data PerformerBase = PerformerBase
-  { tngPerformer :: Maybe TngPerformer.TngPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Next Generation
-  , standInPerformer :: Maybe StandInPerformer.StandInPerformer -- ^ Whether it's a stand-in performer
-  , animalPerformer :: Maybe AnimalPerformer.AnimalPerformer -- ^ Whether it's an animal performer
-  , entPerformer :: Maybe EntPerformer.EntPerformer -- ^ Whether it's a performer that appeared in Star Trek: Enterprise
-  , ds9Performer :: Maybe Ds9Performer.Ds9Performer -- ^ Whether it's a performer that appeared in Star Trek: Deep Space Nine
-  , videoGamePerformer :: Maybe VideoGamePerformer.VideoGamePerformer -- ^ Whether it's a video game performer
-  , gender :: Maybe Gender.Gender -- ^ Gender
-  , filmPerformer :: Maybe FilmPerformer.FilmPerformer -- ^ Whether it's a performer that appeared in a Star Trek movie
-  , voicePerformer :: Maybe VoicePerformer.VoicePerformer -- ^ Whether it's a voice performer
-  , uid :: Uid.Uid -- ^ Performer unique ID
-  , voyPerformer :: Maybe VoyPerformer.VoyPerformer -- ^ Whether it's a performer that appeared in Star Trek: Voyager
-  , stuntPerformer :: Maybe StuntPerformer.StuntPerformer -- ^ Whether it's a stunt performer
-  , dateOfDeath :: Maybe DateOfDeath.DateOfDeath -- ^ Date the performer died
-  , tosPerformer :: Maybe TosPerformer.TosPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Original Series
-  , tasPerformer :: Maybe TasPerformer.TasPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Animated Series
-  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place the performer was born
-  , name :: Name.Name -- ^ Performer name
+  { animalPerformer :: Maybe AnimalPerformer.AnimalPerformer -- ^ Whether it's an animal performer
   , birthName :: Maybe BirthName.BirthName -- ^ Performer birth name
   , dateOfBirth :: Maybe DateOfBirth.DateOfBirth -- ^ Date the performer was born
-  , placeOfDeath :: Maybe PlaceOfDeath.PlaceOfDeath -- ^ Place the performer died
+  , dateOfDeath :: Maybe DateOfDeath.DateOfDeath -- ^ Date the performer died
   , disPerformer :: Maybe DisPerformer.DisPerformer -- ^ Whether it's a performer that appeared in Star Trek: Discovery
+  , ds9Performer :: Maybe Ds9Performer.Ds9Performer -- ^ Whether it's a performer that appeared in Star Trek: Deep Space Nine
+  , entPerformer :: Maybe EntPerformer.EntPerformer -- ^ Whether it's a performer that appeared in Star Trek: Enterprise
+  , filmPerformer :: Maybe FilmPerformer.FilmPerformer -- ^ Whether it's a performer that appeared in a Star Trek movie
+  , gender :: Maybe Gender.Gender -- ^ Gender
+  , name :: Name.Name -- ^ Performer name
+  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place the performer was born
+  , placeOfDeath :: Maybe PlaceOfDeath.PlaceOfDeath -- ^ Place the performer died
+  , standInPerformer :: Maybe StandInPerformer.StandInPerformer -- ^ Whether it's a stand-in performer
+  , stuntPerformer :: Maybe StuntPerformer.StuntPerformer -- ^ Whether it's a stunt performer
+  , tasPerformer :: Maybe TasPerformer.TasPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Animated Series
+  , tngPerformer :: Maybe TngPerformer.TngPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Next Generation
+  , tosPerformer :: Maybe TosPerformer.TosPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Original Series
+  , uid :: Uid.Uid -- ^ Performer unique ID
+  , videoGamePerformer :: Maybe VideoGamePerformer.VideoGamePerformer -- ^ Whether it's a video game performer
+  , voicePerformer :: Maybe VoicePerformer.VoicePerformer -- ^ Whether it's a voice performer
+  , voyPerformer :: Maybe VoyPerformer.VoyPerformer -- ^ Whether it's a performer that appeared in Star Trek: Voyager
   }
   deriving (Eq, Show)
 
@@ -59,24 +59,24 @@ performerBaseSchema :: FC.Fleece schema => schema PerformerBase
 performerBaseSchema =
   FC.object $
     FC.constructor PerformerBase
-      #+ FC.optional "tngPerformer" tngPerformer TngPerformer.tngPerformerSchema
-      #+ FC.optional "standInPerformer" standInPerformer StandInPerformer.standInPerformerSchema
       #+ FC.optional "animalPerformer" animalPerformer AnimalPerformer.animalPerformerSchema
-      #+ FC.optional "entPerformer" entPerformer EntPerformer.entPerformerSchema
-      #+ FC.optional "ds9Performer" ds9Performer Ds9Performer.ds9PerformerSchema
-      #+ FC.optional "videoGamePerformer" videoGamePerformer VideoGamePerformer.videoGamePerformerSchema
-      #+ FC.optional "gender" gender Gender.genderSchema
-      #+ FC.optional "filmPerformer" filmPerformer FilmPerformer.filmPerformerSchema
-      #+ FC.optional "voicePerformer" voicePerformer VoicePerformer.voicePerformerSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "voyPerformer" voyPerformer VoyPerformer.voyPerformerSchema
-      #+ FC.optional "stuntPerformer" stuntPerformer StuntPerformer.stuntPerformerSchema
-      #+ FC.optional "dateOfDeath" dateOfDeath DateOfDeath.dateOfDeathSchema
-      #+ FC.optional "tosPerformer" tosPerformer TosPerformer.tosPerformerSchema
-      #+ FC.optional "tasPerformer" tasPerformer TasPerformer.tasPerformerSchema
-      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
-      #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "birthName" birthName BirthName.birthNameSchema
       #+ FC.optional "dateOfBirth" dateOfBirth DateOfBirth.dateOfBirthSchema
-      #+ FC.optional "placeOfDeath" placeOfDeath PlaceOfDeath.placeOfDeathSchema
+      #+ FC.optional "dateOfDeath" dateOfDeath DateOfDeath.dateOfDeathSchema
       #+ FC.optional "disPerformer" disPerformer DisPerformer.disPerformerSchema
+      #+ FC.optional "ds9Performer" ds9Performer Ds9Performer.ds9PerformerSchema
+      #+ FC.optional "entPerformer" entPerformer EntPerformer.entPerformerSchema
+      #+ FC.optional "filmPerformer" filmPerformer FilmPerformer.filmPerformerSchema
+      #+ FC.optional "gender" gender Gender.genderSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
+      #+ FC.optional "placeOfDeath" placeOfDeath PlaceOfDeath.placeOfDeathSchema
+      #+ FC.optional "standInPerformer" standInPerformer StandInPerformer.standInPerformerSchema
+      #+ FC.optional "stuntPerformer" stuntPerformer StuntPerformer.stuntPerformerSchema
+      #+ FC.optional "tasPerformer" tasPerformer TasPerformer.tasPerformerSchema
+      #+ FC.optional "tngPerformer" tngPerformer TngPerformer.tngPerformerSchema
+      #+ FC.optional "tosPerformer" tosPerformer TosPerformer.tosPerformerSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "videoGamePerformer" videoGamePerformer VideoGamePerformer.videoGamePerformerSchema
+      #+ FC.optional "voicePerformer" voicePerformer VoicePerformer.voicePerformerSchema
+      #+ FC.optional "voyPerformer" voyPerformer VoyPerformer.voyPerformerSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/PerformerBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/PerformerBaseResponse.hs
@@ -14,8 +14,8 @@ import qualified StarTrek.Types.ResponseSort as ResponseSort
 
 data PerformerBaseResponse = PerformerBaseResponse
   { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   , performers :: Maybe [PerformerBase.PerformerBase] -- ^ Base performer, returned in search results
+  , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
 
@@ -24,5 +24,5 @@ performerBaseResponseSchema =
   FC.object $
     FC.constructor PerformerBaseResponse
       #+ FC.optional "page" page ResponsePage.responsePageSchema
-      #+ FC.optional "sort" sort ResponseSort.responseSortSchema
       #+ FC.optional "performers" performers (FC.list PerformerBase.performerBaseSchema)
+      #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/PerformerFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/PerformerFull.hs
@@ -34,34 +34,34 @@ import qualified StarTrek.Types.PerformerFull.VoicePerformer as VoicePerformer
 import qualified StarTrek.Types.PerformerFull.VoyPerformer as VoyPerformer
 
 data PerformerFull = PerformerFull
-  { tngPerformer :: Maybe TngPerformer.TngPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Next Generation
-  , standInPerformer :: Maybe StandInPerformer.StandInPerformer -- ^ Whether it's a stand-in performer
-  , animalPerformer :: Maybe AnimalPerformer.AnimalPerformer -- ^ Whether it's an animal performer
-  , entPerformer :: Maybe EntPerformer.EntPerformer -- ^ Whether it's a performer that appeared in Star Trek: Enterprise
-  , ds9Performer :: Maybe Ds9Performer.Ds9Performer -- ^ Whether it's a performer that appeared in Star Trek: Deep Space Nine
-  , videoGamePerformer :: Maybe VideoGamePerformer.VideoGamePerformer -- ^ Whether it's a video game performer
-  , gender :: Maybe Gender.Gender -- ^ Gender
-  , filmPerformer :: Maybe FilmPerformer.FilmPerformer -- ^ Whether it's a performer that appeared in a Star Trek movie
-  , moviesStuntPerformances :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
-  , voicePerformer :: Maybe VoicePerformer.VoicePerformer -- ^ Whether it's a voice performer
-  , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , episodesStandInPerformances :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
-  , episodesPerformances :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
-  , uid :: Uid.Uid -- ^ Performer unique ID
-  , voyPerformer :: Maybe VoyPerformer.VoyPerformer -- ^ Whether it's a performer that appeared in Star Trek: Voyager
-  , stuntPerformer :: Maybe StuntPerformer.StuntPerformer -- ^ Whether it's a stunt performer
-  , dateOfDeath :: Maybe DateOfDeath.DateOfDeath -- ^ Date the performer died
-  , moviesPerformances :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
-  , tosPerformer :: Maybe TosPerformer.TosPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Original Series
-  , tasPerformer :: Maybe TasPerformer.TasPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Animated Series
-  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place the performer was born
-  , name :: Name.Name -- ^ Performer name
-  , moviesStandInPerformances :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
+  { animalPerformer :: Maybe AnimalPerformer.AnimalPerformer -- ^ Whether it's an animal performer
   , birthName :: Maybe BirthName.BirthName -- ^ Performer birth name
+  , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
   , dateOfBirth :: Maybe DateOfBirth.DateOfBirth -- ^ Date the performer was born
-  , placeOfDeath :: Maybe PlaceOfDeath.PlaceOfDeath -- ^ Place the performer died
-  , episodesStuntPerformances :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , dateOfDeath :: Maybe DateOfDeath.DateOfDeath -- ^ Date the performer died
   , disPerformer :: Maybe DisPerformer.DisPerformer -- ^ Whether it's a performer that appeared in Star Trek: Discovery
+  , ds9Performer :: Maybe Ds9Performer.Ds9Performer -- ^ Whether it's a performer that appeared in Star Trek: Deep Space Nine
+  , entPerformer :: Maybe EntPerformer.EntPerformer -- ^ Whether it's a performer that appeared in Star Trek: Enterprise
+  , episodesPerformances :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , episodesStandInPerformances :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , episodesStuntPerformances :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , filmPerformer :: Maybe FilmPerformer.FilmPerformer -- ^ Whether it's a performer that appeared in a Star Trek movie
+  , gender :: Maybe Gender.Gender -- ^ Gender
+  , moviesPerformances :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
+  , moviesStandInPerformances :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
+  , moviesStuntPerformances :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
+  , name :: Name.Name -- ^ Performer name
+  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place the performer was born
+  , placeOfDeath :: Maybe PlaceOfDeath.PlaceOfDeath -- ^ Place the performer died
+  , standInPerformer :: Maybe StandInPerformer.StandInPerformer -- ^ Whether it's a stand-in performer
+  , stuntPerformer :: Maybe StuntPerformer.StuntPerformer -- ^ Whether it's a stunt performer
+  , tasPerformer :: Maybe TasPerformer.TasPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Animated Series
+  , tngPerformer :: Maybe TngPerformer.TngPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Next Generation
+  , tosPerformer :: Maybe TosPerformer.TosPerformer -- ^ Whether it's a performer that appeared in Star Trek: The Original Series
+  , uid :: Uid.Uid -- ^ Performer unique ID
+  , videoGamePerformer :: Maybe VideoGamePerformer.VideoGamePerformer -- ^ Whether it's a video game performer
+  , voicePerformer :: Maybe VoicePerformer.VoicePerformer -- ^ Whether it's a voice performer
+  , voyPerformer :: Maybe VoyPerformer.VoyPerformer -- ^ Whether it's a performer that appeared in Star Trek: Voyager
   }
   deriving (Eq, Show)
 
@@ -69,31 +69,31 @@ performerFullSchema :: FC.Fleece schema => schema PerformerFull
 performerFullSchema =
   FC.object $
     FC.constructor PerformerFull
-      #+ FC.optional "tngPerformer" tngPerformer TngPerformer.tngPerformerSchema
-      #+ FC.optional "standInPerformer" standInPerformer StandInPerformer.standInPerformerSchema
       #+ FC.optional "animalPerformer" animalPerformer AnimalPerformer.animalPerformerSchema
-      #+ FC.optional "entPerformer" entPerformer EntPerformer.entPerformerSchema
-      #+ FC.optional "ds9Performer" ds9Performer Ds9Performer.ds9PerformerSchema
-      #+ FC.optional "videoGamePerformer" videoGamePerformer VideoGamePerformer.videoGamePerformerSchema
-      #+ FC.optional "gender" gender Gender.genderSchema
-      #+ FC.optional "filmPerformer" filmPerformer FilmPerformer.filmPerformerSchema
-      #+ FC.optional "moviesStuntPerformances" moviesStuntPerformances (FC.list MovieBase.movieBaseSchema)
-      #+ FC.optional "voicePerformer" voicePerformer VoicePerformer.voicePerformerSchema
-      #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.optional "episodesStandInPerformances" episodesStandInPerformances (FC.list EpisodeBase.episodeBaseSchema)
-      #+ FC.optional "episodesPerformances" episodesPerformances (FC.list EpisodeBase.episodeBaseSchema)
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "voyPerformer" voyPerformer VoyPerformer.voyPerformerSchema
-      #+ FC.optional "stuntPerformer" stuntPerformer StuntPerformer.stuntPerformerSchema
-      #+ FC.optional "dateOfDeath" dateOfDeath DateOfDeath.dateOfDeathSchema
-      #+ FC.optional "moviesPerformances" moviesPerformances (FC.list MovieBase.movieBaseSchema)
-      #+ FC.optional "tosPerformer" tosPerformer TosPerformer.tosPerformerSchema
-      #+ FC.optional "tasPerformer" tasPerformer TasPerformer.tasPerformerSchema
-      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "moviesStandInPerformances" moviesStandInPerformances (FC.list MovieBase.movieBaseSchema)
       #+ FC.optional "birthName" birthName BirthName.birthNameSchema
+      #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
       #+ FC.optional "dateOfBirth" dateOfBirth DateOfBirth.dateOfBirthSchema
-      #+ FC.optional "placeOfDeath" placeOfDeath PlaceOfDeath.placeOfDeathSchema
-      #+ FC.optional "episodesStuntPerformances" episodesStuntPerformances (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "dateOfDeath" dateOfDeath DateOfDeath.dateOfDeathSchema
       #+ FC.optional "disPerformer" disPerformer DisPerformer.disPerformerSchema
+      #+ FC.optional "ds9Performer" ds9Performer Ds9Performer.ds9PerformerSchema
+      #+ FC.optional "entPerformer" entPerformer EntPerformer.entPerformerSchema
+      #+ FC.optional "episodesPerformances" episodesPerformances (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "episodesStandInPerformances" episodesStandInPerformances (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "episodesStuntPerformances" episodesStuntPerformances (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "filmPerformer" filmPerformer FilmPerformer.filmPerformerSchema
+      #+ FC.optional "gender" gender Gender.genderSchema
+      #+ FC.optional "moviesPerformances" moviesPerformances (FC.list MovieBase.movieBaseSchema)
+      #+ FC.optional "moviesStandInPerformances" moviesStandInPerformances (FC.list MovieBase.movieBaseSchema)
+      #+ FC.optional "moviesStuntPerformances" moviesStuntPerformances (FC.list MovieBase.movieBaseSchema)
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
+      #+ FC.optional "placeOfDeath" placeOfDeath PlaceOfDeath.placeOfDeathSchema
+      #+ FC.optional "standInPerformer" standInPerformer StandInPerformer.standInPerformerSchema
+      #+ FC.optional "stuntPerformer" stuntPerformer StuntPerformer.stuntPerformerSchema
+      #+ FC.optional "tasPerformer" tasPerformer TasPerformer.tasPerformerSchema
+      #+ FC.optional "tngPerformer" tngPerformer TngPerformer.tngPerformerSchema
+      #+ FC.optional "tosPerformer" tosPerformer TosPerformer.tosPerformerSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "videoGamePerformer" videoGamePerformer VideoGamePerformer.videoGamePerformerSchema
+      #+ FC.optional "voicePerformer" voicePerformer VoicePerformer.voicePerformerSchema
+      #+ FC.optional "voyPerformer" voyPerformer VoyPerformer.voyPerformerSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/PerformerHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/PerformerHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.PerformerHeader.Name as Name
 import qualified StarTrek.Types.PerformerHeader.Uid as Uid
 
 data PerformerHeader = PerformerHeader
-  { uid :: Uid.Uid -- ^ Performer unique ID
-  , name :: Name.Name -- ^ Performer name
+  { name :: Name.Name -- ^ Performer name
+  , uid :: Uid.Uid -- ^ Performer unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ performerHeaderSchema :: FC.Fleece schema => schema PerformerHeader
 performerHeaderSchema =
   FC.object $
     FC.constructor PerformerHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Platform.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Platform.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.Platform.Name as Name
 import qualified StarTrek.Types.Platform.Uid as Uid
 
 data Platform = Platform
-  { uid :: Maybe Uid.Uid -- ^ Platform unique ID
-  , name :: Maybe Name.Name -- ^ Platform name
+  { name :: Maybe Name.Name -- ^ Platform name
+  , uid :: Maybe Uid.Uid -- ^ Platform unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ platformSchema :: FC.Fleece schema => schema Platform
 platformSchema =
   FC.object $
     FC.constructor Platform
-      #+ FC.optional "uid" uid Uid.uidSchema
       #+ FC.optional "name" name Name.nameSchema
+      #+ FC.optional "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Reference.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Reference.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.Reference.Uid as Uid
 import qualified StarTrek.Types.ReferenceType as ReferenceType
 
 data Reference = Reference
-  { uid :: Maybe Uid.Uid -- ^ Reference unique ID
-  , referenceNumber :: Maybe ReferenceNumber.ReferenceNumber -- ^ Reference number
+  { referenceNumber :: Maybe ReferenceNumber.ReferenceNumber -- ^ Reference number
   , referenceType :: Maybe ReferenceType.ReferenceType -- ^ Reference type
+  , uid :: Maybe Uid.Uid -- ^ Reference unique ID
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ referenceSchema :: FC.Fleece schema => schema Reference
 referenceSchema =
   FC.object $
     FC.constructor Reference
-      #+ FC.optional "uid" uid Uid.uidSchema
       #+ FC.optional "referenceNumber" referenceNumber ReferenceNumber.referenceNumberSchema
       #+ FC.optional "referenceType" referenceType ReferenceType.referenceTypeSchema
+      #+ FC.optional "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ResponsePage.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ResponsePage.hs
@@ -17,13 +17,13 @@ import qualified StarTrek.Types.ResponsePage.TotalElements as TotalElements
 import qualified StarTrek.Types.ResponsePage.TotalPages as TotalPages
 
 data ResponsePage = ResponsePage
-  { pageSize :: Maybe PageSize.PageSize -- ^ Page size
-  , pageNumber :: Maybe PageNumber.PageNumber -- ^ Zero-based page number
-  , firstPage :: Maybe FirstPage.FirstPage -- ^ Whether it is the first page
-  , numberOfElements :: Maybe NumberOfElements.NumberOfElements -- ^ Number of elements in page
+  { firstPage :: Maybe FirstPage.FirstPage -- ^ Whether it is the first page
   , lastPage :: Maybe LastPage.LastPage -- ^ Whether it is the last page
-  , totalPages :: Maybe TotalPages.TotalPages -- ^ Total pages found
+  , numberOfElements :: Maybe NumberOfElements.NumberOfElements -- ^ Number of elements in page
+  , pageNumber :: Maybe PageNumber.PageNumber -- ^ Zero-based page number
+  , pageSize :: Maybe PageSize.PageSize -- ^ Page size
   , totalElements :: Maybe TotalElements.TotalElements -- ^ Total elements found
+  , totalPages :: Maybe TotalPages.TotalPages -- ^ Total pages found
   }
   deriving (Eq, Show)
 
@@ -31,10 +31,10 @@ responsePageSchema :: FC.Fleece schema => schema ResponsePage
 responsePageSchema =
   FC.object $
     FC.constructor ResponsePage
-      #+ FC.optional "pageSize" pageSize PageSize.pageSizeSchema
-      #+ FC.optional "pageNumber" pageNumber PageNumber.pageNumberSchema
       #+ FC.optional "firstPage" firstPage FirstPage.firstPageSchema
-      #+ FC.optional "numberOfElements" numberOfElements NumberOfElements.numberOfElementsSchema
       #+ FC.optional "lastPage" lastPage LastPage.lastPageSchema
-      #+ FC.optional "totalPages" totalPages TotalPages.totalPagesSchema
+      #+ FC.optional "numberOfElements" numberOfElements NumberOfElements.numberOfElementsSchema
+      #+ FC.optional "pageNumber" pageNumber PageNumber.pageNumberSchema
+      #+ FC.optional "pageSize" pageSize PageSize.pageSizeSchema
       #+ FC.optional "totalElements" totalElements TotalElements.totalElementsSchema
+      #+ FC.optional "totalPages" totalPages TotalPages.totalPagesSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SeasonBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SeasonBase.hs
@@ -15,11 +15,11 @@ import qualified StarTrek.Types.SeasonBase.Uid as Uid
 import qualified StarTrek.Types.SeriesHeader as SeriesHeader
 
 data SeasonBase = SeasonBase
-  { title :: Title.Title -- ^ Season title
-  , numberOfEpisodes :: Maybe NumberOfEpisodes.NumberOfEpisodes -- ^ Number of episodes in this season
-  , uid :: Uid.Uid -- ^ Season unique ID
+  { numberOfEpisodes :: Maybe NumberOfEpisodes.NumberOfEpisodes -- ^ Number of episodes in this season
   , seasonNumber :: Maybe SeasonNumber.SeasonNumber -- ^ Season number in series
   , series :: Maybe SeriesHeader.SeriesHeader -- ^ Header series, embedded in other objects
+  , title :: Title.Title -- ^ Season title
+  , uid :: Uid.Uid -- ^ Season unique ID
   }
   deriving (Eq, Show)
 
@@ -27,8 +27,8 @@ seasonBaseSchema :: FC.Fleece schema => schema SeasonBase
 seasonBaseSchema =
   FC.object $
     FC.constructor SeasonBase
-      #+ FC.required "title" title Title.titleSchema
       #+ FC.optional "numberOfEpisodes" numberOfEpisodes NumberOfEpisodes.numberOfEpisodesSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "seasonNumber" seasonNumber SeasonNumber.seasonNumberSchema
       #+ FC.optional "series" series SeriesHeader.seriesHeaderSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SeasonFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SeasonFull.hs
@@ -16,12 +16,12 @@ import qualified StarTrek.Types.SeasonFull.Uid as Uid
 import qualified StarTrek.Types.SeriesBase as SeriesBase
 
 data SeasonFull = SeasonFull
-  { title :: Title.Title -- ^ Season title
+  { episodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
   , numberOfEpisodes :: Maybe NumberOfEpisodes.NumberOfEpisodes -- ^ Number of episodes in this season
-  , uid :: Uid.Uid -- ^ Season unique ID
   , seasonNumber :: Maybe SeasonNumber.SeasonNumber -- ^ Season number in series
-  , episodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
   , series :: Maybe SeriesBase.SeriesBase -- ^ Base series, returned in search results
+  , title :: Title.Title -- ^ Season title
+  , uid :: Uid.Uid -- ^ Season unique ID
   }
   deriving (Eq, Show)
 
@@ -29,9 +29,9 @@ seasonFullSchema :: FC.Fleece schema => schema SeasonFull
 seasonFullSchema =
   FC.object $
     FC.constructor SeasonFull
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "numberOfEpisodes" numberOfEpisodes NumberOfEpisodes.numberOfEpisodesSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "seasonNumber" seasonNumber SeasonNumber.seasonNumberSchema
       #+ FC.optional "episodes" episodes (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "numberOfEpisodes" numberOfEpisodes NumberOfEpisodes.numberOfEpisodesSchema
+      #+ FC.optional "seasonNumber" seasonNumber SeasonNumber.seasonNumberSchema
       #+ FC.optional "series" series SeriesBase.seriesBaseSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SeriesBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SeriesBase.hs
@@ -21,18 +21,18 @@ import qualified StarTrek.Types.SeriesBase.Title as Title
 import qualified StarTrek.Types.SeriesBase.Uid as Uid
 
 data SeriesBase = SeriesBase
-  { title :: Title.Title -- ^ Series title
-  , productionStartYear :: Maybe ProductionStartYear.ProductionStartYear -- ^ Year the series production started
+  { abbreviation :: Abbreviation.Abbreviation -- ^ Series abbreviation
   , episodesCount :: Maybe EpisodesCount.EpisodesCount -- ^ Number of episodes
-  , productionCompany :: Maybe CompanyHeader.CompanyHeader -- ^ Header company, embedded in other objects
-  , seasonsCount :: Maybe SeasonsCount.SeasonsCount -- ^ Number of seasons
-  , abbreviation :: Abbreviation.Abbreviation -- ^ Series abbreviation
-  , uid :: Uid.Uid -- ^ Series unique ID
-  , originalRunStartDate :: Maybe OriginalRunStartDate.OriginalRunStartDate -- ^ Date the series originally ran from
-  , originalBroadcaster :: Maybe CompanyHeader.CompanyHeader -- ^ Header company, embedded in other objects
   , featureLengthEpisodesCount :: Maybe FeatureLengthEpisodesCount.FeatureLengthEpisodesCount -- ^ Number of feature length episodes
-  , productionEndYear :: Maybe ProductionEndYear.ProductionEndYear -- ^ Year the series production ended
+  , originalBroadcaster :: Maybe CompanyHeader.CompanyHeader -- ^ Header company, embedded in other objects
   , originalRunEndDate :: Maybe OriginalRunEndDate.OriginalRunEndDate -- ^ Date the series originally ran to
+  , originalRunStartDate :: Maybe OriginalRunStartDate.OriginalRunStartDate -- ^ Date the series originally ran from
+  , productionCompany :: Maybe CompanyHeader.CompanyHeader -- ^ Header company, embedded in other objects
+  , productionEndYear :: Maybe ProductionEndYear.ProductionEndYear -- ^ Year the series production ended
+  , productionStartYear :: Maybe ProductionStartYear.ProductionStartYear -- ^ Year the series production started
+  , seasonsCount :: Maybe SeasonsCount.SeasonsCount -- ^ Number of seasons
+  , title :: Title.Title -- ^ Series title
+  , uid :: Uid.Uid -- ^ Series unique ID
   }
   deriving (Eq, Show)
 
@@ -40,15 +40,15 @@ seriesBaseSchema :: FC.Fleece schema => schema SeriesBase
 seriesBaseSchema =
   FC.object $
     FC.constructor SeriesBase
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "productionStartYear" productionStartYear ProductionStartYear.productionStartYearSchema
-      #+ FC.optional "episodesCount" episodesCount EpisodesCount.episodesCountSchema
-      #+ FC.optional "productionCompany" productionCompany CompanyHeader.companyHeaderSchema
-      #+ FC.optional "seasonsCount" seasonsCount SeasonsCount.seasonsCountSchema
       #+ FC.required "abbreviation" abbreviation Abbreviation.abbreviationSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "originalRunStartDate" originalRunStartDate OriginalRunStartDate.originalRunStartDateSchema
-      #+ FC.optional "originalBroadcaster" originalBroadcaster CompanyHeader.companyHeaderSchema
+      #+ FC.optional "episodesCount" episodesCount EpisodesCount.episodesCountSchema
       #+ FC.optional "featureLengthEpisodesCount" featureLengthEpisodesCount FeatureLengthEpisodesCount.featureLengthEpisodesCountSchema
-      #+ FC.optional "productionEndYear" productionEndYear ProductionEndYear.productionEndYearSchema
+      #+ FC.optional "originalBroadcaster" originalBroadcaster CompanyHeader.companyHeaderSchema
       #+ FC.optional "originalRunEndDate" originalRunEndDate OriginalRunEndDate.originalRunEndDateSchema
+      #+ FC.optional "originalRunStartDate" originalRunStartDate OriginalRunStartDate.originalRunStartDateSchema
+      #+ FC.optional "productionCompany" productionCompany CompanyHeader.companyHeaderSchema
+      #+ FC.optional "productionEndYear" productionEndYear ProductionEndYear.productionEndYearSchema
+      #+ FC.optional "productionStartYear" productionStartYear ProductionStartYear.productionStartYearSchema
+      #+ FC.optional "seasonsCount" seasonsCount SeasonsCount.seasonsCountSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SeriesBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SeriesBaseResponse.hs
@@ -14,8 +14,8 @@ import qualified StarTrek.Types.SeriesBase as SeriesBase
 
 data SeriesBaseResponse = SeriesBaseResponse
   { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   , series :: Maybe [SeriesBase.SeriesBase] -- ^ Base series, returned in search results
+  , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
   }
   deriving (Eq, Show)
 
@@ -24,5 +24,5 @@ seriesBaseResponseSchema =
   FC.object $
     FC.constructor SeriesBaseResponse
       #+ FC.optional "page" page ResponsePage.responsePageSchema
-      #+ FC.optional "sort" sort ResponseSort.responseSortSchema
       #+ FC.optional "series" series (FC.list SeriesBase.seriesBaseSchema)
+      #+ FC.optional "sort" sort ResponseSort.responseSortSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SeriesFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SeriesFull.hs
@@ -23,20 +23,20 @@ import qualified StarTrek.Types.SeriesFull.Title as Title
 import qualified StarTrek.Types.SeriesFull.Uid as Uid
 
 data SeriesFull = SeriesFull
-  { title :: Title.Title -- ^ Series title
-  , productionStartYear :: Maybe ProductionStartYear.ProductionStartYear -- ^ Year the series production started
-  , episodesCount :: Maybe EpisodesCount.EpisodesCount -- ^ Number of episodes
-  , productionCompany :: Maybe CompanyBase.CompanyBase -- ^ Base company, returned in search results
-  , seasonsCount :: Maybe SeasonsCount.SeasonsCount -- ^ Number of seasons
-  , abbreviation :: Abbreviation.Abbreviation -- ^ Series abbreviation
-  , seasons :: Maybe [SeasonBase.SeasonBase] -- ^ Base season, returned in search results
-  , uid :: Uid.Uid -- ^ Series unique ID
-  , originalRunStartDate :: Maybe OriginalRunStartDate.OriginalRunStartDate -- ^ Date the series originally ran from
-  , originalBroadcaster :: Maybe CompanyBase.CompanyBase -- ^ Base company, returned in search results
-  , featureLengthEpisodesCount :: Maybe FeatureLengthEpisodesCount.FeatureLengthEpisodesCount -- ^ Number of feature length episodes
-  , productionEndYear :: Maybe ProductionEndYear.ProductionEndYear -- ^ Year the series production ended
+  { abbreviation :: Abbreviation.Abbreviation -- ^ Series abbreviation
   , episodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , episodesCount :: Maybe EpisodesCount.EpisodesCount -- ^ Number of episodes
+  , featureLengthEpisodesCount :: Maybe FeatureLengthEpisodesCount.FeatureLengthEpisodesCount -- ^ Number of feature length episodes
+  , originalBroadcaster :: Maybe CompanyBase.CompanyBase -- ^ Base company, returned in search results
   , originalRunEndDate :: Maybe OriginalRunEndDate.OriginalRunEndDate -- ^ Date the series originally ran to
+  , originalRunStartDate :: Maybe OriginalRunStartDate.OriginalRunStartDate -- ^ Date the series originally ran from
+  , productionCompany :: Maybe CompanyBase.CompanyBase -- ^ Base company, returned in search results
+  , productionEndYear :: Maybe ProductionEndYear.ProductionEndYear -- ^ Year the series production ended
+  , productionStartYear :: Maybe ProductionStartYear.ProductionStartYear -- ^ Year the series production started
+  , seasons :: Maybe [SeasonBase.SeasonBase] -- ^ Base season, returned in search results
+  , seasonsCount :: Maybe SeasonsCount.SeasonsCount -- ^ Number of seasons
+  , title :: Title.Title -- ^ Series title
+  , uid :: Uid.Uid -- ^ Series unique ID
   }
   deriving (Eq, Show)
 
@@ -44,17 +44,17 @@ seriesFullSchema :: FC.Fleece schema => schema SeriesFull
 seriesFullSchema =
   FC.object $
     FC.constructor SeriesFull
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "productionStartYear" productionStartYear ProductionStartYear.productionStartYearSchema
-      #+ FC.optional "episodesCount" episodesCount EpisodesCount.episodesCountSchema
-      #+ FC.optional "productionCompany" productionCompany CompanyBase.companyBaseSchema
-      #+ FC.optional "seasonsCount" seasonsCount SeasonsCount.seasonsCountSchema
       #+ FC.required "abbreviation" abbreviation Abbreviation.abbreviationSchema
-      #+ FC.optional "seasons" seasons (FC.list SeasonBase.seasonBaseSchema)
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "originalRunStartDate" originalRunStartDate OriginalRunStartDate.originalRunStartDateSchema
-      #+ FC.optional "originalBroadcaster" originalBroadcaster CompanyBase.companyBaseSchema
-      #+ FC.optional "featureLengthEpisodesCount" featureLengthEpisodesCount FeatureLengthEpisodesCount.featureLengthEpisodesCountSchema
-      #+ FC.optional "productionEndYear" productionEndYear ProductionEndYear.productionEndYearSchema
       #+ FC.optional "episodes" episodes (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "episodesCount" episodesCount EpisodesCount.episodesCountSchema
+      #+ FC.optional "featureLengthEpisodesCount" featureLengthEpisodesCount FeatureLengthEpisodesCount.featureLengthEpisodesCountSchema
+      #+ FC.optional "originalBroadcaster" originalBroadcaster CompanyBase.companyBaseSchema
       #+ FC.optional "originalRunEndDate" originalRunEndDate OriginalRunEndDate.originalRunEndDateSchema
+      #+ FC.optional "originalRunStartDate" originalRunStartDate OriginalRunStartDate.originalRunStartDateSchema
+      #+ FC.optional "productionCompany" productionCompany CompanyBase.companyBaseSchema
+      #+ FC.optional "productionEndYear" productionEndYear ProductionEndYear.productionEndYearSchema
+      #+ FC.optional "productionStartYear" productionStartYear ProductionStartYear.productionStartYearSchema
+      #+ FC.optional "seasons" seasons (FC.list SeasonBase.seasonBaseSchema)
+      #+ FC.optional "seasonsCount" seasonsCount SeasonsCount.seasonsCountSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SoundtrackBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SoundtrackBase.hs
@@ -14,10 +14,10 @@ import qualified StarTrek.Types.SoundtrackBase.Title as Title
 import qualified StarTrek.Types.SoundtrackBase.Uid as Uid
 
 data SoundtrackBase = SoundtrackBase
-  { title :: Title.Title -- ^ Soundtrack title
-  , length :: Maybe Length.Length -- ^ Length, in seconds
-  , uid :: Uid.Uid -- ^ Soundtrack unique ID
+  { length :: Maybe Length.Length -- ^ Length, in seconds
   , releaseDate :: Maybe ReleaseDate.ReleaseDate -- ^ Release date
+  , title :: Title.Title -- ^ Soundtrack title
+  , uid :: Uid.Uid -- ^ Soundtrack unique ID
   }
   deriving (Eq, Show)
 
@@ -25,7 +25,7 @@ soundtrackBaseSchema :: FC.Fleece schema => schema SoundtrackBase
 soundtrackBaseSchema =
   FC.object $
     FC.constructor SoundtrackBase
-      #+ FC.required "title" title Title.titleSchema
       #+ FC.optional "length" length Length.lengthSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "releaseDate" releaseDate ReleaseDate.releaseDateSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SoundtrackFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SoundtrackFull.hs
@@ -17,15 +17,15 @@ import qualified StarTrek.Types.SoundtrackFull.Uid as Uid
 import qualified StarTrek.Types.StaffBase as StaffBase
 
 data SoundtrackFull = SoundtrackFull
-  { title :: Title.Title -- ^ Soundtrack title
-  , length :: Maybe Length.Length -- ^ Length, in seconds
-  , composers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
-  , uid :: Uid.Uid -- ^ Soundtrack unique ID
-  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
-  , labels :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  { composers :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
   , contributors :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , labels :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  , length :: Maybe Length.Length -- ^ Length, in seconds
   , orchestrators :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
+  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
   , releaseDate :: Maybe ReleaseDate.ReleaseDate -- ^ Release date
+  , title :: Title.Title -- ^ Soundtrack title
+  , uid :: Uid.Uid -- ^ Soundtrack unique ID
   }
   deriving (Eq, Show)
 
@@ -33,12 +33,12 @@ soundtrackFullSchema :: FC.Fleece schema => schema SoundtrackFull
 soundtrackFullSchema =
   FC.object $
     FC.constructor SoundtrackFull
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "length" length Length.lengthSchema
       #+ FC.optional "composers" composers (FC.list StaffBase.staffBaseSchema)
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
-      #+ FC.optional "labels" labels (FC.list CompanyBase.companyBaseSchema)
       #+ FC.optional "contributors" contributors (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "labels" labels (FC.list CompanyBase.companyBaseSchema)
+      #+ FC.optional "length" length Length.lengthSchema
       #+ FC.optional "orchestrators" orchestrators (FC.list StaffBase.staffBaseSchema)
+      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
       #+ FC.optional "releaseDate" releaseDate ReleaseDate.releaseDateSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftBase.hs
@@ -17,14 +17,14 @@ import qualified StarTrek.Types.SpacecraftBase.Uid as Uid
 import qualified StarTrek.Types.SpacecraftClassHeader as SpacecraftClassHeader
 
 data SpacecraftBase = SpacecraftBase
-  { registry :: Maybe Registry.Registry -- ^ Spacecraft registry
-  , status :: Maybe Status.Status -- ^ Status of a spacecraft (in prime reality, if spacecraft was in more than one realities)
-  , owner :: Maybe OrganizationHeader.OrganizationHeader -- ^ Header organization, embedded in other objects
-  , uid :: Uid.Uid -- ^ Spacecraft unique ID
-  , dateStatus :: Maybe DateStatus.DateStatus -- ^ Date the spacecraft status was last known
+  { dateStatus :: Maybe DateStatus.DateStatus -- ^ Date the spacecraft status was last known
   , name :: Name.Name -- ^ Spacecraft name
   , operator :: Maybe OrganizationHeader.OrganizationHeader -- ^ Header organization, embedded in other objects
+  , owner :: Maybe OrganizationHeader.OrganizationHeader -- ^ Header organization, embedded in other objects
+  , registry :: Maybe Registry.Registry -- ^ Spacecraft registry
   , spacecraftClass :: Maybe SpacecraftClassHeader.SpacecraftClassHeader -- ^ Header spacecraft class, embedded in other objects
+  , status :: Maybe Status.Status -- ^ Status of a spacecraft (in prime reality, if spacecraft was in more than one realities)
+  , uid :: Uid.Uid -- ^ Spacecraft unique ID
   }
   deriving (Eq, Show)
 
@@ -32,11 +32,11 @@ spacecraftBaseSchema :: FC.Fleece schema => schema SpacecraftBase
 spacecraftBaseSchema =
   FC.object $
     FC.constructor SpacecraftBase
-      #+ FC.optional "registry" registry Registry.registrySchema
-      #+ FC.optional "status" status Status.statusSchema
-      #+ FC.optional "owner" owner OrganizationHeader.organizationHeaderSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "dateStatus" dateStatus DateStatus.dateStatusSchema
       #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "operator" operator OrganizationHeader.organizationHeaderSchema
+      #+ FC.optional "owner" owner OrganizationHeader.organizationHeaderSchema
+      #+ FC.optional "registry" registry Registry.registrySchema
       #+ FC.optional "spacecraftClass" spacecraftClass SpacecraftClassHeader.spacecraftClassHeaderSchema
+      #+ FC.optional "status" status Status.statusSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftBaseResponse.hs
@@ -14,8 +14,8 @@ import qualified StarTrek.Types.SpacecraftBase as SpacecraftBase
 
 data SpacecraftBaseResponse = SpacecraftBaseResponse
   { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , spacecrafts :: Maybe [SpacecraftBase.SpacecraftBase] -- ^ Base spacecraft, returned in search results
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
+  , spacecrafts :: Maybe [SpacecraftBase.SpacecraftBase] -- ^ Base spacecraft, returned in search results
   }
   deriving (Eq, Show)
 
@@ -24,5 +24,5 @@ spacecraftBaseResponseSchema =
   FC.object $
     FC.constructor SpacecraftBaseResponse
       #+ FC.optional "page" page ResponsePage.responsePageSchema
-      #+ FC.optional "spacecrafts" spacecrafts (FC.list SpacecraftBase.spacecraftBaseSchema)
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
+      #+ FC.optional "spacecrafts" spacecrafts (FC.list SpacecraftBase.spacecraftBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftClassBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftClassBase.hs
@@ -19,17 +19,17 @@ import qualified StarTrek.Types.SpacecraftClassBase.WarpCapable as WarpCapable
 import qualified StarTrek.Types.SpeciesHeader as SpeciesHeader
 
 data SpacecraftClassBase = SpacecraftClassBase
-  { warpCapable :: Maybe WarpCapable.WarpCapable -- ^ Whether it's a warp-capable spacecraft class
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this spacecraft class is from alternate reality
-  , affiliation :: Maybe OrganizationHeader.OrganizationHeader -- ^ Header organization, embedded in other objects
-  , species :: Maybe SpeciesHeader.SpeciesHeader -- ^ Header species, embedded in other objects
-  , owner :: Maybe OrganizationHeader.OrganizationHeader -- ^ Header organization, embedded in other objects
-  , uid :: Uid.Uid -- ^ Spacecraft class unique ID
-  , numberOfDecks :: Maybe NumberOfDecks.NumberOfDecks -- ^ Number of decks
-  , name :: Name.Name -- ^ Spacecraft class name
+  { activeFrom :: Maybe ActiveFrom.ActiveFrom -- ^ Starting period when this spacecraft class was in use
   , activeTo :: Maybe ActiveTo.ActiveTo -- ^ Ending period when this spacecraft class was in use
-  , activeFrom :: Maybe ActiveFrom.ActiveFrom -- ^ Starting period when this spacecraft class was in use
+  , affiliation :: Maybe OrganizationHeader.OrganizationHeader -- ^ Header organization, embedded in other objects
+  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this spacecraft class is from alternate reality
+  , name :: Name.Name -- ^ Spacecraft class name
+  , numberOfDecks :: Maybe NumberOfDecks.NumberOfDecks -- ^ Number of decks
   , operator :: Maybe OrganizationHeader.OrganizationHeader -- ^ Header organization, embedded in other objects
+  , owner :: Maybe OrganizationHeader.OrganizationHeader -- ^ Header organization, embedded in other objects
+  , species :: Maybe SpeciesHeader.SpeciesHeader -- ^ Header species, embedded in other objects
+  , uid :: Uid.Uid -- ^ Spacecraft class unique ID
+  , warpCapable :: Maybe WarpCapable.WarpCapable -- ^ Whether it's a warp-capable spacecraft class
   }
   deriving (Eq, Show)
 
@@ -37,14 +37,14 @@ spacecraftClassBaseSchema :: FC.Fleece schema => schema SpacecraftClassBase
 spacecraftClassBaseSchema =
   FC.object $
     FC.constructor SpacecraftClassBase
-      #+ FC.optional "warpCapable" warpCapable WarpCapable.warpCapableSchema
-      #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
-      #+ FC.optional "affiliation" affiliation OrganizationHeader.organizationHeaderSchema
-      #+ FC.optional "species" species SpeciesHeader.speciesHeaderSchema
-      #+ FC.optional "owner" owner OrganizationHeader.organizationHeaderSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "numberOfDecks" numberOfDecks NumberOfDecks.numberOfDecksSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "activeTo" activeTo ActiveTo.activeToSchema
       #+ FC.optional "activeFrom" activeFrom ActiveFrom.activeFromSchema
+      #+ FC.optional "activeTo" activeTo ActiveTo.activeToSchema
+      #+ FC.optional "affiliation" affiliation OrganizationHeader.organizationHeaderSchema
+      #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "numberOfDecks" numberOfDecks NumberOfDecks.numberOfDecksSchema
       #+ FC.optional "operator" operator OrganizationHeader.organizationHeaderSchema
+      #+ FC.optional "owner" owner OrganizationHeader.organizationHeaderSchema
+      #+ FC.optional "species" species SpeciesHeader.speciesHeaderSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "warpCapable" warpCapable WarpCapable.warpCapableSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftClassBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftClassBaseResponse.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.ResponseSort as ResponseSort
 import qualified StarTrek.Types.SpacecraftClassBase as SpacecraftClassBase
 
 data SpacecraftClassBaseResponse = SpacecraftClassBaseResponse
-  { spacecraftClasses :: Maybe [SpacecraftClassBase.SpacecraftClassBase] -- ^ Base spacecraft class, returned in search results
-  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
+  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
+  , spacecraftClasses :: Maybe [SpacecraftClassBase.SpacecraftClassBase] -- ^ Base spacecraft class, returned in search results
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ spacecraftClassBaseResponseSchema :: FC.Fleece schema => schema SpacecraftClassB
 spacecraftClassBaseResponseSchema =
   FC.object $
     FC.constructor SpacecraftClassBaseResponse
-      #+ FC.optional "spacecraftClasses" spacecraftClasses (FC.list SpacecraftClassBase.spacecraftClassBaseSchema)
       #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
+      #+ FC.optional "spacecraftClasses" spacecraftClasses (FC.list SpacecraftClassBase.spacecraftClassBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftClassFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftClassFull.hs
@@ -21,19 +21,19 @@ import qualified StarTrek.Types.SpacecraftType as SpacecraftType
 import qualified StarTrek.Types.SpeciesHeader as SpeciesHeader
 
 data SpacecraftClassFull = SpacecraftClassFull
-  { warpCapable :: Maybe WarpCapable.WarpCapable -- ^ Whether it's a warp-capable spacecraft class
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this spacecraft class is from alternate reality
-  , affiliation :: Maybe OrganizationBase.OrganizationBase -- ^ Base organization, returned in search results
-  , species :: Maybe SpeciesHeader.SpeciesHeader -- ^ Header species, embedded in other objects
-  , spacecrafts :: Maybe [SpacecraftBase.SpacecraftBase] -- ^ Base spacecraft, returned in search results
-  , owner :: Maybe OrganizationBase.OrganizationBase -- ^ Base organization, returned in search results
-  , uid :: Uid.Uid -- ^ Spacecraft class unique ID
-  , numberOfDecks :: Maybe NumberOfDecks.NumberOfDecks -- ^ Number of decks
-  , name :: Name.Name -- ^ Spacecraft class name
+  { activeFrom :: Maybe ActiveFrom.ActiveFrom -- ^ Starting period when this spacecraft class was in use
   , activeTo :: Maybe ActiveTo.ActiveTo -- ^ Ending period when this spacecraft class was in use
-  , activeFrom :: Maybe ActiveFrom.ActiveFrom -- ^ Starting period when this spacecraft class was in use
-  , spacecraftTypes :: Maybe [SpacecraftType.SpacecraftType] -- ^ Rating of video release, etc.
+  , affiliation :: Maybe OrganizationBase.OrganizationBase -- ^ Base organization, returned in search results
+  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this spacecraft class is from alternate reality
+  , name :: Name.Name -- ^ Spacecraft class name
+  , numberOfDecks :: Maybe NumberOfDecks.NumberOfDecks -- ^ Number of decks
   , operator :: Maybe OrganizationBase.OrganizationBase -- ^ Base organization, returned in search results
+  , owner :: Maybe OrganizationBase.OrganizationBase -- ^ Base organization, returned in search results
+  , spacecraftTypes :: Maybe [SpacecraftType.SpacecraftType] -- ^ Rating of video release, etc.
+  , spacecrafts :: Maybe [SpacecraftBase.SpacecraftBase] -- ^ Base spacecraft, returned in search results
+  , species :: Maybe SpeciesHeader.SpeciesHeader -- ^ Header species, embedded in other objects
+  , uid :: Uid.Uid -- ^ Spacecraft class unique ID
+  , warpCapable :: Maybe WarpCapable.WarpCapable -- ^ Whether it's a warp-capable spacecraft class
   }
   deriving (Eq, Show)
 
@@ -41,16 +41,16 @@ spacecraftClassFullSchema :: FC.Fleece schema => schema SpacecraftClassFull
 spacecraftClassFullSchema =
   FC.object $
     FC.constructor SpacecraftClassFull
-      #+ FC.optional "warpCapable" warpCapable WarpCapable.warpCapableSchema
-      #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
-      #+ FC.optional "affiliation" affiliation OrganizationBase.organizationBaseSchema
-      #+ FC.optional "species" species SpeciesHeader.speciesHeaderSchema
-      #+ FC.optional "spacecrafts" spacecrafts (FC.list SpacecraftBase.spacecraftBaseSchema)
-      #+ FC.optional "owner" owner OrganizationBase.organizationBaseSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "numberOfDecks" numberOfDecks NumberOfDecks.numberOfDecksSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "activeTo" activeTo ActiveTo.activeToSchema
       #+ FC.optional "activeFrom" activeFrom ActiveFrom.activeFromSchema
-      #+ FC.optional "spacecraftTypes" spacecraftTypes (FC.list SpacecraftType.spacecraftTypeSchema)
+      #+ FC.optional "activeTo" activeTo ActiveTo.activeToSchema
+      #+ FC.optional "affiliation" affiliation OrganizationBase.organizationBaseSchema
+      #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "numberOfDecks" numberOfDecks NumberOfDecks.numberOfDecksSchema
       #+ FC.optional "operator" operator OrganizationBase.organizationBaseSchema
+      #+ FC.optional "owner" owner OrganizationBase.organizationBaseSchema
+      #+ FC.optional "spacecraftTypes" spacecraftTypes (FC.list SpacecraftType.spacecraftTypeSchema)
+      #+ FC.optional "spacecrafts" spacecrafts (FC.list SpacecraftBase.spacecraftBaseSchema)
+      #+ FC.optional "species" species SpeciesHeader.speciesHeaderSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "warpCapable" warpCapable WarpCapable.warpCapableSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftClassHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftClassHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.SpacecraftClassHeader.Name as Name
 import qualified StarTrek.Types.SpacecraftClassHeader.Uid as Uid
 
 data SpacecraftClassHeader = SpacecraftClassHeader
-  { uid :: Uid.Uid -- ^ Spacecraft class unique ID
-  , name :: Name.Name -- ^ Spacecraft class name
+  { name :: Name.Name -- ^ Spacecraft class name
+  , uid :: Uid.Uid -- ^ Spacecraft class unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ spacecraftClassHeaderSchema :: FC.Fleece schema => schema SpacecraftClassHeader
 spacecraftClassHeaderSchema =
   FC.object $
     FC.constructor SpacecraftClassHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftFull.hs
@@ -18,15 +18,15 @@ import qualified StarTrek.Types.SpacecraftFull.Uid as Uid
 import qualified StarTrek.Types.SpacecraftType as SpacecraftType
 
 data SpacecraftFull = SpacecraftFull
-  { registry :: Maybe Registry.Registry -- ^ Spacecraft registry
-  , status :: Maybe Status.Status -- ^ Status of a spacecraft (in prime reality, if spacecraft was in more than one realities)
-  , owner :: Maybe OrganizationBase.OrganizationBase -- ^ Base organization, returned in search results
-  , uid :: Uid.Uid -- ^ Spacecraft unique ID
-  , dateStatus :: Maybe DateStatus.DateStatus -- ^ Date the spacecraft status was last known
+  { dateStatus :: Maybe DateStatus.DateStatus -- ^ Date the spacecraft status was last known
   , name :: Name.Name -- ^ Spacecraft name
-  , spacecraftTypes :: Maybe [SpacecraftType.SpacecraftType] -- ^ Rating of video release, etc.
   , operator :: Maybe OrganizationBase.OrganizationBase -- ^ Base organization, returned in search results
+  , owner :: Maybe OrganizationBase.OrganizationBase -- ^ Base organization, returned in search results
+  , registry :: Maybe Registry.Registry -- ^ Spacecraft registry
   , spacecraftClass :: Maybe SpacecraftClassBase.SpacecraftClassBase -- ^ Base spacecraft class, returned in search results
+  , spacecraftTypes :: Maybe [SpacecraftType.SpacecraftType] -- ^ Rating of video release, etc.
+  , status :: Maybe Status.Status -- ^ Status of a spacecraft (in prime reality, if spacecraft was in more than one realities)
+  , uid :: Uid.Uid -- ^ Spacecraft unique ID
   }
   deriving (Eq, Show)
 
@@ -34,12 +34,12 @@ spacecraftFullSchema :: FC.Fleece schema => schema SpacecraftFull
 spacecraftFullSchema =
   FC.object $
     FC.constructor SpacecraftFull
-      #+ FC.optional "registry" registry Registry.registrySchema
-      #+ FC.optional "status" status Status.statusSchema
-      #+ FC.optional "owner" owner OrganizationBase.organizationBaseSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "dateStatus" dateStatus DateStatus.dateStatusSchema
       #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "spacecraftTypes" spacecraftTypes (FC.list SpacecraftType.spacecraftTypeSchema)
       #+ FC.optional "operator" operator OrganizationBase.organizationBaseSchema
+      #+ FC.optional "owner" owner OrganizationBase.organizationBaseSchema
+      #+ FC.optional "registry" registry Registry.registrySchema
       #+ FC.optional "spacecraftClass" spacecraftClass SpacecraftClassBase.spacecraftClassBaseSchema
+      #+ FC.optional "spacecraftTypes" spacecraftTypes (FC.list SpacecraftType.spacecraftTypeSchema)
+      #+ FC.optional "status" status Status.statusSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.SpacecraftHeader.Name as Name
 import qualified StarTrek.Types.SpacecraftHeader.Uid as Uid
 
 data SpacecraftHeader = SpacecraftHeader
-  { uid :: Uid.Uid -- ^ Spacecraft unique ID
-  , name :: Name.Name -- ^ Spacecraft name
+  { name :: Name.Name -- ^ Spacecraft name
+  , uid :: Uid.Uid -- ^ Spacecraft unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ spacecraftHeaderSchema :: FC.Fleece schema => schema SpacecraftHeader
 spacecraftHeaderSchema =
   FC.object $
     FC.constructor SpacecraftHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftType.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpacecraftType.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.SpacecraftType.Name as Name
 import qualified StarTrek.Types.SpacecraftType.Uid as Uid
 
 data SpacecraftType = SpacecraftType
-  { uid :: Maybe Uid.Uid -- ^ Spacecraft type unique ID
-  , name :: Maybe Name.Name -- ^ Spacecraft type name
+  { name :: Maybe Name.Name -- ^ Spacecraft type name
+  , uid :: Maybe Uid.Uid -- ^ Spacecraft type unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ spacecraftTypeSchema :: FC.Fleece schema => schema SpacecraftType
 spacecraftTypeSchema =
   FC.object $
     FC.constructor SpacecraftType
-      #+ FC.optional "uid" uid Uid.uidSchema
       #+ FC.optional "name" name Name.nameSchema
+      #+ FC.optional "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpeciesBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpeciesBase.hs
@@ -25,22 +25,22 @@ import qualified StarTrek.Types.SpeciesBase.UnnamedSpecies as UnnamedSpecies
 import qualified StarTrek.Types.SpeciesBase.WarpCapableSpecies as WarpCapableSpecies
 
 data SpeciesBase = SpeciesBase
-  { extraGalacticSpecies :: Maybe ExtraGalacticSpecies.ExtraGalacticSpecies -- ^ Whether it's an extra-galactic species
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this species is from alternate reality
   , extinctSpecies :: Maybe ExtinctSpecies.ExtinctSpecies -- ^ Whether it's an extinct species
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this species is from alternate reality
+  , extraGalacticSpecies :: Maybe ExtraGalacticSpecies.ExtraGalacticSpecies -- ^ Whether it's an extra-galactic species
   , homeworld :: Maybe AstronomicalObjectHeader.AstronomicalObjectHeader -- ^ Header astronomical object, embedded in other objects
-  , transDimensionalSpecies :: Maybe TransDimensionalSpecies.TransDimensionalSpecies -- ^ Whether it's a trans-dimensional species
-  , shapeshiftingSpecies :: Maybe ShapeshiftingSpecies.ShapeshiftingSpecies -- ^ Whether it's a shapeshifting species
   , humanoidSpecies :: Maybe HumanoidSpecies.HumanoidSpecies -- ^ Whether it's a humanoid species
-  , reptilianSpecies :: Maybe ReptilianSpecies.ReptilianSpecies -- ^ Whether it's a reptilian species
-  , warpCapableSpecies :: Maybe WarpCapableSpecies.WarpCapableSpecies -- ^ Whether it's a warp-capable species
-  , spaceborneSpecies :: Maybe SpaceborneSpecies.SpaceborneSpecies -- ^ Whether it's a spaceborne species
-  , uid :: Uid.Uid -- ^ Species unique ID
-  , telepathicSpecies :: Maybe TelepathicSpecies.TelepathicSpecies -- ^ Whether it's a telepathic species
-  , unnamedSpecies :: Maybe UnnamedSpecies.UnnamedSpecies -- ^ Whether it's a unnamed species
   , name :: Name.Name -- ^ Species name
   , nonCorporealSpecies :: Maybe NonCorporealSpecies.NonCorporealSpecies -- ^ Whether it's a non-corporeal species
   , quadrant :: Maybe AstronomicalObjectHeader.AstronomicalObjectHeader -- ^ Header astronomical object, embedded in other objects
+  , reptilianSpecies :: Maybe ReptilianSpecies.ReptilianSpecies -- ^ Whether it's a reptilian species
+  , shapeshiftingSpecies :: Maybe ShapeshiftingSpecies.ShapeshiftingSpecies -- ^ Whether it's a shapeshifting species
+  , spaceborneSpecies :: Maybe SpaceborneSpecies.SpaceborneSpecies -- ^ Whether it's a spaceborne species
+  , telepathicSpecies :: Maybe TelepathicSpecies.TelepathicSpecies -- ^ Whether it's a telepathic species
+  , transDimensionalSpecies :: Maybe TransDimensionalSpecies.TransDimensionalSpecies -- ^ Whether it's a trans-dimensional species
+  , uid :: Uid.Uid -- ^ Species unique ID
+  , unnamedSpecies :: Maybe UnnamedSpecies.UnnamedSpecies -- ^ Whether it's a unnamed species
+  , warpCapableSpecies :: Maybe WarpCapableSpecies.WarpCapableSpecies -- ^ Whether it's a warp-capable species
   }
   deriving (Eq, Show)
 
@@ -48,19 +48,19 @@ speciesBaseSchema :: FC.Fleece schema => schema SpeciesBase
 speciesBaseSchema =
   FC.object $
     FC.constructor SpeciesBase
-      #+ FC.optional "extraGalacticSpecies" extraGalacticSpecies ExtraGalacticSpecies.extraGalacticSpeciesSchema
-      #+ FC.optional "extinctSpecies" extinctSpecies ExtinctSpecies.extinctSpeciesSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
+      #+ FC.optional "extinctSpecies" extinctSpecies ExtinctSpecies.extinctSpeciesSchema
+      #+ FC.optional "extraGalacticSpecies" extraGalacticSpecies ExtraGalacticSpecies.extraGalacticSpeciesSchema
       #+ FC.optional "homeworld" homeworld AstronomicalObjectHeader.astronomicalObjectHeaderSchema
-      #+ FC.optional "transDimensionalSpecies" transDimensionalSpecies TransDimensionalSpecies.transDimensionalSpeciesSchema
-      #+ FC.optional "shapeshiftingSpecies" shapeshiftingSpecies ShapeshiftingSpecies.shapeshiftingSpeciesSchema
       #+ FC.optional "humanoidSpecies" humanoidSpecies HumanoidSpecies.humanoidSpeciesSchema
-      #+ FC.optional "reptilianSpecies" reptilianSpecies ReptilianSpecies.reptilianSpeciesSchema
-      #+ FC.optional "warpCapableSpecies" warpCapableSpecies WarpCapableSpecies.warpCapableSpeciesSchema
-      #+ FC.optional "spaceborneSpecies" spaceborneSpecies SpaceborneSpecies.spaceborneSpeciesSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "telepathicSpecies" telepathicSpecies TelepathicSpecies.telepathicSpeciesSchema
-      #+ FC.optional "unnamedSpecies" unnamedSpecies UnnamedSpecies.unnamedSpeciesSchema
       #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "nonCorporealSpecies" nonCorporealSpecies NonCorporealSpecies.nonCorporealSpeciesSchema
       #+ FC.optional "quadrant" quadrant AstronomicalObjectHeader.astronomicalObjectHeaderSchema
+      #+ FC.optional "reptilianSpecies" reptilianSpecies ReptilianSpecies.reptilianSpeciesSchema
+      #+ FC.optional "shapeshiftingSpecies" shapeshiftingSpecies ShapeshiftingSpecies.shapeshiftingSpeciesSchema
+      #+ FC.optional "spaceborneSpecies" spaceborneSpecies SpaceborneSpecies.spaceborneSpeciesSchema
+      #+ FC.optional "telepathicSpecies" telepathicSpecies TelepathicSpecies.telepathicSpeciesSchema
+      #+ FC.optional "transDimensionalSpecies" transDimensionalSpecies TransDimensionalSpecies.transDimensionalSpeciesSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "unnamedSpecies" unnamedSpecies UnnamedSpecies.unnamedSpeciesSchema
+      #+ FC.optional "warpCapableSpecies" warpCapableSpecies WarpCapableSpecies.warpCapableSpeciesSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpeciesBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpeciesBaseResponse.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.ResponseSort as ResponseSort
 import qualified StarTrek.Types.SpeciesBase as SpeciesBase
 
 data SpeciesBaseResponse = SpeciesBaseResponse
-  { species :: Maybe [SpeciesBase.SpeciesBase] -- ^ Base species, returned in search results
-  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
+  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
+  , species :: Maybe [SpeciesBase.SpeciesBase] -- ^ Base species, returned in search results
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ speciesBaseResponseSchema :: FC.Fleece schema => schema SpeciesBaseResponse
 speciesBaseResponseSchema =
   FC.object $
     FC.constructor SpeciesBaseResponse
-      #+ FC.optional "species" species (FC.list SpeciesBase.speciesBaseSchema)
       #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
+      #+ FC.optional "species" species (FC.list SpeciesBase.speciesBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpeciesFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpeciesFull.hs
@@ -26,23 +26,23 @@ import qualified StarTrek.Types.SpeciesFull.UnnamedSpecies as UnnamedSpecies
 import qualified StarTrek.Types.SpeciesFull.WarpCapableSpecies as WarpCapableSpecies
 
 data SpeciesFull = SpeciesFull
-  { extraGalacticSpecies :: Maybe ExtraGalacticSpecies.ExtraGalacticSpecies -- ^ Whether it's an extra-galactic species
-  , extinctSpecies :: Maybe ExtinctSpecies.ExtinctSpecies -- ^ Whether it's an extinct species
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this species is from alternate reality
-  , homeworld :: Maybe AstronomicalObjectBase.AstronomicalObjectBase -- ^ Base astronomical object, returned in search results
-  , transDimensionalSpecies :: Maybe TransDimensionalSpecies.TransDimensionalSpecies -- ^ Whether it's a trans-dimensional species
-  , shapeshiftingSpecies :: Maybe ShapeshiftingSpecies.ShapeshiftingSpecies -- ^ Whether it's a shapeshifting species
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this species is from alternate reality
   , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
+  , extinctSpecies :: Maybe ExtinctSpecies.ExtinctSpecies -- ^ Whether it's an extinct species
+  , extraGalacticSpecies :: Maybe ExtraGalacticSpecies.ExtraGalacticSpecies -- ^ Whether it's an extra-galactic species
+  , homeworld :: Maybe AstronomicalObjectBase.AstronomicalObjectBase -- ^ Base astronomical object, returned in search results
   , humanoidSpecies :: Maybe HumanoidSpecies.HumanoidSpecies -- ^ Whether it's a humanoid species
-  , reptilianSpecies :: Maybe ReptilianSpecies.ReptilianSpecies -- ^ Whether it's a reptilian species
-  , warpCapableSpecies :: Maybe WarpCapableSpecies.WarpCapableSpecies -- ^ Whether it's a warp-capable species
-  , spaceborneSpecies :: Maybe SpaceborneSpecies.SpaceborneSpecies -- ^ Whether it's a spaceborne species
-  , uid :: Uid.Uid -- ^ Species unique ID
-  , telepathicSpecies :: Maybe TelepathicSpecies.TelepathicSpecies -- ^ Whether it's a telepathic species
-  , unnamedSpecies :: Maybe UnnamedSpecies.UnnamedSpecies -- ^ Whether it's a unnamed species
   , name :: Name.Name -- ^ Species name
   , nonCorporealSpecies :: Maybe NonCorporealSpecies.NonCorporealSpecies -- ^ Whether it's a non-corporeal species
   , quadrant :: Maybe AstronomicalObjectBase.AstronomicalObjectBase -- ^ Base astronomical object, returned in search results
+  , reptilianSpecies :: Maybe ReptilianSpecies.ReptilianSpecies -- ^ Whether it's a reptilian species
+  , shapeshiftingSpecies :: Maybe ShapeshiftingSpecies.ShapeshiftingSpecies -- ^ Whether it's a shapeshifting species
+  , spaceborneSpecies :: Maybe SpaceborneSpecies.SpaceborneSpecies -- ^ Whether it's a spaceborne species
+  , telepathicSpecies :: Maybe TelepathicSpecies.TelepathicSpecies -- ^ Whether it's a telepathic species
+  , transDimensionalSpecies :: Maybe TransDimensionalSpecies.TransDimensionalSpecies -- ^ Whether it's a trans-dimensional species
+  , uid :: Uid.Uid -- ^ Species unique ID
+  , unnamedSpecies :: Maybe UnnamedSpecies.UnnamedSpecies -- ^ Whether it's a unnamed species
+  , warpCapableSpecies :: Maybe WarpCapableSpecies.WarpCapableSpecies -- ^ Whether it's a warp-capable species
   }
   deriving (Eq, Show)
 
@@ -50,20 +50,20 @@ speciesFullSchema :: FC.Fleece schema => schema SpeciesFull
 speciesFullSchema =
   FC.object $
     FC.constructor SpeciesFull
-      #+ FC.optional "extraGalacticSpecies" extraGalacticSpecies ExtraGalacticSpecies.extraGalacticSpeciesSchema
-      #+ FC.optional "extinctSpecies" extinctSpecies ExtinctSpecies.extinctSpeciesSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
-      #+ FC.optional "homeworld" homeworld AstronomicalObjectBase.astronomicalObjectBaseSchema
-      #+ FC.optional "transDimensionalSpecies" transDimensionalSpecies TransDimensionalSpecies.transDimensionalSpeciesSchema
-      #+ FC.optional "shapeshiftingSpecies" shapeshiftingSpecies ShapeshiftingSpecies.shapeshiftingSpeciesSchema
       #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
+      #+ FC.optional "extinctSpecies" extinctSpecies ExtinctSpecies.extinctSpeciesSchema
+      #+ FC.optional "extraGalacticSpecies" extraGalacticSpecies ExtraGalacticSpecies.extraGalacticSpeciesSchema
+      #+ FC.optional "homeworld" homeworld AstronomicalObjectBase.astronomicalObjectBaseSchema
       #+ FC.optional "humanoidSpecies" humanoidSpecies HumanoidSpecies.humanoidSpeciesSchema
-      #+ FC.optional "reptilianSpecies" reptilianSpecies ReptilianSpecies.reptilianSpeciesSchema
-      #+ FC.optional "warpCapableSpecies" warpCapableSpecies WarpCapableSpecies.warpCapableSpeciesSchema
-      #+ FC.optional "spaceborneSpecies" spaceborneSpecies SpaceborneSpecies.spaceborneSpeciesSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "telepathicSpecies" telepathicSpecies TelepathicSpecies.telepathicSpeciesSchema
-      #+ FC.optional "unnamedSpecies" unnamedSpecies UnnamedSpecies.unnamedSpeciesSchema
       #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "nonCorporealSpecies" nonCorporealSpecies NonCorporealSpecies.nonCorporealSpeciesSchema
       #+ FC.optional "quadrant" quadrant AstronomicalObjectBase.astronomicalObjectBaseSchema
+      #+ FC.optional "reptilianSpecies" reptilianSpecies ReptilianSpecies.reptilianSpeciesSchema
+      #+ FC.optional "shapeshiftingSpecies" shapeshiftingSpecies ShapeshiftingSpecies.shapeshiftingSpeciesSchema
+      #+ FC.optional "spaceborneSpecies" spaceborneSpecies SpaceborneSpecies.spaceborneSpeciesSchema
+      #+ FC.optional "telepathicSpecies" telepathicSpecies TelepathicSpecies.telepathicSpeciesSchema
+      #+ FC.optional "transDimensionalSpecies" transDimensionalSpecies TransDimensionalSpecies.transDimensionalSpeciesSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "unnamedSpecies" unnamedSpecies UnnamedSpecies.unnamedSpeciesSchema
+      #+ FC.optional "warpCapableSpecies" warpCapableSpecies WarpCapableSpecies.warpCapableSpeciesSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpeciesHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/SpeciesHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.SpeciesHeader.Name as Name
 import qualified StarTrek.Types.SpeciesHeader.Uid as Uid
 
 data SpeciesHeader = SpeciesHeader
-  { uid :: Uid.Uid -- ^ Species unique ID
-  , name :: Name.Name -- ^ Species name
+  { name :: Name.Name -- ^ Species name
+  , uid :: Uid.Uid -- ^ Species unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ speciesHeaderSchema :: FC.Fleece schema => schema SpeciesHeader
 speciesHeaderSchema =
   FC.object $
     FC.constructor SpeciesHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/StaffBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/StaffBase.hs
@@ -73,69 +73,69 @@ import qualified StarTrek.Types.StaffBase.VideoGameProductionStaff as VideoGameP
 import qualified StarTrek.Types.StaffBase.Writer as Writer
 
 data StaffBase = StaffBase
-  { cameraAndElectricalDepartment :: Maybe CameraAndElectricalDepartment.CameraAndElectricalDepartment -- ^ Whether this person is from camera and electrical department
-  , comicArtist :: Maybe ComicArtist.ComicArtist -- ^ Whether this person is a comic artist
-  , director :: Maybe Director.Director -- ^ Whether this person is a director
+  { artDepartment :: Maybe ArtDepartment.ArtDepartment -- ^ Whether this person if from art department
   , artDirector :: Maybe ArtDirector.ArtDirector -- ^ Whether this person is an art director
-  , writer :: Maybe Writer.Writer -- ^ Whether this person is a writer
-  , makeupStaff :: Maybe MakeupStaff.MakeupStaff -- ^ Whether this person is a make-up staff
-  , publicationArtist :: Maybe PublicationArtist.PublicationArtist -- ^ Whether this person is a publication artist
-  , gender :: Maybe Gender.Gender -- ^ Gender
-  , comicColorArtist :: Maybe ComicColorArtist.ComicColorArtist -- ^ Whether this person is a comic color artist
-  , stuntDepartment :: Maybe StuntDepartment.StuntDepartment -- ^ Whether this person is from stunt department
-  , novelArtist :: Maybe NovelArtist.NovelArtist -- ^ Whether this person is a novel artist
-  , artDepartment :: Maybe ArtDepartment.ArtDepartment -- ^ Whether this person if from art department
-  , publicityArtist :: Maybe PublicityArtist.PublicityArtist -- ^ Whether this person is a publication artist
-  , storyEditor :: Maybe StoryEditor.StoryEditor -- ^ Whether this person is a story editor
-  , comicStripArtist :: Maybe ComicStripArtist.ComicStripArtist -- ^ Whether this person is a comic strip artist
-  , comicAuthor :: Maybe ComicAuthor.ComicAuthor -- ^ Whether this person is a comic author
-  , comicPencilArtist :: Maybe ComicPencilArtist.ComicPencilArtist -- ^ Whether this person is a comic pencil artist
-  , transportationDepartment :: Maybe TransportationDepartment.TransportationDepartment -- ^ Whether this person is from transportation department
-  , producer :: Maybe Producer.Producer -- ^ Whether this person is a producer
-  , composer :: Maybe Composer.Composer -- ^ Whether this person is a composer
+  , assistantOrSecondUnitDirector :: Maybe AssistantOrSecondUnitDirector.AssistantOrSecondUnitDirector -- ^ Whether this person is an assistant or secound unit director director
+  , audioAuthor :: Maybe AudioAuthor.AudioAuthor -- ^ Whether this person is an audio author
+  , author :: Maybe Author.Author -- ^ Whether this person is an author
+  , birthName :: Maybe BirthName.BirthName -- ^ Staff birth name
   , calendarArtist :: Maybe CalendarArtist.CalendarArtist -- ^ Whether this person is a calendar artist
-  , referenceAuthor :: Maybe ReferenceAuthor.ReferenceAuthor -- ^ Whether this person is a reference author
+  , cameraAndElectricalDepartment :: Maybe CameraAndElectricalDepartment.CameraAndElectricalDepartment -- ^ Whether this person is from camera and electrical department
+  , castingDepartment :: Maybe CastingDepartment.CastingDepartment -- ^ Whether this person is from casting department
+  , cbsDigitalStaff :: Maybe CbsDigitalStaff.CbsDigitalStaff -- ^ Whether this person is a part of CBS digital staff
+  , cinematographer :: Maybe Cinematographer.Cinematographer -- ^ Whether this person is a cinematographer
+  , comicArtist :: Maybe ComicArtist.ComicArtist -- ^ Whether this person is a comic artist
+  , comicAuthor :: Maybe ComicAuthor.ComicAuthor -- ^ Whether this person is a comic author
+  , comicColorArtist :: Maybe ComicColorArtist.ComicColorArtist -- ^ Whether this person is a comic color artist
+  , comicInkArtist :: Maybe ComicInkArtist.ComicInkArtist -- ^ Whether this person is a comic ink artist
+  , comicInteriorArtist :: Maybe ComicInteriorArtist.ComicInteriorArtist -- ^ Whether this person is a comic interior artist
+  , comicLetterArtist :: Maybe ComicLetterArtist.ComicLetterArtist -- ^ Whether this person is a comic letter artist
+  , comicPencilArtist :: Maybe ComicPencilArtist.ComicPencilArtist -- ^ Whether this person is a comic pencil artist
+  , comicStripArtist :: Maybe ComicStripArtist.ComicStripArtist -- ^ Whether this person is a comic strip artist
+  , composer :: Maybe Composer.Composer -- ^ Whether this person is a composer
+  , costumeDepartment :: Maybe CostumeDepartment.CostumeDepartment -- ^ Whether this person is from costume department
+  , costumeDesigner :: Maybe CostumeDesigner.CostumeDesigner -- ^ Whether this person is a custume designer
+  , dateOfBirth :: Maybe DateOfBirth.DateOfBirth -- ^ Date the staff was born
+  , dateOfDeath :: Maybe DateOfDeath.DateOfDeath -- ^ Date the staff died
+  , director :: Maybe Director.Director -- ^ Whether this person is a director
+  , exhibitAndAttractionStaff :: Maybe ExhibitAndAttractionStaff.ExhibitAndAttractionStaff -- ^ Whether this person is an exhibit and tttraction staff
+  , filmEditor :: Maybe FilmEditor.FilmEditor -- ^ Whether this person is a film editor
+  , gameArtist :: Maybe GameArtist.GameArtist -- ^ Whether this person is a game artist
+  , gameAuthor :: Maybe GameAuthor.GameAuthor -- ^ Whether this person is a game author
+  , gender :: Maybe Gender.Gender -- ^ Gender
+  , ilmProductionStaff :: Maybe IlmProductionStaff.IlmProductionStaff -- ^ Whether this person is a part of ILM production staff
+  , linguist :: Maybe Linguist.Linguist -- ^ Whether this person is a linguist
+  , locationStaff :: Maybe LocationStaff.LocationStaff -- ^ Whether this person is a location staff
+  , makeupStaff :: Maybe MakeupStaff.MakeupStaff -- ^ Whether this person is a make-up staff
+  , musicDepartment :: Maybe MusicDepartment.MusicDepartment -- ^ Whether this person is from music department
+  , name :: Name.Name -- ^ Staff name
+  , novelArtist :: Maybe NovelArtist.NovelArtist -- ^ Whether this person is a novel artist
+  , novelAuthor :: Maybe NovelAuthor.NovelAuthor -- ^ Whether this person is a novel author
+  , personalAssistant :: Maybe PersonalAssistant.PersonalAssistant -- ^ Whether this person is a personal assistant
+  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place the staff was born
+  , placeOfDeath :: Maybe PlaceOfDeath.PlaceOfDeath -- ^ Place the staff died
+  , producer :: Maybe Producer.Producer -- ^ Whether this person is a producer
+  , productionAssociate :: Maybe ProductionAssociate.ProductionAssociate -- ^ Whether this person is a production associate
+  , productionDesigner :: Maybe ProductionDesigner.ProductionDesigner -- ^ Whether this person is a production designer
+  , productionStaff :: Maybe ProductionStaff.ProductionStaff -- ^ Whether this person is a production staff
+  , publicationArtist :: Maybe PublicationArtist.PublicationArtist -- ^ Whether this person is a publication artist
+  , publicationDesigner :: Maybe PublicationDesigner.PublicationDesigner -- ^ Whether this person is a publication designer
   , publicationEditor :: Maybe PublicationEditor.PublicationEditor -- ^ Whether this person is a publication editor
   , publicationStaff :: Maybe PublicationStaff.PublicationStaff -- ^ Whether this person is a publication staff
-  , novelAuthor :: Maybe NovelAuthor.NovelAuthor -- ^ Whether this person is a novel author
-  , castingDepartment :: Maybe CastingDepartment.CastingDepartment -- ^ Whether this person is from casting department
-  , musicDepartment :: Maybe MusicDepartment.MusicDepartment -- ^ Whether this person is from music department
-  , cbsDigitalStaff :: Maybe CbsDigitalStaff.CbsDigitalStaff -- ^ Whether this person is a part of CBS digital staff
-  , costumeDesigner :: Maybe CostumeDesigner.CostumeDesigner -- ^ Whether this person is a custume designer
-  , comicInteriorArtist :: Maybe ComicInteriorArtist.ComicInteriorArtist -- ^ Whether this person is a comic interior artist
-  , uid :: Uid.Uid -- ^ Staff unique ID
-  , gameAuthor :: Maybe GameAuthor.GameAuthor -- ^ Whether this person is a game author
-  , scienceConsultant :: Maybe ScienceConsultant.ScienceConsultant -- ^ Whether this person is a science consultant
-  , dateOfDeath :: Maybe DateOfDeath.DateOfDeath -- ^ Date the staff died
-  , filmEditor :: Maybe FilmEditor.FilmEditor -- ^ Whether this person is a film editor
-  , productionStaff :: Maybe ProductionStaff.ProductionStaff -- ^ Whether this person is a production staff
-  , specialFeaturesStaff :: Maybe SpecialFeaturesStaff.SpecialFeaturesStaff -- ^ Whether this person is a special features artist
-  , comicInkArtist :: Maybe ComicInkArtist.ComicInkArtist -- ^ Whether this person is a comic ink artist
-  , personalAssistant :: Maybe PersonalAssistant.PersonalAssistant -- ^ Whether this person is a personal assistant
-  , soundDepartment :: Maybe SoundDepartment.SoundDepartment -- ^ Whether this person is from sound department
-  , audioAuthor :: Maybe AudioAuthor.AudioAuthor -- ^ Whether this person is an audio author
-  , videoGameProductionStaff :: Maybe VideoGameProductionStaff.VideoGameProductionStaff -- ^ Whether this person is video game production staff
-  , linguist :: Maybe Linguist.Linguist -- ^ Whether this person is a linguist
-  , author :: Maybe Author.Author -- ^ Whether this person is an author
-  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place the staff was born
-  , name :: Name.Name -- ^ Staff name
-  , gameArtist :: Maybe GameArtist.GameArtist -- ^ Whether this person is a game artist
-  , costumeDepartment :: Maybe CostumeDepartment.CostumeDepartment -- ^ Whether this person is from costume department
-  , assistantOrSecondUnitDirector :: Maybe AssistantOrSecondUnitDirector.AssistantOrSecondUnitDirector -- ^ Whether this person is an assistant or secound unit director director
-  , productionDesigner :: Maybe ProductionDesigner.ProductionDesigner -- ^ Whether this person is a production designer
-  , cinematographer :: Maybe Cinematographer.Cinematographer -- ^ Whether this person is a cinematographer
-  , locationStaff :: Maybe LocationStaff.LocationStaff -- ^ Whether this person is a location staff
-  , birthName :: Maybe BirthName.BirthName -- ^ Staff birth name
-  , ilmProductionStaff :: Maybe IlmProductionStaff.IlmProductionStaff -- ^ Whether this person is a part of ILM production staff
-  , publicationDesigner :: Maybe PublicationDesigner.PublicationDesigner -- ^ Whether this person is a publication designer
-  , productionAssociate :: Maybe ProductionAssociate.ProductionAssociate -- ^ Whether this person is a production associate
-  , dateOfBirth :: Maybe DateOfBirth.DateOfBirth -- ^ Date the staff was born
+  , publicityArtist :: Maybe PublicityArtist.PublicityArtist -- ^ Whether this person is a publication artist
   , referenceArtist :: Maybe ReferenceArtist.ReferenceArtist -- ^ Whether this person is a reference artist
-  , placeOfDeath :: Maybe PlaceOfDeath.PlaceOfDeath -- ^ Place the staff died
+  , referenceAuthor :: Maybe ReferenceAuthor.ReferenceAuthor -- ^ Whether this person is a reference author
+  , scienceConsultant :: Maybe ScienceConsultant.ScienceConsultant -- ^ Whether this person is a science consultant
+  , soundDepartment :: Maybe SoundDepartment.SoundDepartment -- ^ Whether this person is from sound department
   , specialAndVisualEffectsStaff :: Maybe SpecialAndVisualEffectsStaff.SpecialAndVisualEffectsStaff -- ^ Whether this person is a special and visual effects staff
-  , exhibitAndAttractionStaff :: Maybe ExhibitAndAttractionStaff.ExhibitAndAttractionStaff -- ^ Whether this person is an exhibit and tttraction staff
-  , comicLetterArtist :: Maybe ComicLetterArtist.ComicLetterArtist -- ^ Whether this person is a comic letter artist
+  , specialFeaturesStaff :: Maybe SpecialFeaturesStaff.SpecialFeaturesStaff -- ^ Whether this person is a special features artist
+  , storyEditor :: Maybe StoryEditor.StoryEditor -- ^ Whether this person is a story editor
   , studioExecutive :: Maybe StudioExecutive.StudioExecutive -- ^ Whether this person is a studio executive
+  , stuntDepartment :: Maybe StuntDepartment.StuntDepartment -- ^ Whether this person is from stunt department
+  , transportationDepartment :: Maybe TransportationDepartment.TransportationDepartment -- ^ Whether this person is from transportation department
+  , uid :: Uid.Uid -- ^ Staff unique ID
+  , videoGameProductionStaff :: Maybe VideoGameProductionStaff.VideoGameProductionStaff -- ^ Whether this person is video game production staff
+  , writer :: Maybe Writer.Writer -- ^ Whether this person is a writer
   }
   deriving (Eq, Show)
 
@@ -143,66 +143,66 @@ staffBaseSchema :: FC.Fleece schema => schema StaffBase
 staffBaseSchema =
   FC.object $
     FC.constructor StaffBase
-      #+ FC.optional "cameraAndElectricalDepartment" cameraAndElectricalDepartment CameraAndElectricalDepartment.cameraAndElectricalDepartmentSchema
-      #+ FC.optional "comicArtist" comicArtist ComicArtist.comicArtistSchema
-      #+ FC.optional "director" director Director.directorSchema
-      #+ FC.optional "artDirector" artDirector ArtDirector.artDirectorSchema
-      #+ FC.optional "writer" writer Writer.writerSchema
-      #+ FC.optional "makeupStaff" makeupStaff MakeupStaff.makeupStaffSchema
-      #+ FC.optional "publicationArtist" publicationArtist PublicationArtist.publicationArtistSchema
-      #+ FC.optional "gender" gender Gender.genderSchema
-      #+ FC.optional "comicColorArtist" comicColorArtist ComicColorArtist.comicColorArtistSchema
-      #+ FC.optional "stuntDepartment" stuntDepartment StuntDepartment.stuntDepartmentSchema
-      #+ FC.optional "novelArtist" novelArtist NovelArtist.novelArtistSchema
       #+ FC.optional "artDepartment" artDepartment ArtDepartment.artDepartmentSchema
-      #+ FC.optional "publicityArtist" publicityArtist PublicityArtist.publicityArtistSchema
-      #+ FC.optional "storyEditor" storyEditor StoryEditor.storyEditorSchema
-      #+ FC.optional "comicStripArtist" comicStripArtist ComicStripArtist.comicStripArtistSchema
-      #+ FC.optional "comicAuthor" comicAuthor ComicAuthor.comicAuthorSchema
-      #+ FC.optional "comicPencilArtist" comicPencilArtist ComicPencilArtist.comicPencilArtistSchema
-      #+ FC.optional "transportationDepartment" transportationDepartment TransportationDepartment.transportationDepartmentSchema
-      #+ FC.optional "producer" producer Producer.producerSchema
-      #+ FC.optional "composer" composer Composer.composerSchema
+      #+ FC.optional "artDirector" artDirector ArtDirector.artDirectorSchema
+      #+ FC.optional "assistantOrSecondUnitDirector" assistantOrSecondUnitDirector AssistantOrSecondUnitDirector.assistantOrSecondUnitDirectorSchema
+      #+ FC.optional "audioAuthor" audioAuthor AudioAuthor.audioAuthorSchema
+      #+ FC.optional "author" author Author.authorSchema
+      #+ FC.optional "birthName" birthName BirthName.birthNameSchema
       #+ FC.optional "calendarArtist" calendarArtist CalendarArtist.calendarArtistSchema
-      #+ FC.optional "referenceAuthor" referenceAuthor ReferenceAuthor.referenceAuthorSchema
+      #+ FC.optional "cameraAndElectricalDepartment" cameraAndElectricalDepartment CameraAndElectricalDepartment.cameraAndElectricalDepartmentSchema
+      #+ FC.optional "castingDepartment" castingDepartment CastingDepartment.castingDepartmentSchema
+      #+ FC.optional "cbsDigitalStaff" cbsDigitalStaff CbsDigitalStaff.cbsDigitalStaffSchema
+      #+ FC.optional "cinematographer" cinematographer Cinematographer.cinematographerSchema
+      #+ FC.optional "comicArtist" comicArtist ComicArtist.comicArtistSchema
+      #+ FC.optional "comicAuthor" comicAuthor ComicAuthor.comicAuthorSchema
+      #+ FC.optional "comicColorArtist" comicColorArtist ComicColorArtist.comicColorArtistSchema
+      #+ FC.optional "comicInkArtist" comicInkArtist ComicInkArtist.comicInkArtistSchema
+      #+ FC.optional "comicInteriorArtist" comicInteriorArtist ComicInteriorArtist.comicInteriorArtistSchema
+      #+ FC.optional "comicLetterArtist" comicLetterArtist ComicLetterArtist.comicLetterArtistSchema
+      #+ FC.optional "comicPencilArtist" comicPencilArtist ComicPencilArtist.comicPencilArtistSchema
+      #+ FC.optional "comicStripArtist" comicStripArtist ComicStripArtist.comicStripArtistSchema
+      #+ FC.optional "composer" composer Composer.composerSchema
+      #+ FC.optional "costumeDepartment" costumeDepartment CostumeDepartment.costumeDepartmentSchema
+      #+ FC.optional "costumeDesigner" costumeDesigner CostumeDesigner.costumeDesignerSchema
+      #+ FC.optional "dateOfBirth" dateOfBirth DateOfBirth.dateOfBirthSchema
+      #+ FC.optional "dateOfDeath" dateOfDeath DateOfDeath.dateOfDeathSchema
+      #+ FC.optional "director" director Director.directorSchema
+      #+ FC.optional "exhibitAndAttractionStaff" exhibitAndAttractionStaff ExhibitAndAttractionStaff.exhibitAndAttractionStaffSchema
+      #+ FC.optional "filmEditor" filmEditor FilmEditor.filmEditorSchema
+      #+ FC.optional "gameArtist" gameArtist GameArtist.gameArtistSchema
+      #+ FC.optional "gameAuthor" gameAuthor GameAuthor.gameAuthorSchema
+      #+ FC.optional "gender" gender Gender.genderSchema
+      #+ FC.optional "ilmProductionStaff" ilmProductionStaff IlmProductionStaff.ilmProductionStaffSchema
+      #+ FC.optional "linguist" linguist Linguist.linguistSchema
+      #+ FC.optional "locationStaff" locationStaff LocationStaff.locationStaffSchema
+      #+ FC.optional "makeupStaff" makeupStaff MakeupStaff.makeupStaffSchema
+      #+ FC.optional "musicDepartment" musicDepartment MusicDepartment.musicDepartmentSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "novelArtist" novelArtist NovelArtist.novelArtistSchema
+      #+ FC.optional "novelAuthor" novelAuthor NovelAuthor.novelAuthorSchema
+      #+ FC.optional "personalAssistant" personalAssistant PersonalAssistant.personalAssistantSchema
+      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
+      #+ FC.optional "placeOfDeath" placeOfDeath PlaceOfDeath.placeOfDeathSchema
+      #+ FC.optional "producer" producer Producer.producerSchema
+      #+ FC.optional "productionAssociate" productionAssociate ProductionAssociate.productionAssociateSchema
+      #+ FC.optional "productionDesigner" productionDesigner ProductionDesigner.productionDesignerSchema
+      #+ FC.optional "productionStaff" productionStaff ProductionStaff.productionStaffSchema
+      #+ FC.optional "publicationArtist" publicationArtist PublicationArtist.publicationArtistSchema
+      #+ FC.optional "publicationDesigner" publicationDesigner PublicationDesigner.publicationDesignerSchema
       #+ FC.optional "publicationEditor" publicationEditor PublicationEditor.publicationEditorSchema
       #+ FC.optional "publicationStaff" publicationStaff PublicationStaff.publicationStaffSchema
-      #+ FC.optional "novelAuthor" novelAuthor NovelAuthor.novelAuthorSchema
-      #+ FC.optional "castingDepartment" castingDepartment CastingDepartment.castingDepartmentSchema
-      #+ FC.optional "musicDepartment" musicDepartment MusicDepartment.musicDepartmentSchema
-      #+ FC.optional "cbsDigitalStaff" cbsDigitalStaff CbsDigitalStaff.cbsDigitalStaffSchema
-      #+ FC.optional "costumeDesigner" costumeDesigner CostumeDesigner.costumeDesignerSchema
-      #+ FC.optional "comicInteriorArtist" comicInteriorArtist ComicInteriorArtist.comicInteriorArtistSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "gameAuthor" gameAuthor GameAuthor.gameAuthorSchema
-      #+ FC.optional "scienceConsultant" scienceConsultant ScienceConsultant.scienceConsultantSchema
-      #+ FC.optional "dateOfDeath" dateOfDeath DateOfDeath.dateOfDeathSchema
-      #+ FC.optional "filmEditor" filmEditor FilmEditor.filmEditorSchema
-      #+ FC.optional "productionStaff" productionStaff ProductionStaff.productionStaffSchema
-      #+ FC.optional "specialFeaturesStaff" specialFeaturesStaff SpecialFeaturesStaff.specialFeaturesStaffSchema
-      #+ FC.optional "comicInkArtist" comicInkArtist ComicInkArtist.comicInkArtistSchema
-      #+ FC.optional "personalAssistant" personalAssistant PersonalAssistant.personalAssistantSchema
-      #+ FC.optional "soundDepartment" soundDepartment SoundDepartment.soundDepartmentSchema
-      #+ FC.optional "audioAuthor" audioAuthor AudioAuthor.audioAuthorSchema
-      #+ FC.optional "videoGameProductionStaff" videoGameProductionStaff VideoGameProductionStaff.videoGameProductionStaffSchema
-      #+ FC.optional "linguist" linguist Linguist.linguistSchema
-      #+ FC.optional "author" author Author.authorSchema
-      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "gameArtist" gameArtist GameArtist.gameArtistSchema
-      #+ FC.optional "costumeDepartment" costumeDepartment CostumeDepartment.costumeDepartmentSchema
-      #+ FC.optional "assistantOrSecondUnitDirector" assistantOrSecondUnitDirector AssistantOrSecondUnitDirector.assistantOrSecondUnitDirectorSchema
-      #+ FC.optional "productionDesigner" productionDesigner ProductionDesigner.productionDesignerSchema
-      #+ FC.optional "cinematographer" cinematographer Cinematographer.cinematographerSchema
-      #+ FC.optional "locationStaff" locationStaff LocationStaff.locationStaffSchema
-      #+ FC.optional "birthName" birthName BirthName.birthNameSchema
-      #+ FC.optional "ilmProductionStaff" ilmProductionStaff IlmProductionStaff.ilmProductionStaffSchema
-      #+ FC.optional "publicationDesigner" publicationDesigner PublicationDesigner.publicationDesignerSchema
-      #+ FC.optional "productionAssociate" productionAssociate ProductionAssociate.productionAssociateSchema
-      #+ FC.optional "dateOfBirth" dateOfBirth DateOfBirth.dateOfBirthSchema
+      #+ FC.optional "publicityArtist" publicityArtist PublicityArtist.publicityArtistSchema
       #+ FC.optional "referenceArtist" referenceArtist ReferenceArtist.referenceArtistSchema
-      #+ FC.optional "placeOfDeath" placeOfDeath PlaceOfDeath.placeOfDeathSchema
+      #+ FC.optional "referenceAuthor" referenceAuthor ReferenceAuthor.referenceAuthorSchema
+      #+ FC.optional "scienceConsultant" scienceConsultant ScienceConsultant.scienceConsultantSchema
+      #+ FC.optional "soundDepartment" soundDepartment SoundDepartment.soundDepartmentSchema
       #+ FC.optional "specialAndVisualEffectsStaff" specialAndVisualEffectsStaff SpecialAndVisualEffectsStaff.specialAndVisualEffectsStaffSchema
-      #+ FC.optional "exhibitAndAttractionStaff" exhibitAndAttractionStaff ExhibitAndAttractionStaff.exhibitAndAttractionStaffSchema
-      #+ FC.optional "comicLetterArtist" comicLetterArtist ComicLetterArtist.comicLetterArtistSchema
+      #+ FC.optional "specialFeaturesStaff" specialFeaturesStaff SpecialFeaturesStaff.specialFeaturesStaffSchema
+      #+ FC.optional "storyEditor" storyEditor StoryEditor.storyEditorSchema
       #+ FC.optional "studioExecutive" studioExecutive StudioExecutive.studioExecutiveSchema
+      #+ FC.optional "stuntDepartment" stuntDepartment StuntDepartment.stuntDepartmentSchema
+      #+ FC.optional "transportationDepartment" transportationDepartment TransportationDepartment.transportationDepartmentSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "videoGameProductionStaff" videoGameProductionStaff VideoGameProductionStaff.videoGameProductionStaffSchema
+      #+ FC.optional "writer" writer Writer.writerSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/StaffBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/StaffBaseResponse.hs
@@ -14,8 +14,8 @@ import qualified StarTrek.Types.StaffBase as StaffBase
 
 data StaffBaseResponse = StaffBaseResponse
   { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , staff :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
+  , staff :: Maybe [StaffBase.StaffBase] -- ^ Base staff, returned in search results
   }
   deriving (Eq, Show)
 
@@ -24,5 +24,5 @@ staffBaseResponseSchema =
   FC.object $
     FC.constructor StaffBaseResponse
       #+ FC.optional "page" page ResponsePage.responsePageSchema
-      #+ FC.optional "staff" staff (FC.list StaffBase.staffBaseSchema)
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
+      #+ FC.optional "staff" staff (FC.list StaffBase.staffBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/StaffFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/StaffFull.hs
@@ -75,80 +75,80 @@ import qualified StarTrek.Types.StaffFull.VideoGameProductionStaff as VideoGameP
 import qualified StarTrek.Types.StaffFull.Writer as Writer
 
 data StaffFull = StaffFull
-  { cameraAndElectricalDepartment :: Maybe CameraAndElectricalDepartment.CameraAndElectricalDepartment -- ^ Whether this person is from camera and electrical department
-  , comicArtist :: Maybe ComicArtist.ComicArtist -- ^ Whether this person is a comic artist
-  , director :: Maybe Director.Director -- ^ Whether this person is a director
+  { artDepartment :: Maybe ArtDepartment.ArtDepartment -- ^ Whether this person is from art department
   , artDirector :: Maybe ArtDirector.ArtDirector -- ^ Whether this person is an art director
-  , writer :: Maybe Writer.Writer -- ^ Whether this person is a writer
-  , screenplayAuthoredMovies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
-  , makeupStaff :: Maybe MakeupStaff.MakeupStaff -- ^ Whether this person is a make-up staff
-  , publicationArtist :: Maybe PublicationArtist.PublicationArtist -- ^ Whether this person is a publication artist
-  , gender :: Maybe Gender.Gender -- ^ Gender
-  , comicColorArtist :: Maybe ComicColorArtist.ComicColorArtist -- ^ Whether this person is a comic color artist
-  , stuntDepartment :: Maybe StuntDepartment.StuntDepartment -- ^ Whether this person is from stunt department
-  , novelArtist :: Maybe NovelArtist.NovelArtist -- ^ Whether this person is a novel artist
-  , artDepartment :: Maybe ArtDepartment.ArtDepartment -- ^ Whether this person is from art department
-  , publicityArtist :: Maybe PublicityArtist.PublicityArtist -- ^ Whether this person is a publicity artist
-  , storyEditor :: Maybe StoryEditor.StoryEditor -- ^ Whether this person is a story editor
-  , comicStripArtist :: Maybe ComicStripArtist.ComicStripArtist -- ^ Whether this person is a comic strip artist
-  , comicAuthor :: Maybe ComicAuthor.ComicAuthor -- ^ Whether this person is a comic author
-  , movies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
-  , comicPencilArtist :: Maybe ComicPencilArtist.ComicPencilArtist -- ^ Whether this person is a comic pencil artist
-  , transportationDepartment :: Maybe TransportationDepartment.TransportationDepartment -- ^ Whether this person is from transportation department
-  , producer :: Maybe Producer.Producer -- ^ Whether this person is a producer
-  , composer :: Maybe Composer.Composer -- ^ Whether this person is a composer
-  , directedEpisodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
-  , storyAuthoredEpisodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
-  , teleplayAuthoredEpisodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , assistantOrSecondUnitDirector :: Maybe AssistantOrSecondUnitDirector.AssistantOrSecondUnitDirector -- ^ Whether this person is an assistant or secound unit director director
+  , audioAuthor :: Maybe AudioAuthor.AudioAuthor -- ^ Whether this person is an audio author
+  , author :: Maybe Author.Author -- ^ Whether this person is an author
+  , birthName :: Maybe BirthName.BirthName -- ^ Staff birth name
   , calendarArtist :: Maybe CalendarArtist.CalendarArtist -- ^ Whether this person is a calendar artist
+  , cameraAndElectricalDepartment :: Maybe CameraAndElectricalDepartment.CameraAndElectricalDepartment -- ^ Whether this person is from camera and electrical department
+  , castingDepartment :: Maybe CastingDepartment.CastingDepartment -- ^ Whether this person is from casting department
+  , cbsDigitalStaff :: Maybe CbsDigitalStaff.CbsDigitalStaff -- ^ Whether this person is a part of CBS digital staff
+  , cinematographer :: Maybe Cinematographer.Cinematographer -- ^ Whether this person is a cinematographer
+  , comicArtist :: Maybe ComicArtist.ComicArtist -- ^ Whether this person is a comic artist
+  , comicAuthor :: Maybe ComicAuthor.ComicAuthor -- ^ Whether this person is a comic author
+  , comicColorArtist :: Maybe ComicColorArtist.ComicColorArtist -- ^ Whether this person is a comic color artist
+  , comicInkArtist :: Maybe ComicInkArtist.ComicInkArtist -- ^ Whether this person is a comic ink artist
+  , comicInteriorArtist :: Maybe ComicInteriorArtist.ComicInteriorArtist -- ^ Whether this person is a comic interior artist
+  , comicLetterArtist :: Maybe ComicLetterArtist.ComicLetterArtist -- ^ Whether this person is a comic letter artist
+  , comicPencilArtist :: Maybe ComicPencilArtist.ComicPencilArtist -- ^ Whether this person is a comic pencil artist
+  , comicStripArtist :: Maybe ComicStripArtist.ComicStripArtist -- ^ Whether this person is a comic strip artist
+  , composer :: Maybe Composer.Composer -- ^ Whether this person is a composer
+  , costumeDepartment :: Maybe CostumeDepartment.CostumeDepartment -- ^ Whether this person is from costume department
+  , costumeDesigner :: Maybe CostumeDesigner.CostumeDesigner -- ^ Whether this person is a custume designer
+  , dateOfBirth :: Maybe DateOfBirth.DateOfBirth -- ^ Date the staff was born
+  , dateOfDeath :: Maybe DateOfDeath.DateOfDeath -- ^ Date the staff died
+  , directedEpisodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , directedMovies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
+  , director :: Maybe Director.Director -- ^ Whether this person is a director
+  , episodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , exhibitAndAttractionStaff :: Maybe ExhibitAndAttractionStaff.ExhibitAndAttractionStaff -- ^ Whether this person is an exhibit and attraction staff
+  , filmEditor :: Maybe FilmEditor.FilmEditor -- ^ Whether this person is a film editor
+  , gameArtist :: Maybe GameArtist.GameArtist -- ^ Whether this person is a game artist
+  , gameAuthor :: Maybe GameAuthor.GameAuthor -- ^ Whether this person is a game author
+  , gender :: Maybe Gender.Gender -- ^ Gender
+  , ilmProductionStaff :: Maybe IlmProductionStaff.IlmProductionStaff -- ^ Whether this person is a part of ILM production staff
+  , linguist :: Maybe Linguist.Linguist -- ^ Whether this person is a linguist
+  , locationStaff :: Maybe LocationStaff.LocationStaff -- ^ Whether this person is a location staff
+  , makeupStaff :: Maybe MakeupStaff.MakeupStaff -- ^ Whether this person is a make-up staff
+  , movies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
+  , musicDepartment :: Maybe MusicDepartment.MusicDepartment -- ^ Whether this person is from music department
+  , name :: Name.Name -- ^ Staff name
+  , novelArtist :: Maybe NovelArtist.NovelArtist -- ^ Whether this person is a novel artist
+  , novelAuthor :: Maybe NovelAuthor.NovelAuthor -- ^ Whether this person is a novel author
+  , personalAssistant :: Maybe PersonalAssistant.PersonalAssistant -- ^ Whether this person is a personal assistant
+  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place the staff was born
+  , placeOfDeath :: Maybe PlaceOfDeath.PlaceOfDeath -- ^ Place the staff died
   , producedMovies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
-  , referenceAuthor :: Maybe ReferenceAuthor.ReferenceAuthor -- ^ Whether this person is a reference author
+  , producer :: Maybe Producer.Producer -- ^ Whether this person is a producer
+  , productionAssociate :: Maybe ProductionAssociate.ProductionAssociate -- ^ Whether this person is a production associate
+  , productionDesigner :: Maybe ProductionDesigner.ProductionDesigner -- ^ Whether this person is a production designer
+  , productionStaff :: Maybe ProductionStaff.ProductionStaff -- ^ Whether this person is a production staff
+  , publicationArtist :: Maybe PublicationArtist.PublicationArtist -- ^ Whether this person is a publication artist
+  , publicationDesigner :: Maybe PublicationDesigner.PublicationDesigner -- ^ Whether this person is a publication designer
   , publicationEditor :: Maybe PublicationEditor.PublicationEditor -- ^ Whether this person is a publication editor
   , publicationStaff :: Maybe PublicationStaff.PublicationStaff -- ^ Whether this person is a publication staff
-  , novelAuthor :: Maybe NovelAuthor.NovelAuthor -- ^ Whether this person is a novel author
-  , castingDepartment :: Maybe CastingDepartment.CastingDepartment -- ^ Whether this person is from casting department
-  , musicDepartment :: Maybe MusicDepartment.MusicDepartment -- ^ Whether this person is from music department
-  , cbsDigitalStaff :: Maybe CbsDigitalStaff.CbsDigitalStaff -- ^ Whether this person is a part of CBS digital staff
-  , costumeDesigner :: Maybe CostumeDesigner.CostumeDesigner -- ^ Whether this person is a custume designer
-  , comicInteriorArtist :: Maybe ComicInteriorArtist.ComicInteriorArtist -- ^ Whether this person is a comic interior artist
-  , uid :: Uid.Uid -- ^ Staff unique ID
-  , gameAuthor :: Maybe GameAuthor.GameAuthor -- ^ Whether this person is a game author
-  , directedMovies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
-  , scienceConsultant :: Maybe ScienceConsultant.ScienceConsultant -- ^ Whether this person is a science consultant
-  , writtenEpisodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
-  , dateOfDeath :: Maybe DateOfDeath.DateOfDeath -- ^ Date the staff died
-  , filmEditor :: Maybe FilmEditor.FilmEditor -- ^ Whether this person is a film editor
-  , productionStaff :: Maybe ProductionStaff.ProductionStaff -- ^ Whether this person is a production staff
-  , specialFeaturesStaff :: Maybe SpecialFeaturesStaff.SpecialFeaturesStaff -- ^ Whether this person is a special features artist
-  , comicInkArtist :: Maybe ComicInkArtist.ComicInkArtist -- ^ Whether this person is a comic ink artist
-  , personalAssistant :: Maybe PersonalAssistant.PersonalAssistant -- ^ Whether this person is a personal assistant
-  , soundDepartment :: Maybe SoundDepartment.SoundDepartment -- ^ Whether this person is from sound department
-  , audioAuthor :: Maybe AudioAuthor.AudioAuthor -- ^ Whether this person is an audio author
-  , videoGameProductionStaff :: Maybe VideoGameProductionStaff.VideoGameProductionStaff -- ^ Whether this person is video game production staff
-  , writtenMovies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
-  , linguist :: Maybe Linguist.Linguist -- ^ Whether this person is a linguist
-  , author :: Maybe Author.Author -- ^ Whether this person is an author
-  , placeOfBirth :: Maybe PlaceOfBirth.PlaceOfBirth -- ^ Place the staff was born
-  , name :: Name.Name -- ^ Staff name
-  , gameArtist :: Maybe GameArtist.GameArtist -- ^ Whether this person is a game artist
-  , costumeDepartment :: Maybe CostumeDepartment.CostumeDepartment -- ^ Whether this person is from costume department
-  , storyAuthoredMovies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
-  , assistantOrSecondUnitDirector :: Maybe AssistantOrSecondUnitDirector.AssistantOrSecondUnitDirector -- ^ Whether this person is an assistant or secound unit director director
-  , productionDesigner :: Maybe ProductionDesigner.ProductionDesigner -- ^ Whether this person is a production designer
-  , cinematographer :: Maybe Cinematographer.Cinematographer -- ^ Whether this person is a cinematographer
-  , locationStaff :: Maybe LocationStaff.LocationStaff -- ^ Whether this person is a location staff
-  , birthName :: Maybe BirthName.BirthName -- ^ Staff birth name
-  , ilmProductionStaff :: Maybe IlmProductionStaff.IlmProductionStaff -- ^ Whether this person is a part of ILM production staff
-  , episodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
-  , publicationDesigner :: Maybe PublicationDesigner.PublicationDesigner -- ^ Whether this person is a publication designer
-  , productionAssociate :: Maybe ProductionAssociate.ProductionAssociate -- ^ Whether this person is a production associate
-  , dateOfBirth :: Maybe DateOfBirth.DateOfBirth -- ^ Date the staff was born
+  , publicityArtist :: Maybe PublicityArtist.PublicityArtist -- ^ Whether this person is a publicity artist
   , referenceArtist :: Maybe ReferenceArtist.ReferenceArtist -- ^ Whether this person is a reference artist
-  , placeOfDeath :: Maybe PlaceOfDeath.PlaceOfDeath -- ^ Place the staff died
+  , referenceAuthor :: Maybe ReferenceAuthor.ReferenceAuthor -- ^ Whether this person is a reference author
+  , scienceConsultant :: Maybe ScienceConsultant.ScienceConsultant -- ^ Whether this person is a science consultant
+  , screenplayAuthoredMovies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
+  , soundDepartment :: Maybe SoundDepartment.SoundDepartment -- ^ Whether this person is from sound department
   , specialAndVisualEffectsStaff :: Maybe SpecialAndVisualEffectsStaff.SpecialAndVisualEffectsStaff -- ^ Whether this person is a special and visual effects staff
-  , exhibitAndAttractionStaff :: Maybe ExhibitAndAttractionStaff.ExhibitAndAttractionStaff -- ^ Whether this person is an exhibit and attraction staff
-  , comicLetterArtist :: Maybe ComicLetterArtist.ComicLetterArtist -- ^ Whether this person is a comic letter artist
+  , specialFeaturesStaff :: Maybe SpecialFeaturesStaff.SpecialFeaturesStaff -- ^ Whether this person is a special features artist
+  , storyAuthoredEpisodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , storyAuthoredMovies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
+  , storyEditor :: Maybe StoryEditor.StoryEditor -- ^ Whether this person is a story editor
   , studioExecutive :: Maybe StudioExecutive.StudioExecutive -- ^ Whether this person is a studio executive
+  , stuntDepartment :: Maybe StuntDepartment.StuntDepartment -- ^ Whether this person is from stunt department
+  , teleplayAuthoredEpisodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , transportationDepartment :: Maybe TransportationDepartment.TransportationDepartment -- ^ Whether this person is from transportation department
+  , uid :: Uid.Uid -- ^ Staff unique ID
+  , videoGameProductionStaff :: Maybe VideoGameProductionStaff.VideoGameProductionStaff -- ^ Whether this person is video game production staff
+  , writer :: Maybe Writer.Writer -- ^ Whether this person is a writer
+  , writtenEpisodes :: Maybe [EpisodeBase.EpisodeBase] -- ^ Base episode, returned in search results
+  , writtenMovies :: Maybe [MovieBase.MovieBase] -- ^ Base movie, returned in search results
   }
   deriving (Eq, Show)
 
@@ -156,77 +156,77 @@ staffFullSchema :: FC.Fleece schema => schema StaffFull
 staffFullSchema =
   FC.object $
     FC.constructor StaffFull
-      #+ FC.optional "cameraAndElectricalDepartment" cameraAndElectricalDepartment CameraAndElectricalDepartment.cameraAndElectricalDepartmentSchema
-      #+ FC.optional "comicArtist" comicArtist ComicArtist.comicArtistSchema
-      #+ FC.optional "director" director Director.directorSchema
-      #+ FC.optional "artDirector" artDirector ArtDirector.artDirectorSchema
-      #+ FC.optional "writer" writer Writer.writerSchema
-      #+ FC.optional "screenplayAuthoredMovies" screenplayAuthoredMovies (FC.list MovieBase.movieBaseSchema)
-      #+ FC.optional "makeupStaff" makeupStaff MakeupStaff.makeupStaffSchema
-      #+ FC.optional "publicationArtist" publicationArtist PublicationArtist.publicationArtistSchema
-      #+ FC.optional "gender" gender Gender.genderSchema
-      #+ FC.optional "comicColorArtist" comicColorArtist ComicColorArtist.comicColorArtistSchema
-      #+ FC.optional "stuntDepartment" stuntDepartment StuntDepartment.stuntDepartmentSchema
-      #+ FC.optional "novelArtist" novelArtist NovelArtist.novelArtistSchema
       #+ FC.optional "artDepartment" artDepartment ArtDepartment.artDepartmentSchema
-      #+ FC.optional "publicityArtist" publicityArtist PublicityArtist.publicityArtistSchema
-      #+ FC.optional "storyEditor" storyEditor StoryEditor.storyEditorSchema
-      #+ FC.optional "comicStripArtist" comicStripArtist ComicStripArtist.comicStripArtistSchema
-      #+ FC.optional "comicAuthor" comicAuthor ComicAuthor.comicAuthorSchema
-      #+ FC.optional "movies" movies (FC.list MovieBase.movieBaseSchema)
-      #+ FC.optional "comicPencilArtist" comicPencilArtist ComicPencilArtist.comicPencilArtistSchema
-      #+ FC.optional "transportationDepartment" transportationDepartment TransportationDepartment.transportationDepartmentSchema
-      #+ FC.optional "producer" producer Producer.producerSchema
-      #+ FC.optional "composer" composer Composer.composerSchema
-      #+ FC.optional "directedEpisodes" directedEpisodes (FC.list EpisodeBase.episodeBaseSchema)
-      #+ FC.optional "storyAuthoredEpisodes" storyAuthoredEpisodes (FC.list EpisodeBase.episodeBaseSchema)
-      #+ FC.optional "teleplayAuthoredEpisodes" teleplayAuthoredEpisodes (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "artDirector" artDirector ArtDirector.artDirectorSchema
+      #+ FC.optional "assistantOrSecondUnitDirector" assistantOrSecondUnitDirector AssistantOrSecondUnitDirector.assistantOrSecondUnitDirectorSchema
+      #+ FC.optional "audioAuthor" audioAuthor AudioAuthor.audioAuthorSchema
+      #+ FC.optional "author" author Author.authorSchema
+      #+ FC.optional "birthName" birthName BirthName.birthNameSchema
       #+ FC.optional "calendarArtist" calendarArtist CalendarArtist.calendarArtistSchema
+      #+ FC.optional "cameraAndElectricalDepartment" cameraAndElectricalDepartment CameraAndElectricalDepartment.cameraAndElectricalDepartmentSchema
+      #+ FC.optional "castingDepartment" castingDepartment CastingDepartment.castingDepartmentSchema
+      #+ FC.optional "cbsDigitalStaff" cbsDigitalStaff CbsDigitalStaff.cbsDigitalStaffSchema
+      #+ FC.optional "cinematographer" cinematographer Cinematographer.cinematographerSchema
+      #+ FC.optional "comicArtist" comicArtist ComicArtist.comicArtistSchema
+      #+ FC.optional "comicAuthor" comicAuthor ComicAuthor.comicAuthorSchema
+      #+ FC.optional "comicColorArtist" comicColorArtist ComicColorArtist.comicColorArtistSchema
+      #+ FC.optional "comicInkArtist" comicInkArtist ComicInkArtist.comicInkArtistSchema
+      #+ FC.optional "comicInteriorArtist" comicInteriorArtist ComicInteriorArtist.comicInteriorArtistSchema
+      #+ FC.optional "comicLetterArtist" comicLetterArtist ComicLetterArtist.comicLetterArtistSchema
+      #+ FC.optional "comicPencilArtist" comicPencilArtist ComicPencilArtist.comicPencilArtistSchema
+      #+ FC.optional "comicStripArtist" comicStripArtist ComicStripArtist.comicStripArtistSchema
+      #+ FC.optional "composer" composer Composer.composerSchema
+      #+ FC.optional "costumeDepartment" costumeDepartment CostumeDepartment.costumeDepartmentSchema
+      #+ FC.optional "costumeDesigner" costumeDesigner CostumeDesigner.costumeDesignerSchema
+      #+ FC.optional "dateOfBirth" dateOfBirth DateOfBirth.dateOfBirthSchema
+      #+ FC.optional "dateOfDeath" dateOfDeath DateOfDeath.dateOfDeathSchema
+      #+ FC.optional "directedEpisodes" directedEpisodes (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "directedMovies" directedMovies (FC.list MovieBase.movieBaseSchema)
+      #+ FC.optional "director" director Director.directorSchema
+      #+ FC.optional "episodes" episodes (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "exhibitAndAttractionStaff" exhibitAndAttractionStaff ExhibitAndAttractionStaff.exhibitAndAttractionStaffSchema
+      #+ FC.optional "filmEditor" filmEditor FilmEditor.filmEditorSchema
+      #+ FC.optional "gameArtist" gameArtist GameArtist.gameArtistSchema
+      #+ FC.optional "gameAuthor" gameAuthor GameAuthor.gameAuthorSchema
+      #+ FC.optional "gender" gender Gender.genderSchema
+      #+ FC.optional "ilmProductionStaff" ilmProductionStaff IlmProductionStaff.ilmProductionStaffSchema
+      #+ FC.optional "linguist" linguist Linguist.linguistSchema
+      #+ FC.optional "locationStaff" locationStaff LocationStaff.locationStaffSchema
+      #+ FC.optional "makeupStaff" makeupStaff MakeupStaff.makeupStaffSchema
+      #+ FC.optional "movies" movies (FC.list MovieBase.movieBaseSchema)
+      #+ FC.optional "musicDepartment" musicDepartment MusicDepartment.musicDepartmentSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "novelArtist" novelArtist NovelArtist.novelArtistSchema
+      #+ FC.optional "novelAuthor" novelAuthor NovelAuthor.novelAuthorSchema
+      #+ FC.optional "personalAssistant" personalAssistant PersonalAssistant.personalAssistantSchema
+      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
+      #+ FC.optional "placeOfDeath" placeOfDeath PlaceOfDeath.placeOfDeathSchema
       #+ FC.optional "producedMovies" producedMovies (FC.list MovieBase.movieBaseSchema)
-      #+ FC.optional "referenceAuthor" referenceAuthor ReferenceAuthor.referenceAuthorSchema
+      #+ FC.optional "producer" producer Producer.producerSchema
+      #+ FC.optional "productionAssociate" productionAssociate ProductionAssociate.productionAssociateSchema
+      #+ FC.optional "productionDesigner" productionDesigner ProductionDesigner.productionDesignerSchema
+      #+ FC.optional "productionStaff" productionStaff ProductionStaff.productionStaffSchema
+      #+ FC.optional "publicationArtist" publicationArtist PublicationArtist.publicationArtistSchema
+      #+ FC.optional "publicationDesigner" publicationDesigner PublicationDesigner.publicationDesignerSchema
       #+ FC.optional "publicationEditor" publicationEditor PublicationEditor.publicationEditorSchema
       #+ FC.optional "publicationStaff" publicationStaff PublicationStaff.publicationStaffSchema
-      #+ FC.optional "novelAuthor" novelAuthor NovelAuthor.novelAuthorSchema
-      #+ FC.optional "castingDepartment" castingDepartment CastingDepartment.castingDepartmentSchema
-      #+ FC.optional "musicDepartment" musicDepartment MusicDepartment.musicDepartmentSchema
-      #+ FC.optional "cbsDigitalStaff" cbsDigitalStaff CbsDigitalStaff.cbsDigitalStaffSchema
-      #+ FC.optional "costumeDesigner" costumeDesigner CostumeDesigner.costumeDesignerSchema
-      #+ FC.optional "comicInteriorArtist" comicInteriorArtist ComicInteriorArtist.comicInteriorArtistSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "gameAuthor" gameAuthor GameAuthor.gameAuthorSchema
-      #+ FC.optional "directedMovies" directedMovies (FC.list MovieBase.movieBaseSchema)
-      #+ FC.optional "scienceConsultant" scienceConsultant ScienceConsultant.scienceConsultantSchema
-      #+ FC.optional "writtenEpisodes" writtenEpisodes (FC.list EpisodeBase.episodeBaseSchema)
-      #+ FC.optional "dateOfDeath" dateOfDeath DateOfDeath.dateOfDeathSchema
-      #+ FC.optional "filmEditor" filmEditor FilmEditor.filmEditorSchema
-      #+ FC.optional "productionStaff" productionStaff ProductionStaff.productionStaffSchema
-      #+ FC.optional "specialFeaturesStaff" specialFeaturesStaff SpecialFeaturesStaff.specialFeaturesStaffSchema
-      #+ FC.optional "comicInkArtist" comicInkArtist ComicInkArtist.comicInkArtistSchema
-      #+ FC.optional "personalAssistant" personalAssistant PersonalAssistant.personalAssistantSchema
-      #+ FC.optional "soundDepartment" soundDepartment SoundDepartment.soundDepartmentSchema
-      #+ FC.optional "audioAuthor" audioAuthor AudioAuthor.audioAuthorSchema
-      #+ FC.optional "videoGameProductionStaff" videoGameProductionStaff VideoGameProductionStaff.videoGameProductionStaffSchema
-      #+ FC.optional "writtenMovies" writtenMovies (FC.list MovieBase.movieBaseSchema)
-      #+ FC.optional "linguist" linguist Linguist.linguistSchema
-      #+ FC.optional "author" author Author.authorSchema
-      #+ FC.optional "placeOfBirth" placeOfBirth PlaceOfBirth.placeOfBirthSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "gameArtist" gameArtist GameArtist.gameArtistSchema
-      #+ FC.optional "costumeDepartment" costumeDepartment CostumeDepartment.costumeDepartmentSchema
-      #+ FC.optional "storyAuthoredMovies" storyAuthoredMovies (FC.list MovieBase.movieBaseSchema)
-      #+ FC.optional "assistantOrSecondUnitDirector" assistantOrSecondUnitDirector AssistantOrSecondUnitDirector.assistantOrSecondUnitDirectorSchema
-      #+ FC.optional "productionDesigner" productionDesigner ProductionDesigner.productionDesignerSchema
-      #+ FC.optional "cinematographer" cinematographer Cinematographer.cinematographerSchema
-      #+ FC.optional "locationStaff" locationStaff LocationStaff.locationStaffSchema
-      #+ FC.optional "birthName" birthName BirthName.birthNameSchema
-      #+ FC.optional "ilmProductionStaff" ilmProductionStaff IlmProductionStaff.ilmProductionStaffSchema
-      #+ FC.optional "episodes" episodes (FC.list EpisodeBase.episodeBaseSchema)
-      #+ FC.optional "publicationDesigner" publicationDesigner PublicationDesigner.publicationDesignerSchema
-      #+ FC.optional "productionAssociate" productionAssociate ProductionAssociate.productionAssociateSchema
-      #+ FC.optional "dateOfBirth" dateOfBirth DateOfBirth.dateOfBirthSchema
+      #+ FC.optional "publicityArtist" publicityArtist PublicityArtist.publicityArtistSchema
       #+ FC.optional "referenceArtist" referenceArtist ReferenceArtist.referenceArtistSchema
-      #+ FC.optional "placeOfDeath" placeOfDeath PlaceOfDeath.placeOfDeathSchema
+      #+ FC.optional "referenceAuthor" referenceAuthor ReferenceAuthor.referenceAuthorSchema
+      #+ FC.optional "scienceConsultant" scienceConsultant ScienceConsultant.scienceConsultantSchema
+      #+ FC.optional "screenplayAuthoredMovies" screenplayAuthoredMovies (FC.list MovieBase.movieBaseSchema)
+      #+ FC.optional "soundDepartment" soundDepartment SoundDepartment.soundDepartmentSchema
       #+ FC.optional "specialAndVisualEffectsStaff" specialAndVisualEffectsStaff SpecialAndVisualEffectsStaff.specialAndVisualEffectsStaffSchema
-      #+ FC.optional "exhibitAndAttractionStaff" exhibitAndAttractionStaff ExhibitAndAttractionStaff.exhibitAndAttractionStaffSchema
-      #+ FC.optional "comicLetterArtist" comicLetterArtist ComicLetterArtist.comicLetterArtistSchema
+      #+ FC.optional "specialFeaturesStaff" specialFeaturesStaff SpecialFeaturesStaff.specialFeaturesStaffSchema
+      #+ FC.optional "storyAuthoredEpisodes" storyAuthoredEpisodes (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "storyAuthoredMovies" storyAuthoredMovies (FC.list MovieBase.movieBaseSchema)
+      #+ FC.optional "storyEditor" storyEditor StoryEditor.storyEditorSchema
       #+ FC.optional "studioExecutive" studioExecutive StudioExecutive.studioExecutiveSchema
+      #+ FC.optional "stuntDepartment" stuntDepartment StuntDepartment.stuntDepartmentSchema
+      #+ FC.optional "teleplayAuthoredEpisodes" teleplayAuthoredEpisodes (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "transportationDepartment" transportationDepartment TransportationDepartment.transportationDepartmentSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "videoGameProductionStaff" videoGameProductionStaff VideoGameProductionStaff.videoGameProductionStaffSchema
+      #+ FC.optional "writer" writer Writer.writerSchema
+      #+ FC.optional "writtenEpisodes" writtenEpisodes (FC.list EpisodeBase.episodeBaseSchema)
+      #+ FC.optional "writtenMovies" writtenMovies (FC.list MovieBase.movieBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/StaffHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/StaffHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.StaffHeader.Name as Name
 import qualified StarTrek.Types.StaffHeader.Uid as Uid
 
 data StaffHeader = StaffHeader
-  { uid :: Uid.Uid -- ^ Staff unique ID
-  , name :: Name.Name -- ^ Staff name
+  { name :: Name.Name -- ^ Staff name
+  , uid :: Uid.Uid -- ^ Staff unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ staffHeaderSchema :: FC.Fleece schema => schema StaffHeader
 staffHeaderSchema =
   FC.object $
     FC.constructor StaffHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TechnologyBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TechnologyBase.hs
@@ -32,28 +32,28 @@ import qualified StarTrek.Types.TechnologyBase.TransporterTechnology as Transpor
 import qualified StarTrek.Types.TechnologyBase.Uid as Uid
 
 data TechnologyBase = TechnologyBase
-  { sensorTechnology :: Maybe SensorTechnology.SensorTechnology -- ^ Whether it's a sensor technology
+  { borgComponent :: Maybe BorgComponent.BorgComponent -- ^ Whether it's a Borg component
   , borgTechnology :: Maybe BorgTechnology.BorgTechnology -- ^ Whether it's a Borg technology
-  , culinaryTool :: Maybe CulinaryTool.CulinaryTool -- ^ Whether it's a culinary tool
-  , database :: Maybe Database.Database -- ^ Whether it's a database
-  , subroutine :: Maybe Subroutine.Subroutine -- ^ Whether it's a subroutine
-  , identificationTechnology :: Maybe IdentificationTechnology.IdentificationTechnology -- ^ Whether it's a identification technology
-  , borgComponent :: Maybe BorgComponent.BorgComponent -- ^ Whether it's a Borg component
-  , medicalEquipment :: Maybe MedicalEquipment.MedicalEquipment -- ^ Whether it's a medical equipment
-  , energyTechnology :: Maybe EnergyTechnology.EnergyTechnology -- ^ Whether it's a energy technology
-  , holographicTechnology :: Maybe HolographicTechnology.HolographicTechnology -- ^ Whether it's a holographic technology
-  , uid :: Uid.Uid -- ^ Technology unique ID
-  , householdTool :: Maybe HouseholdTool.HouseholdTool -- ^ Whether it's a household tool
-  , lifeSupportTechnology :: Maybe LifeSupportTechnology.LifeSupportTechnology -- ^ Whether it's a life support technology
-  , transporterTechnology :: Maybe TransporterTechnology.TransporterTechnology -- ^ Whether it's a transporter technology
-  , engineeringTool :: Maybe EngineeringTool.EngineeringTool -- ^ Whether it's a engineering tool
-  , name :: Name.Name -- ^ Technology name
-  , fictionalTechnology :: Maybe FictionalTechnology.FictionalTechnology -- ^ Whether it's a fictional technology
   , communicationsTechnology :: Maybe CommunicationsTechnology.CommunicationsTechnology -- ^ Whether it's a communications technology
   , computerProgramming :: Maybe ComputerProgramming.ComputerProgramming -- ^ Whether it's a technology related to computer programming
-  , shieldTechnology :: Maybe ShieldTechnology.ShieldTechnology -- ^ Whether it's a shield technology
   , computerTechnology :: Maybe ComputerTechnology.ComputerTechnology -- ^ Whether it's a computer technology
+  , culinaryTool :: Maybe CulinaryTool.CulinaryTool -- ^ Whether it's a culinary tool
+  , database :: Maybe Database.Database -- ^ Whether it's a database
+  , energyTechnology :: Maybe EnergyTechnology.EnergyTechnology -- ^ Whether it's a energy technology
+  , engineeringTool :: Maybe EngineeringTool.EngineeringTool -- ^ Whether it's a engineering tool
+  , fictionalTechnology :: Maybe FictionalTechnology.FictionalTechnology -- ^ Whether it's a fictional technology
+  , holographicTechnology :: Maybe HolographicTechnology.HolographicTechnology -- ^ Whether it's a holographic technology
+  , householdTool :: Maybe HouseholdTool.HouseholdTool -- ^ Whether it's a household tool
+  , identificationTechnology :: Maybe IdentificationTechnology.IdentificationTechnology -- ^ Whether it's a identification technology
+  , lifeSupportTechnology :: Maybe LifeSupportTechnology.LifeSupportTechnology -- ^ Whether it's a life support technology
+  , medicalEquipment :: Maybe MedicalEquipment.MedicalEquipment -- ^ Whether it's a medical equipment
+  , name :: Name.Name -- ^ Technology name
+  , sensorTechnology :: Maybe SensorTechnology.SensorTechnology -- ^ Whether it's a sensor technology
+  , shieldTechnology :: Maybe ShieldTechnology.ShieldTechnology -- ^ Whether it's a shield technology
+  , subroutine :: Maybe Subroutine.Subroutine -- ^ Whether it's a subroutine
   , tool :: Maybe Tool.Tool -- ^ Whether it's a tool
+  , transporterTechnology :: Maybe TransporterTechnology.TransporterTechnology -- ^ Whether it's a transporter technology
+  , uid :: Uid.Uid -- ^ Technology unique ID
   }
   deriving (Eq, Show)
 
@@ -61,25 +61,25 @@ technologyBaseSchema :: FC.Fleece schema => schema TechnologyBase
 technologyBaseSchema =
   FC.object $
     FC.constructor TechnologyBase
-      #+ FC.optional "sensorTechnology" sensorTechnology SensorTechnology.sensorTechnologySchema
-      #+ FC.optional "borgTechnology" borgTechnology BorgTechnology.borgTechnologySchema
-      #+ FC.optional "culinaryTool" culinaryTool CulinaryTool.culinaryToolSchema
-      #+ FC.optional "database" database Database.databaseSchema
-      #+ FC.optional "subroutine" subroutine Subroutine.subroutineSchema
-      #+ FC.optional "identificationTechnology" identificationTechnology IdentificationTechnology.identificationTechnologySchema
       #+ FC.optional "borgComponent" borgComponent BorgComponent.borgComponentSchema
-      #+ FC.optional "medicalEquipment" medicalEquipment MedicalEquipment.medicalEquipmentSchema
-      #+ FC.optional "energyTechnology" energyTechnology EnergyTechnology.energyTechnologySchema
-      #+ FC.optional "holographicTechnology" holographicTechnology HolographicTechnology.holographicTechnologySchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "householdTool" householdTool HouseholdTool.householdToolSchema
-      #+ FC.optional "lifeSupportTechnology" lifeSupportTechnology LifeSupportTechnology.lifeSupportTechnologySchema
-      #+ FC.optional "transporterTechnology" transporterTechnology TransporterTechnology.transporterTechnologySchema
-      #+ FC.optional "engineeringTool" engineeringTool EngineeringTool.engineeringToolSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "fictionalTechnology" fictionalTechnology FictionalTechnology.fictionalTechnologySchema
+      #+ FC.optional "borgTechnology" borgTechnology BorgTechnology.borgTechnologySchema
       #+ FC.optional "communicationsTechnology" communicationsTechnology CommunicationsTechnology.communicationsTechnologySchema
       #+ FC.optional "computerProgramming" computerProgramming ComputerProgramming.computerProgrammingSchema
-      #+ FC.optional "shieldTechnology" shieldTechnology ShieldTechnology.shieldTechnologySchema
       #+ FC.optional "computerTechnology" computerTechnology ComputerTechnology.computerTechnologySchema
+      #+ FC.optional "culinaryTool" culinaryTool CulinaryTool.culinaryToolSchema
+      #+ FC.optional "database" database Database.databaseSchema
+      #+ FC.optional "energyTechnology" energyTechnology EnergyTechnology.energyTechnologySchema
+      #+ FC.optional "engineeringTool" engineeringTool EngineeringTool.engineeringToolSchema
+      #+ FC.optional "fictionalTechnology" fictionalTechnology FictionalTechnology.fictionalTechnologySchema
+      #+ FC.optional "holographicTechnology" holographicTechnology HolographicTechnology.holographicTechnologySchema
+      #+ FC.optional "householdTool" householdTool HouseholdTool.householdToolSchema
+      #+ FC.optional "identificationTechnology" identificationTechnology IdentificationTechnology.identificationTechnologySchema
+      #+ FC.optional "lifeSupportTechnology" lifeSupportTechnology LifeSupportTechnology.lifeSupportTechnologySchema
+      #+ FC.optional "medicalEquipment" medicalEquipment MedicalEquipment.medicalEquipmentSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "sensorTechnology" sensorTechnology SensorTechnology.sensorTechnologySchema
+      #+ FC.optional "shieldTechnology" shieldTechnology ShieldTechnology.shieldTechnologySchema
+      #+ FC.optional "subroutine" subroutine Subroutine.subroutineSchema
       #+ FC.optional "tool" tool Tool.toolSchema
+      #+ FC.optional "transporterTechnology" transporterTechnology TransporterTechnology.transporterTechnologySchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TechnologyBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TechnologyBaseResponse.hs
@@ -14,8 +14,8 @@ import qualified StarTrek.Types.TechnologyBase as TechnologyBase
 
 data TechnologyBaseResponse = TechnologyBaseResponse
   { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , technology :: Maybe [TechnologyBase.TechnologyBase] -- ^ Base technology, returned in search results
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
+  , technology :: Maybe [TechnologyBase.TechnologyBase] -- ^ Base technology, returned in search results
   }
   deriving (Eq, Show)
 
@@ -24,5 +24,5 @@ technologyBaseResponseSchema =
   FC.object $
     FC.constructor TechnologyBaseResponse
       #+ FC.optional "page" page ResponsePage.responsePageSchema
-      #+ FC.optional "technology" technology (FC.list TechnologyBase.technologyBaseSchema)
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
+      #+ FC.optional "technology" technology (FC.list TechnologyBase.technologyBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TechnologyFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TechnologyFull.hs
@@ -32,28 +32,28 @@ import qualified StarTrek.Types.TechnologyFull.TransporterTechnology as Transpor
 import qualified StarTrek.Types.TechnologyFull.Uid as Uid
 
 data TechnologyFull = TechnologyFull
-  { sensorTechnology :: Maybe SensorTechnology.SensorTechnology -- ^ Whether it's a sensor technology
+  { borgComponent :: Maybe BorgComponent.BorgComponent -- ^ Whether it's a Borg component
   , borgTechnology :: Maybe BorgTechnology.BorgTechnology -- ^ Whether it's a Borg technology
-  , culinaryTool :: Maybe CulinaryTool.CulinaryTool -- ^ Whether it's a culinary tool
-  , database :: Maybe Database.Database -- ^ Whether it's a database
-  , subroutine :: Maybe Subroutine.Subroutine -- ^ Whether it's a subroutine
-  , identificationTechnology :: Maybe IdentificationTechnology.IdentificationTechnology -- ^ Whether it's a identification technology
-  , borgComponent :: Maybe BorgComponent.BorgComponent -- ^ Whether it's a Borg component
-  , medicalEquipment :: Maybe MedicalEquipment.MedicalEquipment -- ^ Whether it's a medical equipment
-  , energyTechnology :: Maybe EnergyTechnology.EnergyTechnology -- ^ Whether it's a energy technology
-  , holographicTechnology :: Maybe HolographicTechnology.HolographicTechnology -- ^ Whether it's a holographic technology
-  , uid :: Uid.Uid -- ^ Technology unique ID
-  , householdTool :: Maybe HouseholdTool.HouseholdTool -- ^ Whether it's a household tool
-  , lifeSupportTechnology :: Maybe LifeSupportTechnology.LifeSupportTechnology -- ^ Whether it's a life support technology
-  , transporterTechnology :: Maybe TransporterTechnology.TransporterTechnology -- ^ Whether it's a transporter technology
-  , engineeringTool :: Maybe EngineeringTool.EngineeringTool -- ^ Whether it's a engineering tool
-  , name :: Name.Name -- ^ Technology name
-  , fictionalTechnology :: Maybe FictionalTechnology.FictionalTechnology -- ^ Whether it's a fictional technology
   , communicationsTechnology :: Maybe CommunicationsTechnology.CommunicationsTechnology -- ^ Whether it's a communications technology
   , computerProgramming :: Maybe ComputerProgramming.ComputerProgramming -- ^ Whether it's a technology related to computer programming
-  , shieldTechnology :: Maybe ShieldTechnology.ShieldTechnology -- ^ Whether it's a shield technology
   , computerTechnology :: Maybe ComputerTechnology.ComputerTechnology -- ^ Whether it's a computer technology
+  , culinaryTool :: Maybe CulinaryTool.CulinaryTool -- ^ Whether it's a culinary tool
+  , database :: Maybe Database.Database -- ^ Whether it's a database
+  , energyTechnology :: Maybe EnergyTechnology.EnergyTechnology -- ^ Whether it's a energy technology
+  , engineeringTool :: Maybe EngineeringTool.EngineeringTool -- ^ Whether it's a engineering tool
+  , fictionalTechnology :: Maybe FictionalTechnology.FictionalTechnology -- ^ Whether it's a fictional technology
+  , holographicTechnology :: Maybe HolographicTechnology.HolographicTechnology -- ^ Whether it's a holographic technology
+  , householdTool :: Maybe HouseholdTool.HouseholdTool -- ^ Whether it's a household tool
+  , identificationTechnology :: Maybe IdentificationTechnology.IdentificationTechnology -- ^ Whether it's a identification technology
+  , lifeSupportTechnology :: Maybe LifeSupportTechnology.LifeSupportTechnology -- ^ Whether it's a life support technology
+  , medicalEquipment :: Maybe MedicalEquipment.MedicalEquipment -- ^ Whether it's a medical equipment
+  , name :: Name.Name -- ^ Technology name
+  , sensorTechnology :: Maybe SensorTechnology.SensorTechnology -- ^ Whether it's a sensor technology
+  , shieldTechnology :: Maybe ShieldTechnology.ShieldTechnology -- ^ Whether it's a shield technology
+  , subroutine :: Maybe Subroutine.Subroutine -- ^ Whether it's a subroutine
   , tool :: Maybe Tool.Tool -- ^ Whether it's a tool
+  , transporterTechnology :: Maybe TransporterTechnology.TransporterTechnology -- ^ Whether it's a transporter technology
+  , uid :: Uid.Uid -- ^ Technology unique ID
   }
   deriving (Eq, Show)
 
@@ -61,25 +61,25 @@ technologyFullSchema :: FC.Fleece schema => schema TechnologyFull
 technologyFullSchema =
   FC.object $
     FC.constructor TechnologyFull
-      #+ FC.optional "sensorTechnology" sensorTechnology SensorTechnology.sensorTechnologySchema
-      #+ FC.optional "borgTechnology" borgTechnology BorgTechnology.borgTechnologySchema
-      #+ FC.optional "culinaryTool" culinaryTool CulinaryTool.culinaryToolSchema
-      #+ FC.optional "database" database Database.databaseSchema
-      #+ FC.optional "subroutine" subroutine Subroutine.subroutineSchema
-      #+ FC.optional "identificationTechnology" identificationTechnology IdentificationTechnology.identificationTechnologySchema
       #+ FC.optional "borgComponent" borgComponent BorgComponent.borgComponentSchema
-      #+ FC.optional "medicalEquipment" medicalEquipment MedicalEquipment.medicalEquipmentSchema
-      #+ FC.optional "energyTechnology" energyTechnology EnergyTechnology.energyTechnologySchema
-      #+ FC.optional "holographicTechnology" holographicTechnology HolographicTechnology.holographicTechnologySchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "householdTool" householdTool HouseholdTool.householdToolSchema
-      #+ FC.optional "lifeSupportTechnology" lifeSupportTechnology LifeSupportTechnology.lifeSupportTechnologySchema
-      #+ FC.optional "transporterTechnology" transporterTechnology TransporterTechnology.transporterTechnologySchema
-      #+ FC.optional "engineeringTool" engineeringTool EngineeringTool.engineeringToolSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "fictionalTechnology" fictionalTechnology FictionalTechnology.fictionalTechnologySchema
+      #+ FC.optional "borgTechnology" borgTechnology BorgTechnology.borgTechnologySchema
       #+ FC.optional "communicationsTechnology" communicationsTechnology CommunicationsTechnology.communicationsTechnologySchema
       #+ FC.optional "computerProgramming" computerProgramming ComputerProgramming.computerProgrammingSchema
-      #+ FC.optional "shieldTechnology" shieldTechnology ShieldTechnology.shieldTechnologySchema
       #+ FC.optional "computerTechnology" computerTechnology ComputerTechnology.computerTechnologySchema
+      #+ FC.optional "culinaryTool" culinaryTool CulinaryTool.culinaryToolSchema
+      #+ FC.optional "database" database Database.databaseSchema
+      #+ FC.optional "energyTechnology" energyTechnology EnergyTechnology.energyTechnologySchema
+      #+ FC.optional "engineeringTool" engineeringTool EngineeringTool.engineeringToolSchema
+      #+ FC.optional "fictionalTechnology" fictionalTechnology FictionalTechnology.fictionalTechnologySchema
+      #+ FC.optional "holographicTechnology" holographicTechnology HolographicTechnology.holographicTechnologySchema
+      #+ FC.optional "householdTool" householdTool HouseholdTool.householdToolSchema
+      #+ FC.optional "identificationTechnology" identificationTechnology IdentificationTechnology.identificationTechnologySchema
+      #+ FC.optional "lifeSupportTechnology" lifeSupportTechnology LifeSupportTechnology.lifeSupportTechnologySchema
+      #+ FC.optional "medicalEquipment" medicalEquipment MedicalEquipment.medicalEquipmentSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "sensorTechnology" sensorTechnology SensorTechnology.sensorTechnologySchema
+      #+ FC.optional "shieldTechnology" shieldTechnology ShieldTechnology.shieldTechnologySchema
+      #+ FC.optional "subroutine" subroutine Subroutine.subroutineSchema
       #+ FC.optional "tool" tool Tool.toolSchema
+      #+ FC.optional "transporterTechnology" transporterTechnology TransporterTechnology.transporterTechnologySchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TechnologyHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TechnologyHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.TechnologyHeader.Name as Name
 import qualified StarTrek.Types.TechnologyHeader.Uid as Uid
 
 data TechnologyHeader = TechnologyHeader
-  { uid :: Uid.Uid -- ^ Technology unique ID
-  , name :: Name.Name -- ^ Technology name
+  { name :: Name.Name -- ^ Technology name
+  , uid :: Uid.Uid -- ^ Technology unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ technologyHeaderSchema :: FC.Fleece schema => schema TechnologyHeader
 technologyHeaderSchema =
   FC.object $
     FC.constructor TechnologyHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TitleBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TitleBase.hs
@@ -17,13 +17,13 @@ import qualified StarTrek.Types.TitleBase.ReligiousTitle as ReligiousTitle
 import qualified StarTrek.Types.TitleBase.Uid as Uid
 
 data TitleBase = TitleBase
-  { mirror :: Maybe Mirror.Mirror -- ^ Whether this title is from mirror universe
+  { fleetRank :: Maybe FleetRank.FleetRank -- ^ Whether it's a fleet rank
+  , militaryRank :: Maybe MilitaryRank.MilitaryRank -- ^ Whether it's a military rank
+  , mirror :: Maybe Mirror.Mirror -- ^ Whether this title is from mirror universe
+  , name :: Name.Name -- ^ Title name
+  , position :: Maybe Position.Position -- ^ Whether it's a position
   , religiousTitle :: Maybe ReligiousTitle.ReligiousTitle -- ^ Whether it's a religious title
   , uid :: Uid.Uid -- ^ Title unique ID
-  , fleetRank :: Maybe FleetRank.FleetRank -- ^ Whether it's a fleet rank
-  , name :: Name.Name -- ^ Title name
-  , militaryRank :: Maybe MilitaryRank.MilitaryRank -- ^ Whether it's a military rank
-  , position :: Maybe Position.Position -- ^ Whether it's a position
   }
   deriving (Eq, Show)
 
@@ -31,10 +31,10 @@ titleBaseSchema :: FC.Fleece schema => schema TitleBase
 titleBaseSchema =
   FC.object $
     FC.constructor TitleBase
+      #+ FC.optional "fleetRank" fleetRank FleetRank.fleetRankSchema
+      #+ FC.optional "militaryRank" militaryRank MilitaryRank.militaryRankSchema
       #+ FC.optional "mirror" mirror Mirror.mirrorSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "position" position Position.positionSchema
       #+ FC.optional "religiousTitle" religiousTitle ReligiousTitle.religiousTitleSchema
       #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "fleetRank" fleetRank FleetRank.fleetRankSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "militaryRank" militaryRank MilitaryRank.militaryRankSchema
-      #+ FC.optional "position" position Position.positionSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TitleBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TitleBaseResponse.hs
@@ -14,8 +14,8 @@ import qualified StarTrek.Types.TitleBase as TitleBase
 
 data TitleBaseResponse = TitleBaseResponse
   { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , titles :: Maybe [TitleBase.TitleBase] -- ^ Base title, returned in search results
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
+  , titles :: Maybe [TitleBase.TitleBase] -- ^ Base title, returned in search results
   }
   deriving (Eq, Show)
 
@@ -24,5 +24,5 @@ titleBaseResponseSchema =
   FC.object $
     FC.constructor TitleBaseResponse
       #+ FC.optional "page" page ResponsePage.responsePageSchema
-      #+ FC.optional "titles" titles (FC.list TitleBase.titleBaseSchema)
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
+      #+ FC.optional "titles" titles (FC.list TitleBase.titleBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TitleFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TitleFull.hs
@@ -18,14 +18,14 @@ import qualified StarTrek.Types.TitleFull.ReligiousTitle as ReligiousTitle
 import qualified StarTrek.Types.TitleFull.Uid as Uid
 
 data TitleFull = TitleFull
-  { mirror :: Maybe Mirror.Mirror -- ^ Whether this title is from mirror universe
-  , religiousTitle :: Maybe ReligiousTitle.ReligiousTitle -- ^ Whether it's a religious title
-  , characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
-  , uid :: Uid.Uid -- ^ Title unique ID
+  { characters :: Maybe [CharacterBase.CharacterBase] -- ^ Base character, returned in search results
   , fleetRank :: Maybe FleetRank.FleetRank -- ^ Whether it's a fleet rank
-  , name :: Name.Name -- ^ Title name
   , militaryRank :: Maybe MilitaryRank.MilitaryRank -- ^ Whether it's a military rank
+  , mirror :: Maybe Mirror.Mirror -- ^ Whether this title is from mirror universe
+  , name :: Name.Name -- ^ Title name
   , position :: Maybe Position.Position -- ^ Whether it's a position
+  , religiousTitle :: Maybe ReligiousTitle.ReligiousTitle -- ^ Whether it's a religious title
+  , uid :: Uid.Uid -- ^ Title unique ID
   }
   deriving (Eq, Show)
 
@@ -33,11 +33,11 @@ titleFullSchema :: FC.Fleece schema => schema TitleFull
 titleFullSchema =
   FC.object $
     FC.constructor TitleFull
-      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
-      #+ FC.optional "religiousTitle" religiousTitle ReligiousTitle.religiousTitleSchema
       #+ FC.optional "characters" characters (FC.list CharacterBase.characterBaseSchema)
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "fleetRank" fleetRank FleetRank.fleetRankSchema
-      #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "militaryRank" militaryRank MilitaryRank.militaryRankSchema
+      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
+      #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "position" position Position.positionSchema
+      #+ FC.optional "religiousTitle" religiousTitle ReligiousTitle.religiousTitleSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TitleHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TitleHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.TitleHeader.Name as Name
 import qualified StarTrek.Types.TitleHeader.Uid as Uid
 
 data TitleHeader = TitleHeader
-  { uid :: Uid.Uid -- ^ Title unique ID
-  , name :: Name.Name -- ^ Title name
+  { name :: Name.Name -- ^ Title name
+  , uid :: Uid.Uid -- ^ Title unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ titleHeaderSchema :: FC.Fleece schema => schema TitleHeader
 titleHeaderSchema =
   FC.object $
     FC.constructor TitleHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardBase.hs
@@ -17,13 +17,13 @@ import qualified StarTrek.Types.TradingCardDeckHeader as TradingCardDeckHeader
 import qualified StarTrek.Types.TradingCardSetHeader as TradingCardSetHeader
 
 data TradingCardBase = TradingCardBase
-  { tradingCardDeck :: Maybe TradingCardDeckHeader.TradingCardDeckHeader -- ^ Header trading card deck, embedded in other objects
-  , tradingCardSet :: Maybe TradingCardSetHeader.TradingCardSetHeader -- ^ Header trading card set, embedded in other objects
-  , uid :: Uid.Uid -- ^ Trading card unique ID
-  , name :: Name.Name -- ^ Trading card name
-  , releaseYear :: Maybe ReleaseYear.ReleaseYear -- ^ Release year, if set was releases over multiple years
+  { name :: Name.Name -- ^ Trading card name
   , number :: Maybe Number.Number -- ^ Trading card number
   , productionRun :: Maybe ProductionRun.ProductionRun -- ^ Production run, if different from trading card set production run
+  , releaseYear :: Maybe ReleaseYear.ReleaseYear -- ^ Release year, if set was releases over multiple years
+  , tradingCardDeck :: Maybe TradingCardDeckHeader.TradingCardDeckHeader -- ^ Header trading card deck, embedded in other objects
+  , tradingCardSet :: Maybe TradingCardSetHeader.TradingCardSetHeader -- ^ Header trading card set, embedded in other objects
+  , uid :: Uid.Uid -- ^ Trading card unique ID
   }
   deriving (Eq, Show)
 
@@ -31,10 +31,10 @@ tradingCardBaseSchema :: FC.Fleece schema => schema TradingCardBase
 tradingCardBaseSchema =
   FC.object $
     FC.constructor TradingCardBase
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "number" number Number.numberSchema
+      #+ FC.optional "productionRun" productionRun ProductionRun.productionRunSchema
+      #+ FC.optional "releaseYear" releaseYear ReleaseYear.releaseYearSchema
       #+ FC.optional "tradingCardDeck" tradingCardDeck TradingCardDeckHeader.tradingCardDeckHeaderSchema
       #+ FC.optional "tradingCardSet" tradingCardSet TradingCardSetHeader.tradingCardSetHeaderSchema
       #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "releaseYear" releaseYear ReleaseYear.releaseYearSchema
-      #+ FC.optional "number" number Number.numberSchema
-      #+ FC.optional "productionRun" productionRun ProductionRun.productionRunSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardBaseResponse.hs
@@ -13,9 +13,9 @@ import qualified StarTrek.Types.ResponseSort as ResponseSort
 import qualified StarTrek.Types.TradingCardBase as TradingCardBase
 
 data TradingCardBaseResponse = TradingCardBaseResponse
-  { tradingCards :: Maybe [TradingCardBase.TradingCardBase] -- ^ Base trading card, returned in search results
-  , page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
+  { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
+  , tradingCards :: Maybe [TradingCardBase.TradingCardBase] -- ^ Base trading card, returned in search results
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ tradingCardBaseResponseSchema :: FC.Fleece schema => schema TradingCardBaseRespo
 tradingCardBaseResponseSchema =
   FC.object $
     FC.constructor TradingCardBaseResponse
-      #+ FC.optional "tradingCards" tradingCards (FC.list TradingCardBase.tradingCardBaseSchema)
       #+ FC.optional "page" page ResponsePage.responsePageSchema
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
+      #+ FC.optional "tradingCards" tradingCards (FC.list TradingCardBase.tradingCardBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardDeckBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardDeckBase.hs
@@ -15,9 +15,9 @@ import qualified StarTrek.Types.TradingCardSetHeader as TradingCardSetHeader
 
 data TradingCardDeckBase = TradingCardDeckBase
   { frequency :: Maybe Frequency.Frequency -- ^ Frequency with which this deck occur in it's set
+  , name :: Name.Name -- ^ Trading card deck name
   , tradingCardSet :: Maybe TradingCardSetHeader.TradingCardSetHeader -- ^ Header trading card set, embedded in other objects
   , uid :: Uid.Uid -- ^ Trading card deck unique ID
-  , name :: Name.Name -- ^ Trading card deck name
   }
   deriving (Eq, Show)
 
@@ -26,6 +26,6 @@ tradingCardDeckBaseSchema =
   FC.object $
     FC.constructor TradingCardDeckBase
       #+ FC.optional "frequency" frequency Frequency.frequencySchema
+      #+ FC.required "name" name Name.nameSchema
       #+ FC.optional "tradingCardSet" tradingCardSet TradingCardSetHeader.tradingCardSetHeaderSchema
       #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.required "name" name Name.nameSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardDeckBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardDeckBaseResponse.hs
@@ -14,8 +14,8 @@ import qualified StarTrek.Types.TradingCardDeckBase as TradingCardDeckBase
 
 data TradingCardDeckBaseResponse = TradingCardDeckBaseResponse
   { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , tradingCardDecks :: Maybe [TradingCardDeckBase.TradingCardDeckBase] -- ^ Base trading card deck, returned in search results
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
+  , tradingCardDecks :: Maybe [TradingCardDeckBase.TradingCardDeckBase] -- ^ Base trading card deck, returned in search results
   }
   deriving (Eq, Show)
 
@@ -24,5 +24,5 @@ tradingCardDeckBaseResponseSchema =
   FC.object $
     FC.constructor TradingCardDeckBaseResponse
       #+ FC.optional "page" page ResponsePage.responsePageSchema
-      #+ FC.optional "tradingCardDecks" tradingCardDecks (FC.list TradingCardDeckBase.tradingCardDeckBaseSchema)
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
+      #+ FC.optional "tradingCardDecks" tradingCardDecks (FC.list TradingCardDeckBase.tradingCardDeckBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardDeckFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardDeckFull.hs
@@ -15,11 +15,11 @@ import qualified StarTrek.Types.TradingCardDeckFull.Uid as Uid
 import qualified StarTrek.Types.TradingCardSetHeader as TradingCardSetHeader
 
 data TradingCardDeckFull = TradingCardDeckFull
-  { tradingCards :: Maybe [TradingCardBase.TradingCardBase] -- ^ Base trading card, returned in search results
-  , frequency :: Maybe Frequency.Frequency -- ^ Frequency with which this deck occur in it's set
-  , tradingCardSet :: Maybe TradingCardSetHeader.TradingCardSetHeader -- ^ Header trading card set, embedded in other objects
-  , uid :: Uid.Uid -- ^ Trading card deck unique ID
+  { frequency :: Maybe Frequency.Frequency -- ^ Frequency with which this deck occur in it's set
   , name :: Name.Name -- ^ Trading card deck name
+  , tradingCardSet :: Maybe TradingCardSetHeader.TradingCardSetHeader -- ^ Header trading card set, embedded in other objects
+  , tradingCards :: Maybe [TradingCardBase.TradingCardBase] -- ^ Base trading card, returned in search results
+  , uid :: Uid.Uid -- ^ Trading card deck unique ID
   }
   deriving (Eq, Show)
 
@@ -27,8 +27,8 @@ tradingCardDeckFullSchema :: FC.Fleece schema => schema TradingCardDeckFull
 tradingCardDeckFullSchema =
   FC.object $
     FC.constructor TradingCardDeckFull
-      #+ FC.optional "tradingCards" tradingCards (FC.list TradingCardBase.tradingCardBaseSchema)
       #+ FC.optional "frequency" frequency Frequency.frequencySchema
-      #+ FC.optional "tradingCardSet" tradingCardSet TradingCardSetHeader.tradingCardSetHeaderSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "tradingCardSet" tradingCardSet TradingCardSetHeader.tradingCardSetHeaderSchema
+      #+ FC.optional "tradingCards" tradingCards (FC.list TradingCardBase.tradingCardBaseSchema)
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardDeckHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardDeckHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.TradingCardDeckHeader.Name as Name
 import qualified StarTrek.Types.TradingCardDeckHeader.Uid as Uid
 
 data TradingCardDeckHeader = TradingCardDeckHeader
-  { uid :: Uid.Uid -- ^ Trading card deck unique ID
-  , name :: Name.Name -- ^ Trading card deck name
+  { name :: Name.Name -- ^ Trading card deck name
+  , uid :: Uid.Uid -- ^ Trading card deck unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ tradingCardDeckHeaderSchema :: FC.Fleece schema => schema TradingCardDeckHeader
 tradingCardDeckHeaderSchema =
   FC.object $
     FC.constructor TradingCardDeckHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardFull.hs
@@ -17,13 +17,13 @@ import qualified StarTrek.Types.TradingCardFull.Uid as Uid
 import qualified StarTrek.Types.TradingCardSetBase as TradingCardSetBase
 
 data TradingCardFull = TradingCardFull
-  { tradingCardDeck :: Maybe TradingCardDeckBase.TradingCardDeckBase -- ^ Base trading card deck, returned in search results
-  , tradingCardSet :: Maybe TradingCardSetBase.TradingCardSetBase -- ^ Base trading card set, returned in search results
-  , uid :: Uid.Uid -- ^ Trading card unique ID
-  , name :: Name.Name -- ^ Trading card name
-  , releaseYear :: Maybe ReleaseYear.ReleaseYear -- ^ Release year, if set was releases over multiple years
+  { name :: Name.Name -- ^ Trading card name
   , number :: Maybe Number.Number -- ^ Trading card number
   , productionRun :: Maybe ProductionRun.ProductionRun -- ^ Production run, if different from trading card set production run
+  , releaseYear :: Maybe ReleaseYear.ReleaseYear -- ^ Release year, if set was releases over multiple years
+  , tradingCardDeck :: Maybe TradingCardDeckBase.TradingCardDeckBase -- ^ Base trading card deck, returned in search results
+  , tradingCardSet :: Maybe TradingCardSetBase.TradingCardSetBase -- ^ Base trading card set, returned in search results
+  , uid :: Uid.Uid -- ^ Trading card unique ID
   }
   deriving (Eq, Show)
 
@@ -31,10 +31,10 @@ tradingCardFullSchema :: FC.Fleece schema => schema TradingCardFull
 tradingCardFullSchema =
   FC.object $
     FC.constructor TradingCardFull
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "number" number Number.numberSchema
+      #+ FC.optional "productionRun" productionRun ProductionRun.productionRunSchema
+      #+ FC.optional "releaseYear" releaseYear ReleaseYear.releaseYearSchema
       #+ FC.optional "tradingCardDeck" tradingCardDeck TradingCardDeckBase.tradingCardDeckBaseSchema
       #+ FC.optional "tradingCardSet" tradingCardSet TradingCardSetBase.tradingCardSetBaseSchema
       #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "releaseYear" releaseYear ReleaseYear.releaseYearSchema
-      #+ FC.optional "number" number Number.numberSchema
-      #+ FC.optional "productionRun" productionRun ProductionRun.productionRunSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.TradingCardHeader.Name as Name
 import qualified StarTrek.Types.TradingCardHeader.Uid as Uid
 
 data TradingCardHeader = TradingCardHeader
-  { uid :: Uid.Uid -- ^ Trading card unique ID
-  , name :: Name.Name -- ^ Trading card name
+  { name :: Name.Name -- ^ Trading card name
+  , uid :: Uid.Uid -- ^ Trading card unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ tradingCardHeaderSchema :: FC.Fleece schema => schema TradingCardHeader
 tradingCardHeaderSchema =
   FC.object $
     FC.constructor TradingCardHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardSetBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardSetBase.hs
@@ -22,18 +22,18 @@ import qualified StarTrek.Types.TradingCardSetBase.ReleaseYear as ReleaseYear
 import qualified StarTrek.Types.TradingCardSetBase.Uid as Uid
 
 data TradingCardSetBase = TradingCardSetBase
-  { releaseMonth :: Maybe ReleaseMonth.ReleaseMonth -- ^ Release month
+  { boxesPerCase :: Maybe BoxesPerCase.BoxesPerCase -- ^ Boxes per case
   , cardHeight :: Maybe CardHeight.CardHeight -- ^ Card height, in inches
-  , packsPerBox :: Maybe PacksPerBox.PacksPerBox -- ^ Packs per box
-  , productionRunUnit :: Maybe ProductionRunUnit.ProductionRunUnit -- ^ Production run unit
-  , uid :: Uid.Uid -- ^ Trading card set unique ID
-  , boxesPerCase :: Maybe BoxesPerCase.BoxesPerCase -- ^ Boxes per case
   , cardWidth :: Maybe CardWidth.CardWidth -- ^ Card width, in inches
-  , name :: Name.Name -- ^ Trading card set name
-  , releaseYear :: Maybe ReleaseYear.ReleaseYear -- ^ Release year
   , cardsPerPack :: Maybe CardsPerPack.CardsPerPack -- ^ Cards per deck
+  , name :: Name.Name -- ^ Trading card set name
+  , packsPerBox :: Maybe PacksPerBox.PacksPerBox -- ^ Packs per box
   , productionRun :: Maybe ProductionRun.ProductionRun -- ^ Production run
+  , productionRunUnit :: Maybe ProductionRunUnit.ProductionRunUnit -- ^ Production run unit
   , releaseDay :: Maybe ReleaseDay.ReleaseDay -- ^ Release day
+  , releaseMonth :: Maybe ReleaseMonth.ReleaseMonth -- ^ Release month
+  , releaseYear :: Maybe ReleaseYear.ReleaseYear -- ^ Release year
+  , uid :: Uid.Uid -- ^ Trading card set unique ID
   }
   deriving (Eq, Show)
 
@@ -41,15 +41,15 @@ tradingCardSetBaseSchema :: FC.Fleece schema => schema TradingCardSetBase
 tradingCardSetBaseSchema =
   FC.object $
     FC.constructor TradingCardSetBase
-      #+ FC.optional "releaseMonth" releaseMonth ReleaseMonth.releaseMonthSchema
-      #+ FC.optional "cardHeight" cardHeight CardHeight.cardHeightSchema
-      #+ FC.optional "packsPerBox" packsPerBox PacksPerBox.packsPerBoxSchema
-      #+ FC.optional "productionRunUnit" productionRunUnit ProductionRunUnit.productionRunUnitSchema
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.optional "boxesPerCase" boxesPerCase BoxesPerCase.boxesPerCaseSchema
+      #+ FC.optional "cardHeight" cardHeight CardHeight.cardHeightSchema
       #+ FC.optional "cardWidth" cardWidth CardWidth.cardWidthSchema
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "releaseYear" releaseYear ReleaseYear.releaseYearSchema
       #+ FC.optional "cardsPerPack" cardsPerPack CardsPerPack.cardsPerPackSchema
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "packsPerBox" packsPerBox PacksPerBox.packsPerBoxSchema
       #+ FC.optional "productionRun" productionRun ProductionRun.productionRunSchema
+      #+ FC.optional "productionRunUnit" productionRunUnit ProductionRunUnit.productionRunUnitSchema
       #+ FC.optional "releaseDay" releaseDay ReleaseDay.releaseDaySchema
+      #+ FC.optional "releaseMonth" releaseMonth ReleaseMonth.releaseMonthSchema
+      #+ FC.optional "releaseYear" releaseYear ReleaseYear.releaseYearSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardSetBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardSetBaseResponse.hs
@@ -14,8 +14,8 @@ import qualified StarTrek.Types.TradingCardSetBase as TradingCardSetBase
 
 data TradingCardSetBaseResponse = TradingCardSetBaseResponse
   { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , tradingCardSets :: Maybe [TradingCardSetBase.TradingCardSetBase] -- ^ Base trading card set, returned in search results
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
+  , tradingCardSets :: Maybe [TradingCardSetBase.TradingCardSetBase] -- ^ Base trading card set, returned in search results
   }
   deriving (Eq, Show)
 
@@ -24,5 +24,5 @@ tradingCardSetBaseResponseSchema =
   FC.object $
     FC.constructor TradingCardSetBaseResponse
       #+ FC.optional "page" page ResponsePage.responsePageSchema
-      #+ FC.optional "tradingCardSets" tradingCardSets (FC.list TradingCardSetBase.tradingCardSetBaseSchema)
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
+      #+ FC.optional "tradingCardSets" tradingCardSets (FC.list TradingCardSetBase.tradingCardSetBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardSetFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardSetFull.hs
@@ -26,22 +26,22 @@ import qualified StarTrek.Types.TradingCardSetFull.ReleaseYear as ReleaseYear
 import qualified StarTrek.Types.TradingCardSetFull.Uid as Uid
 
 data TradingCardSetFull = TradingCardSetFull
-  { manufacturers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
-  , releaseMonth :: Maybe ReleaseMonth.ReleaseMonth -- ^ Release month
-  , tradingCards :: Maybe [TradingCardBase.TradingCardBase] -- ^ Base trading card, returned in search results
+  { boxesPerCase :: Maybe BoxesPerCase.BoxesPerCase -- ^ Boxes per case
   , cardHeight :: Maybe CardHeight.CardHeight -- ^ Card height, in inches
-  , packsPerBox :: Maybe PacksPerBox.PacksPerBox -- ^ Packs per box
-  , productionRunUnit :: Maybe ProductionRunUnit.ProductionRunUnit -- ^ Production run unit
-  , uid :: Uid.Uid -- ^ Trading card set unique ID
-  , tradingCardDecks :: Maybe [TradingCardDeckBase.TradingCardDeckBase] -- ^ Base trading card deck, returned in search results
-  , boxesPerCase :: Maybe BoxesPerCase.BoxesPerCase -- ^ Boxes per case
   , cardWidth :: Maybe CardWidth.CardWidth -- ^ Card width, in inches
-  , countriesOfOrigin :: Maybe [Country.Country] -- ^ Real-world country
-  , name :: Name.Name -- ^ Trading card set name
-  , releaseYear :: Maybe ReleaseYear.ReleaseYear -- ^ Release year
   , cardsPerPack :: Maybe CardsPerPack.CardsPerPack -- ^ Cards per deck
+  , countriesOfOrigin :: Maybe [Country.Country] -- ^ Real-world country
+  , manufacturers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  , name :: Name.Name -- ^ Trading card set name
+  , packsPerBox :: Maybe PacksPerBox.PacksPerBox -- ^ Packs per box
   , productionRun :: Maybe ProductionRun.ProductionRun -- ^ Production run
+  , productionRunUnit :: Maybe ProductionRunUnit.ProductionRunUnit -- ^ Production run unit
   , releaseDay :: Maybe ReleaseDay.ReleaseDay -- ^ Release day
+  , releaseMonth :: Maybe ReleaseMonth.ReleaseMonth -- ^ Release month
+  , releaseYear :: Maybe ReleaseYear.ReleaseYear -- ^ Release year
+  , tradingCardDecks :: Maybe [TradingCardDeckBase.TradingCardDeckBase] -- ^ Base trading card deck, returned in search results
+  , tradingCards :: Maybe [TradingCardBase.TradingCardBase] -- ^ Base trading card, returned in search results
+  , uid :: Uid.Uid -- ^ Trading card set unique ID
   }
   deriving (Eq, Show)
 
@@ -49,19 +49,19 @@ tradingCardSetFullSchema :: FC.Fleece schema => schema TradingCardSetFull
 tradingCardSetFullSchema =
   FC.object $
     FC.constructor TradingCardSetFull
-      #+ FC.optional "manufacturers" manufacturers (FC.list CompanyBase.companyBaseSchema)
-      #+ FC.optional "releaseMonth" releaseMonth ReleaseMonth.releaseMonthSchema
-      #+ FC.optional "tradingCards" tradingCards (FC.list TradingCardBase.tradingCardBaseSchema)
-      #+ FC.optional "cardHeight" cardHeight CardHeight.cardHeightSchema
-      #+ FC.optional "packsPerBox" packsPerBox PacksPerBox.packsPerBoxSchema
-      #+ FC.optional "productionRunUnit" productionRunUnit ProductionRunUnit.productionRunUnitSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "tradingCardDecks" tradingCardDecks (FC.list TradingCardDeckBase.tradingCardDeckBaseSchema)
       #+ FC.optional "boxesPerCase" boxesPerCase BoxesPerCase.boxesPerCaseSchema
+      #+ FC.optional "cardHeight" cardHeight CardHeight.cardHeightSchema
       #+ FC.optional "cardWidth" cardWidth CardWidth.cardWidthSchema
-      #+ FC.optional "countriesOfOrigin" countriesOfOrigin (FC.list Country.countrySchema)
-      #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "releaseYear" releaseYear ReleaseYear.releaseYearSchema
       #+ FC.optional "cardsPerPack" cardsPerPack CardsPerPack.cardsPerPackSchema
+      #+ FC.optional "countriesOfOrigin" countriesOfOrigin (FC.list Country.countrySchema)
+      #+ FC.optional "manufacturers" manufacturers (FC.list CompanyBase.companyBaseSchema)
+      #+ FC.required "name" name Name.nameSchema
+      #+ FC.optional "packsPerBox" packsPerBox PacksPerBox.packsPerBoxSchema
       #+ FC.optional "productionRun" productionRun ProductionRun.productionRunSchema
+      #+ FC.optional "productionRunUnit" productionRunUnit ProductionRunUnit.productionRunUnitSchema
       #+ FC.optional "releaseDay" releaseDay ReleaseDay.releaseDaySchema
+      #+ FC.optional "releaseMonth" releaseMonth ReleaseMonth.releaseMonthSchema
+      #+ FC.optional "releaseYear" releaseYear ReleaseYear.releaseYearSchema
+      #+ FC.optional "tradingCardDecks" tradingCardDecks (FC.list TradingCardDeckBase.tradingCardDeckBaseSchema)
+      #+ FC.optional "tradingCards" tradingCards (FC.list TradingCardBase.tradingCardBaseSchema)
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardSetHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/TradingCardSetHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.TradingCardSetHeader.Name as Name
 import qualified StarTrek.Types.TradingCardSetHeader.Uid as Uid
 
 data TradingCardSetHeader = TradingCardSetHeader
-  { uid :: Uid.Uid -- ^ Trading card set unique ID
-  , name :: Name.Name -- ^ Trading card set name
+  { name :: Name.Name -- ^ Trading card set name
+  , uid :: Uid.Uid -- ^ Trading card set unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ tradingCardSetHeaderSchema :: FC.Fleece schema => schema TradingCardSetHeader
 tradingCardSetHeaderSchema =
   FC.object $
     FC.constructor TradingCardSetHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoGameBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoGameBase.hs
@@ -18,14 +18,14 @@ import qualified StarTrek.Types.VideoGameBase.YearFrom as YearFrom
 import qualified StarTrek.Types.VideoGameBase.YearTo as YearTo
 
 data VideoGameBase = VideoGameBase
-  { title :: Title.Title -- ^ Video game title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of video game story
-  , systemRequirements :: Maybe SystemRequirements.SystemRequirements -- ^ System requirements
-  , uid :: Uid.Uid -- ^ Video game unique ID
+  { releaseDate :: Maybe ReleaseDate.ReleaseDate -- ^ Release date
   , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of video game story
-  , releaseDate :: Maybe ReleaseDate.ReleaseDate -- ^ Release date
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of video game story
   , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of video game story
+  , systemRequirements :: Maybe SystemRequirements.SystemRequirements -- ^ System requirements
+  , title :: Title.Title -- ^ Video game title
+  , uid :: Uid.Uid -- ^ Video game unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of video game story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of video game story
   }
   deriving (Eq, Show)
 
@@ -33,11 +33,11 @@ videoGameBaseSchema :: FC.Fleece schema => schema VideoGameBase
 videoGameBaseSchema =
   FC.object $
     FC.constructor VideoGameBase
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "systemRequirements" systemRequirements SystemRequirements.systemRequirementsSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
       #+ FC.optional "releaseDate" releaseDate ReleaseDate.releaseDateSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
+      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
       #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
+      #+ FC.optional "systemRequirements" systemRequirements SystemRequirements.systemRequirementsSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoGameFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoGameFull.hs
@@ -23,20 +23,20 @@ import qualified StarTrek.Types.VideoGameFull.YearFrom as YearFrom
 import qualified StarTrek.Types.VideoGameFull.YearTo as YearTo
 
 data VideoGameFull = VideoGameFull
-  { title :: Title.Title -- ^ Video game title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of video game story
-  , systemRequirements :: Maybe SystemRequirements.SystemRequirements -- ^ System requirements
-  , uid :: Uid.Uid -- ^ Video game unique ID
-  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
+  { developers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
+  , genres :: Maybe [Genre.Genre] -- ^ Genre of video games
   , platforms :: Maybe [Platform.Platform] -- ^ Platform of video games
   , publishers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
   , ratings :: Maybe [ContentRating.ContentRating] -- ^ Rating of video release, etc.
-  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of video game story
+  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
   , releaseDate :: Maybe ReleaseDate.ReleaseDate -- ^ Release date
-  , developers :: Maybe [CompanyBase.CompanyBase] -- ^ Base company, returned in search results
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of video game story
+  , stardateFrom :: Maybe StardateFrom.StardateFrom -- ^ Starting stardate of video game story
   , stardateTo :: Maybe StardateTo.StardateTo -- ^ Ending stardate of video game story
-  , genres :: Maybe [Genre.Genre] -- ^ Genre of video games
+  , systemRequirements :: Maybe SystemRequirements.SystemRequirements -- ^ System requirements
+  , title :: Title.Title -- ^ Video game title
+  , uid :: Uid.Uid -- ^ Video game unique ID
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of video game story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of video game story
   }
   deriving (Eq, Show)
 
@@ -44,17 +44,17 @@ videoGameFullSchema :: FC.Fleece schema => schema VideoGameFull
 videoGameFullSchema =
   FC.object $
     FC.constructor VideoGameFull
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "systemRequirements" systemRequirements SystemRequirements.systemRequirementsSchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
+      #+ FC.optional "developers" developers (FC.list CompanyBase.companyBaseSchema)
+      #+ FC.optional "genres" genres (FC.list Genre.genreSchema)
       #+ FC.optional "platforms" platforms (FC.list Platform.platformSchema)
       #+ FC.optional "publishers" publishers (FC.list CompanyBase.companyBaseSchema)
       #+ FC.optional "ratings" ratings (FC.list ContentRating.contentRatingSchema)
-      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
+      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
       #+ FC.optional "releaseDate" releaseDate ReleaseDate.releaseDateSchema
-      #+ FC.optional "developers" developers (FC.list CompanyBase.companyBaseSchema)
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
+      #+ FC.optional "stardateFrom" stardateFrom StardateFrom.stardateFromSchema
       #+ FC.optional "stardateTo" stardateTo StardateTo.stardateToSchema
-      #+ FC.optional "genres" genres (FC.list Genre.genreSchema)
+      #+ FC.optional "systemRequirements" systemRequirements SystemRequirements.systemRequirementsSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoReleaseBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoReleaseBase.hs
@@ -38,34 +38,34 @@ import qualified StarTrek.Types.VideoReleaseBase.YouTubeDigitalRelease as YouTub
 import qualified StarTrek.Types.VideoReleaseFormat as VideoReleaseFormat
 
 data VideoReleaseBase = VideoReleaseBase
-  { region2SlimlineReleaseDate :: Maybe Region2SlimlineReleaseDate.Region2SlimlineReleaseDate -- ^ Region 2 slimline release date
-  , numberOfDataCarriers :: Maybe NumberOfDataCarriers.NumberOfDataCarriers -- ^ Number of data carriers (like DVD, VCD, VHS etc.)
-  , amazonDigitalRelease :: Maybe AmazonDigitalRelease.AmazonDigitalRelease -- ^ Whether this video has been release on Amazon.com
-  , format :: Maybe VideoReleaseFormat.VideoReleaseFormat -- ^ Video release format
-  , title :: Title.Title -- ^ Video release title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of video release story
-  , numberOfEpisodes :: Maybe NumberOfEpisodes.NumberOfEpisodes -- ^ Number of episodes
-  , region4SlimlineReleaseDate :: Maybe Region4SlimlineReleaseDate.Region4SlimlineReleaseDate -- ^ Region 4 slimline release date
-  , googlePlayDigitalRelease :: Maybe GooglePlayDigitalRelease.GooglePlayDigitalRelease -- ^ Whether this video has been release on Google Play
-  , runTime :: Maybe RunTime.RunTime -- ^ Run time, in minutes
+  { amazonDigitalRelease :: Maybe AmazonDigitalRelease.AmazonDigitalRelease -- ^ Whether this video has been release on Amazon.com
   , dailymotionDigitalRelease :: Maybe DailymotionDigitalRelease.DailymotionDigitalRelease -- ^ Whether this video has been release on Dailymotion
-  , vuduDigitalRelease :: Maybe VuduDigitalRelease.VuduDigitalRelease -- ^ Whether this video has been release on VUDU
-  , season :: Maybe SeasonHeader.SeasonHeader -- ^ Header season, embedded in other objects
+  , format :: Maybe VideoReleaseFormat.VideoReleaseFormat -- ^ Video release format
+  , googlePlayDigitalRelease :: Maybe GooglePlayDigitalRelease.GooglePlayDigitalRelease -- ^ Whether this video has been release on Google Play
   , iTunesDigitalRelease :: Maybe ITunesDigitalRelease.ITunesDigitalRelease -- ^ Whether this video has been release on iTunes
-  , youTubeDigitalRelease :: Maybe YouTubeDigitalRelease.YouTubeDigitalRelease -- ^ Whether this video has been release on YouTube
-  , region2BReleaseDate :: Maybe Region2BReleaseDate.Region2BReleaseDate -- ^ Region 2/B release date
   , netflixDigitalRelease :: Maybe NetflixDigitalRelease.NetflixDigitalRelease -- ^ Whether this video has been release on Netflix
-  , uid :: Uid.Uid -- ^ Video release unique ID
+  , numberOfDataCarriers :: Maybe NumberOfDataCarriers.NumberOfDataCarriers -- ^ Number of data carriers (like DVD, VCD, VHS etc.)
+  , numberOfEpisodes :: Maybe NumberOfEpisodes.NumberOfEpisodes -- ^ Number of episodes
   , numberOfFeatureLengthEpisodes :: Maybe NumberOfFeatureLengthEpisodes.NumberOfFeatureLengthEpisodes -- ^ Number of feature-length episodes
-  , vimeoDigitalRelease :: Maybe VimeoDigitalRelease.VimeoDigitalRelease -- ^ Whether this video has been release on Vimeo
-  , xboxSmartGlassDigitalRelease :: Maybe XboxSmartGlassDigitalRelease.XboxSmartGlassDigitalRelease -- ^ Whether this video has been release on Xbox SmartGlass
-  , ultraVioletDigitalRelease :: Maybe UltraVioletDigitalRelease.UltraVioletDigitalRelease -- ^ Whether this video has been release on UltraViolet
-  , regionFreeReleaseDate :: Maybe RegionFreeReleaseDate.RegionFreeReleaseDate -- ^ Region free release date
-  , region4AReleaseDate :: Maybe Region4AReleaseDate.Region4AReleaseDate -- ^ Region 4 release date
   , region1AReleaseDate :: Maybe Region1AReleaseDate.Region1AReleaseDate -- ^ Region 1/A release date
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of video release story
   , region1SlimlineReleaseDate :: Maybe Region1SlimlineReleaseDate.Region1SlimlineReleaseDate -- ^ Region 1 slimline release date
+  , region2BReleaseDate :: Maybe Region2BReleaseDate.Region2BReleaseDate -- ^ Region 2/B release date
+  , region2SlimlineReleaseDate :: Maybe Region2SlimlineReleaseDate.Region2SlimlineReleaseDate -- ^ Region 2 slimline release date
+  , region4AReleaseDate :: Maybe Region4AReleaseDate.Region4AReleaseDate -- ^ Region 4 release date
+  , region4SlimlineReleaseDate :: Maybe Region4SlimlineReleaseDate.Region4SlimlineReleaseDate -- ^ Region 4 slimline release date
+  , regionFreeReleaseDate :: Maybe RegionFreeReleaseDate.RegionFreeReleaseDate -- ^ Region free release date
+  , runTime :: Maybe RunTime.RunTime -- ^ Run time, in minutes
+  , season :: Maybe SeasonHeader.SeasonHeader -- ^ Header season, embedded in other objects
   , series :: Maybe SeriesHeader.SeriesHeader -- ^ Header series, embedded in other objects
+  , title :: Title.Title -- ^ Video release title
+  , uid :: Uid.Uid -- ^ Video release unique ID
+  , ultraVioletDigitalRelease :: Maybe UltraVioletDigitalRelease.UltraVioletDigitalRelease -- ^ Whether this video has been release on UltraViolet
+  , vimeoDigitalRelease :: Maybe VimeoDigitalRelease.VimeoDigitalRelease -- ^ Whether this video has been release on Vimeo
+  , vuduDigitalRelease :: Maybe VuduDigitalRelease.VuduDigitalRelease -- ^ Whether this video has been release on VUDU
+  , xboxSmartGlassDigitalRelease :: Maybe XboxSmartGlassDigitalRelease.XboxSmartGlassDigitalRelease -- ^ Whether this video has been release on Xbox SmartGlass
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of video release story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of video release story
+  , youTubeDigitalRelease :: Maybe YouTubeDigitalRelease.YouTubeDigitalRelease -- ^ Whether this video has been release on YouTube
   }
   deriving (Eq, Show)
 
@@ -73,31 +73,31 @@ videoReleaseBaseSchema :: FC.Fleece schema => schema VideoReleaseBase
 videoReleaseBaseSchema =
   FC.object $
     FC.constructor VideoReleaseBase
-      #+ FC.optional "region2SlimlineReleaseDate" region2SlimlineReleaseDate Region2SlimlineReleaseDate.region2SlimlineReleaseDateSchema
-      #+ FC.optional "numberOfDataCarriers" numberOfDataCarriers NumberOfDataCarriers.numberOfDataCarriersSchema
       #+ FC.optional "amazonDigitalRelease" amazonDigitalRelease AmazonDigitalRelease.amazonDigitalReleaseSchema
-      #+ FC.optional "format" format VideoReleaseFormat.videoReleaseFormatSchema
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "numberOfEpisodes" numberOfEpisodes NumberOfEpisodes.numberOfEpisodesSchema
-      #+ FC.optional "region4SlimlineReleaseDate" region4SlimlineReleaseDate Region4SlimlineReleaseDate.region4SlimlineReleaseDateSchema
-      #+ FC.optional "googlePlayDigitalRelease" googlePlayDigitalRelease GooglePlayDigitalRelease.googlePlayDigitalReleaseSchema
-      #+ FC.optional "runTime" runTime RunTime.runTimeSchema
       #+ FC.optional "dailymotionDigitalRelease" dailymotionDigitalRelease DailymotionDigitalRelease.dailymotionDigitalReleaseSchema
-      #+ FC.optional "vuduDigitalRelease" vuduDigitalRelease VuduDigitalRelease.vuduDigitalReleaseSchema
-      #+ FC.optional "season" season SeasonHeader.seasonHeaderSchema
+      #+ FC.optional "format" format VideoReleaseFormat.videoReleaseFormatSchema
+      #+ FC.optional "googlePlayDigitalRelease" googlePlayDigitalRelease GooglePlayDigitalRelease.googlePlayDigitalReleaseSchema
       #+ FC.optional "iTunesDigitalRelease" iTunesDigitalRelease ITunesDigitalRelease.iTunesDigitalReleaseSchema
-      #+ FC.optional "youTubeDigitalRelease" youTubeDigitalRelease YouTubeDigitalRelease.youTubeDigitalReleaseSchema
-      #+ FC.optional "region2BReleaseDate" region2BReleaseDate Region2BReleaseDate.region2BReleaseDateSchema
       #+ FC.optional "netflixDigitalRelease" netflixDigitalRelease NetflixDigitalRelease.netflixDigitalReleaseSchema
-      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "numberOfDataCarriers" numberOfDataCarriers NumberOfDataCarriers.numberOfDataCarriersSchema
+      #+ FC.optional "numberOfEpisodes" numberOfEpisodes NumberOfEpisodes.numberOfEpisodesSchema
       #+ FC.optional "numberOfFeatureLengthEpisodes" numberOfFeatureLengthEpisodes NumberOfFeatureLengthEpisodes.numberOfFeatureLengthEpisodesSchema
-      #+ FC.optional "vimeoDigitalRelease" vimeoDigitalRelease VimeoDigitalRelease.vimeoDigitalReleaseSchema
-      #+ FC.optional "xboxSmartGlassDigitalRelease" xboxSmartGlassDigitalRelease XboxSmartGlassDigitalRelease.xboxSmartGlassDigitalReleaseSchema
-      #+ FC.optional "ultraVioletDigitalRelease" ultraVioletDigitalRelease UltraVioletDigitalRelease.ultraVioletDigitalReleaseSchema
-      #+ FC.optional "regionFreeReleaseDate" regionFreeReleaseDate RegionFreeReleaseDate.regionFreeReleaseDateSchema
-      #+ FC.optional "region4AReleaseDate" region4AReleaseDate Region4AReleaseDate.region4AReleaseDateSchema
       #+ FC.optional "region1AReleaseDate" region1AReleaseDate Region1AReleaseDate.region1AReleaseDateSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
       #+ FC.optional "region1SlimlineReleaseDate" region1SlimlineReleaseDate Region1SlimlineReleaseDate.region1SlimlineReleaseDateSchema
+      #+ FC.optional "region2BReleaseDate" region2BReleaseDate Region2BReleaseDate.region2BReleaseDateSchema
+      #+ FC.optional "region2SlimlineReleaseDate" region2SlimlineReleaseDate Region2SlimlineReleaseDate.region2SlimlineReleaseDateSchema
+      #+ FC.optional "region4AReleaseDate" region4AReleaseDate Region4AReleaseDate.region4AReleaseDateSchema
+      #+ FC.optional "region4SlimlineReleaseDate" region4SlimlineReleaseDate Region4SlimlineReleaseDate.region4SlimlineReleaseDateSchema
+      #+ FC.optional "regionFreeReleaseDate" regionFreeReleaseDate RegionFreeReleaseDate.regionFreeReleaseDateSchema
+      #+ FC.optional "runTime" runTime RunTime.runTimeSchema
+      #+ FC.optional "season" season SeasonHeader.seasonHeaderSchema
       #+ FC.optional "series" series SeriesHeader.seriesHeaderSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "ultraVioletDigitalRelease" ultraVioletDigitalRelease UltraVioletDigitalRelease.ultraVioletDigitalReleaseSchema
+      #+ FC.optional "vimeoDigitalRelease" vimeoDigitalRelease VimeoDigitalRelease.vimeoDigitalReleaseSchema
+      #+ FC.optional "vuduDigitalRelease" vuduDigitalRelease VuduDigitalRelease.vuduDigitalReleaseSchema
+      #+ FC.optional "xboxSmartGlassDigitalRelease" xboxSmartGlassDigitalRelease XboxSmartGlassDigitalRelease.xboxSmartGlassDigitalReleaseSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
+      #+ FC.optional "youTubeDigitalRelease" youTubeDigitalRelease YouTubeDigitalRelease.youTubeDigitalReleaseSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoReleaseFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoReleaseFull.hs
@@ -41,39 +41,39 @@ import qualified StarTrek.Types.VideoReleaseFull.YearTo as YearTo
 import qualified StarTrek.Types.VideoReleaseFull.YouTubeDigitalRelease as YouTubeDigitalRelease
 
 data VideoReleaseFull = VideoReleaseFull
-  { region2SlimlineReleaseDate :: Maybe Region2SlimlineReleaseDate.Region2SlimlineReleaseDate -- ^ Region 2 slimline release date
-  , numberOfDataCarriers :: Maybe NumberOfDataCarriers.NumberOfDataCarriers -- ^ Number of data carriers (like DVD, VCD, VHS etc.)
-  , amazonDigitalRelease :: Maybe AmazonDigitalRelease.AmazonDigitalRelease -- ^ Whether this video has been release on Amazon.com
-  , format :: Maybe VideoReleaseFormat.VideoReleaseFormat -- ^ Video release format
-  , title :: Title.Title -- ^ Video release title
-  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of video release story
-  , numberOfEpisodes :: Maybe NumberOfEpisodes.NumberOfEpisodes -- ^ Number of episodes
-  , languagesDubbed :: Maybe [ContentLanguage.ContentLanguage] -- ^ Rating of video release, etc.
-  , region4SlimlineReleaseDate :: Maybe Region4SlimlineReleaseDate.Region4SlimlineReleaseDate -- ^ Region 4 slimline release date
-  , googlePlayDigitalRelease :: Maybe GooglePlayDigitalRelease.GooglePlayDigitalRelease -- ^ Whether this video has been release on Google Play
-  , runTime :: Maybe RunTime.RunTime -- ^ Run time, in minutes
+  { amazonDigitalRelease :: Maybe AmazonDigitalRelease.AmazonDigitalRelease -- ^ Whether this video has been release on Amazon.com
   , dailymotionDigitalRelease :: Maybe DailymotionDigitalRelease.DailymotionDigitalRelease -- ^ Whether this video has been release on Dailymotion
-  , vuduDigitalRelease :: Maybe VuduDigitalRelease.VuduDigitalRelease -- ^ Whether this video has been release on VUDU
-  , season :: Maybe SeasonBase.SeasonBase -- ^ Base season, returned in search results
+  , format :: Maybe VideoReleaseFormat.VideoReleaseFormat -- ^ Video release format
+  , googlePlayDigitalRelease :: Maybe GooglePlayDigitalRelease.GooglePlayDigitalRelease -- ^ Whether this video has been release on Google Play
   , iTunesDigitalRelease :: Maybe ITunesDigitalRelease.ITunesDigitalRelease -- ^ Whether this video has been release on iTunes
-  , youTubeDigitalRelease :: Maybe YouTubeDigitalRelease.YouTubeDigitalRelease -- ^ Whether this video has been release on YouTube
-  , region2BReleaseDate :: Maybe Region2BReleaseDate.Region2BReleaseDate -- ^ Region 2/B release date
   , languages :: Maybe [ContentLanguage.ContentLanguage] -- ^ Rating of video release, etc.
-  , netflixDigitalRelease :: Maybe NetflixDigitalRelease.NetflixDigitalRelease -- ^ Whether this video has been release on Netflix
+  , languagesDubbed :: Maybe [ContentLanguage.ContentLanguage] -- ^ Rating of video release, etc.
   , languagesSubtitles :: Maybe [ContentLanguage.ContentLanguage] -- ^ Rating of video release, etc.
-  , uid :: Uid.Uid -- ^ Video release unique ID
+  , netflixDigitalRelease :: Maybe NetflixDigitalRelease.NetflixDigitalRelease -- ^ Whether this video has been release on Netflix
+  , numberOfDataCarriers :: Maybe NumberOfDataCarriers.NumberOfDataCarriers -- ^ Number of data carriers (like DVD, VCD, VHS etc.)
+  , numberOfEpisodes :: Maybe NumberOfEpisodes.NumberOfEpisodes -- ^ Number of episodes
   , numberOfFeatureLengthEpisodes :: Maybe NumberOfFeatureLengthEpisodes.NumberOfFeatureLengthEpisodes -- ^ Number of feature-length episodes
-  , vimeoDigitalRelease :: Maybe VimeoDigitalRelease.VimeoDigitalRelease -- ^ Whether this video has been release on Vimeo
-  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
-  , xboxSmartGlassDigitalRelease :: Maybe XboxSmartGlassDigitalRelease.XboxSmartGlassDigitalRelease -- ^ Whether this video has been release on Xbox SmartGlass
-  , ultraVioletDigitalRelease :: Maybe UltraVioletDigitalRelease.UltraVioletDigitalRelease -- ^ Whether this video has been release on UltraViolet
   , ratings :: Maybe [ContentRating.ContentRating] -- ^ Rating of video release, etc.
-  , regionFreeReleaseDate :: Maybe RegionFreeReleaseDate.RegionFreeReleaseDate -- ^ Region free release date
-  , region4AReleaseDate :: Maybe Region4AReleaseDate.Region4AReleaseDate -- ^ Region 4 release date
+  , references :: Maybe [Reference.Reference] -- ^ Reference of book, comics, video release, etc.
   , region1AReleaseDate :: Maybe Region1AReleaseDate.Region1AReleaseDate -- ^ Region 1/A release date
-  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of video release story
   , region1SlimlineReleaseDate :: Maybe Region1SlimlineReleaseDate.Region1SlimlineReleaseDate -- ^ Region 1 slimline release date
+  , region2BReleaseDate :: Maybe Region2BReleaseDate.Region2BReleaseDate -- ^ Region 2/B release date
+  , region2SlimlineReleaseDate :: Maybe Region2SlimlineReleaseDate.Region2SlimlineReleaseDate -- ^ Region 2 slimline release date
+  , region4AReleaseDate :: Maybe Region4AReleaseDate.Region4AReleaseDate -- ^ Region 4 release date
+  , region4SlimlineReleaseDate :: Maybe Region4SlimlineReleaseDate.Region4SlimlineReleaseDate -- ^ Region 4 slimline release date
+  , regionFreeReleaseDate :: Maybe RegionFreeReleaseDate.RegionFreeReleaseDate -- ^ Region free release date
+  , runTime :: Maybe RunTime.RunTime -- ^ Run time, in minutes
+  , season :: Maybe SeasonBase.SeasonBase -- ^ Base season, returned in search results
   , series :: Maybe SeriesBase.SeriesBase -- ^ Base series, returned in search results
+  , title :: Title.Title -- ^ Video release title
+  , uid :: Uid.Uid -- ^ Video release unique ID
+  , ultraVioletDigitalRelease :: Maybe UltraVioletDigitalRelease.UltraVioletDigitalRelease -- ^ Whether this video has been release on UltraViolet
+  , vimeoDigitalRelease :: Maybe VimeoDigitalRelease.VimeoDigitalRelease -- ^ Whether this video has been release on Vimeo
+  , vuduDigitalRelease :: Maybe VuduDigitalRelease.VuduDigitalRelease -- ^ Whether this video has been release on VUDU
+  , xboxSmartGlassDigitalRelease :: Maybe XboxSmartGlassDigitalRelease.XboxSmartGlassDigitalRelease -- ^ Whether this video has been release on Xbox SmartGlass
+  , yearFrom :: Maybe YearFrom.YearFrom -- ^ Starting year of video release story
+  , yearTo :: Maybe YearTo.YearTo -- ^ Ending year of video release story
+  , youTubeDigitalRelease :: Maybe YouTubeDigitalRelease.YouTubeDigitalRelease -- ^ Whether this video has been release on YouTube
   }
   deriving (Eq, Show)
 
@@ -81,36 +81,36 @@ videoReleaseFullSchema :: FC.Fleece schema => schema VideoReleaseFull
 videoReleaseFullSchema =
   FC.object $
     FC.constructor VideoReleaseFull
-      #+ FC.optional "region2SlimlineReleaseDate" region2SlimlineReleaseDate Region2SlimlineReleaseDate.region2SlimlineReleaseDateSchema
-      #+ FC.optional "numberOfDataCarriers" numberOfDataCarriers NumberOfDataCarriers.numberOfDataCarriersSchema
       #+ FC.optional "amazonDigitalRelease" amazonDigitalRelease AmazonDigitalRelease.amazonDigitalReleaseSchema
-      #+ FC.optional "format" format VideoReleaseFormat.videoReleaseFormatSchema
-      #+ FC.required "title" title Title.titleSchema
-      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
-      #+ FC.optional "numberOfEpisodes" numberOfEpisodes NumberOfEpisodes.numberOfEpisodesSchema
-      #+ FC.optional "languagesDubbed" languagesDubbed (FC.list ContentLanguage.contentLanguageSchema)
-      #+ FC.optional "region4SlimlineReleaseDate" region4SlimlineReleaseDate Region4SlimlineReleaseDate.region4SlimlineReleaseDateSchema
-      #+ FC.optional "googlePlayDigitalRelease" googlePlayDigitalRelease GooglePlayDigitalRelease.googlePlayDigitalReleaseSchema
-      #+ FC.optional "runTime" runTime RunTime.runTimeSchema
       #+ FC.optional "dailymotionDigitalRelease" dailymotionDigitalRelease DailymotionDigitalRelease.dailymotionDigitalReleaseSchema
-      #+ FC.optional "vuduDigitalRelease" vuduDigitalRelease VuduDigitalRelease.vuduDigitalReleaseSchema
-      #+ FC.optional "season" season SeasonBase.seasonBaseSchema
+      #+ FC.optional "format" format VideoReleaseFormat.videoReleaseFormatSchema
+      #+ FC.optional "googlePlayDigitalRelease" googlePlayDigitalRelease GooglePlayDigitalRelease.googlePlayDigitalReleaseSchema
       #+ FC.optional "iTunesDigitalRelease" iTunesDigitalRelease ITunesDigitalRelease.iTunesDigitalReleaseSchema
-      #+ FC.optional "youTubeDigitalRelease" youTubeDigitalRelease YouTubeDigitalRelease.youTubeDigitalReleaseSchema
-      #+ FC.optional "region2BReleaseDate" region2BReleaseDate Region2BReleaseDate.region2BReleaseDateSchema
       #+ FC.optional "languages" languages (FC.list ContentLanguage.contentLanguageSchema)
-      #+ FC.optional "netflixDigitalRelease" netflixDigitalRelease NetflixDigitalRelease.netflixDigitalReleaseSchema
+      #+ FC.optional "languagesDubbed" languagesDubbed (FC.list ContentLanguage.contentLanguageSchema)
       #+ FC.optional "languagesSubtitles" languagesSubtitles (FC.list ContentLanguage.contentLanguageSchema)
-      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "netflixDigitalRelease" netflixDigitalRelease NetflixDigitalRelease.netflixDigitalReleaseSchema
+      #+ FC.optional "numberOfDataCarriers" numberOfDataCarriers NumberOfDataCarriers.numberOfDataCarriersSchema
+      #+ FC.optional "numberOfEpisodes" numberOfEpisodes NumberOfEpisodes.numberOfEpisodesSchema
       #+ FC.optional "numberOfFeatureLengthEpisodes" numberOfFeatureLengthEpisodes NumberOfFeatureLengthEpisodes.numberOfFeatureLengthEpisodesSchema
-      #+ FC.optional "vimeoDigitalRelease" vimeoDigitalRelease VimeoDigitalRelease.vimeoDigitalReleaseSchema
-      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
-      #+ FC.optional "xboxSmartGlassDigitalRelease" xboxSmartGlassDigitalRelease XboxSmartGlassDigitalRelease.xboxSmartGlassDigitalReleaseSchema
-      #+ FC.optional "ultraVioletDigitalRelease" ultraVioletDigitalRelease UltraVioletDigitalRelease.ultraVioletDigitalReleaseSchema
       #+ FC.optional "ratings" ratings (FC.list ContentRating.contentRatingSchema)
-      #+ FC.optional "regionFreeReleaseDate" regionFreeReleaseDate RegionFreeReleaseDate.regionFreeReleaseDateSchema
-      #+ FC.optional "region4AReleaseDate" region4AReleaseDate Region4AReleaseDate.region4AReleaseDateSchema
+      #+ FC.optional "references" references (FC.list Reference.referenceSchema)
       #+ FC.optional "region1AReleaseDate" region1AReleaseDate Region1AReleaseDate.region1AReleaseDateSchema
-      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
       #+ FC.optional "region1SlimlineReleaseDate" region1SlimlineReleaseDate Region1SlimlineReleaseDate.region1SlimlineReleaseDateSchema
+      #+ FC.optional "region2BReleaseDate" region2BReleaseDate Region2BReleaseDate.region2BReleaseDateSchema
+      #+ FC.optional "region2SlimlineReleaseDate" region2SlimlineReleaseDate Region2SlimlineReleaseDate.region2SlimlineReleaseDateSchema
+      #+ FC.optional "region4AReleaseDate" region4AReleaseDate Region4AReleaseDate.region4AReleaseDateSchema
+      #+ FC.optional "region4SlimlineReleaseDate" region4SlimlineReleaseDate Region4SlimlineReleaseDate.region4SlimlineReleaseDateSchema
+      #+ FC.optional "regionFreeReleaseDate" regionFreeReleaseDate RegionFreeReleaseDate.regionFreeReleaseDateSchema
+      #+ FC.optional "runTime" runTime RunTime.runTimeSchema
+      #+ FC.optional "season" season SeasonBase.seasonBaseSchema
       #+ FC.optional "series" series SeriesBase.seriesBaseSchema
+      #+ FC.required "title" title Title.titleSchema
+      #+ FC.required "uid" uid Uid.uidSchema
+      #+ FC.optional "ultraVioletDigitalRelease" ultraVioletDigitalRelease UltraVioletDigitalRelease.ultraVioletDigitalReleaseSchema
+      #+ FC.optional "vimeoDigitalRelease" vimeoDigitalRelease VimeoDigitalRelease.vimeoDigitalReleaseSchema
+      #+ FC.optional "vuduDigitalRelease" vuduDigitalRelease VuduDigitalRelease.vuduDigitalReleaseSchema
+      #+ FC.optional "xboxSmartGlassDigitalRelease" xboxSmartGlassDigitalRelease XboxSmartGlassDigitalRelease.xboxSmartGlassDigitalReleaseSchema
+      #+ FC.optional "yearFrom" yearFrom YearFrom.yearFromSchema
+      #+ FC.optional "yearTo" yearTo YearTo.yearToSchema
+      #+ FC.optional "youTubeDigitalRelease" youTubeDigitalRelease YouTubeDigitalRelease.youTubeDigitalReleaseSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/WeaponBase.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/WeaponBase.hs
@@ -19,15 +19,15 @@ import qualified StarTrek.Types.WeaponBase.PlasmaTechnology as PlasmaTechnology
 import qualified StarTrek.Types.WeaponBase.Uid as Uid
 
 data WeaponBase = WeaponBase
-  { handHeldWeapon :: Maybe HandHeldWeapon.HandHeldWeapon -- ^ Whether it's hand-help weapon
-  , mirror :: Maybe Mirror.Mirror -- ^ Whether this weapon is from mirror universe
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this weapon is from alternate reality
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this weapon is from alternate reality
+  , handHeldWeapon :: Maybe HandHeldWeapon.HandHeldWeapon -- ^ Whether it's hand-help weapon
   , laserTechnology :: Maybe LaserTechnology.LaserTechnology -- ^ Whether it's a laser technology
-  , uid :: Uid.Uid -- ^ Weapon unique ID
-  , plasmaTechnology :: Maybe PlasmaTechnology.PlasmaTechnology -- ^ Whether it's a plasma technology
+  , mirror :: Maybe Mirror.Mirror -- ^ Whether this weapon is from mirror universe
   , name :: Name.Name -- ^ Weapon name
-  , photonicTechnology :: Maybe PhotonicTechnology.PhotonicTechnology -- ^ Whether it's a photonic technology
   , phaserTechnology :: Maybe PhaserTechnology.PhaserTechnology -- ^ Whether it's a phaser technology
+  , photonicTechnology :: Maybe PhotonicTechnology.PhotonicTechnology -- ^ Whether it's a photonic technology
+  , plasmaTechnology :: Maybe PlasmaTechnology.PlasmaTechnology -- ^ Whether it's a plasma technology
+  , uid :: Uid.Uid -- ^ Weapon unique ID
   }
   deriving (Eq, Show)
 
@@ -35,12 +35,12 @@ weaponBaseSchema :: FC.Fleece schema => schema WeaponBase
 weaponBaseSchema =
   FC.object $
     FC.constructor WeaponBase
-      #+ FC.optional "handHeldWeapon" handHeldWeapon HandHeldWeapon.handHeldWeaponSchema
-      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
+      #+ FC.optional "handHeldWeapon" handHeldWeapon HandHeldWeapon.handHeldWeaponSchema
       #+ FC.optional "laserTechnology" laserTechnology LaserTechnology.laserTechnologySchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "plasmaTechnology" plasmaTechnology PlasmaTechnology.plasmaTechnologySchema
+      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
       #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "photonicTechnology" photonicTechnology PhotonicTechnology.photonicTechnologySchema
       #+ FC.optional "phaserTechnology" phaserTechnology PhaserTechnology.phaserTechnologySchema
+      #+ FC.optional "photonicTechnology" photonicTechnology PhotonicTechnology.photonicTechnologySchema
+      #+ FC.optional "plasmaTechnology" plasmaTechnology PlasmaTechnology.plasmaTechnologySchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/WeaponBaseResponse.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/WeaponBaseResponse.hs
@@ -14,8 +14,8 @@ import qualified StarTrek.Types.WeaponBase as WeaponBase
 
 data WeaponBaseResponse = WeaponBaseResponse
   { page :: Maybe ResponsePage.ResponsePage -- ^ Object describing response page
-  , weapons :: Maybe [WeaponBase.WeaponBase] -- ^ Base weapon, returned in search results
   , sort :: Maybe ResponseSort.ResponseSort -- ^ Response sort
+  , weapons :: Maybe [WeaponBase.WeaponBase] -- ^ Base weapon, returned in search results
   }
   deriving (Eq, Show)
 
@@ -24,5 +24,5 @@ weaponBaseResponseSchema =
   FC.object $
     FC.constructor WeaponBaseResponse
       #+ FC.optional "page" page ResponsePage.responsePageSchema
-      #+ FC.optional "weapons" weapons (FC.list WeaponBase.weaponBaseSchema)
       #+ FC.optional "sort" sort ResponseSort.responseSortSchema
+      #+ FC.optional "weapons" weapons (FC.list WeaponBase.weaponBaseSchema)

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/WeaponFull.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/WeaponFull.hs
@@ -19,15 +19,15 @@ import qualified StarTrek.Types.WeaponFull.PlasmaTechnology as PlasmaTechnology
 import qualified StarTrek.Types.WeaponFull.Uid as Uid
 
 data WeaponFull = WeaponFull
-  { handHeldWeapon :: Maybe HandHeldWeapon.HandHeldWeapon -- ^ Whether it's a hand-help weapon
-  , mirror :: Maybe Mirror.Mirror -- ^ Whether this weapon is from mirror universe
-  , alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this weapon is from alternate reality
+  { alternateReality :: Maybe AlternateReality.AlternateReality -- ^ Whether this weapon is from alternate reality
+  , handHeldWeapon :: Maybe HandHeldWeapon.HandHeldWeapon -- ^ Whether it's a hand-help weapon
   , laserTechnology :: Maybe LaserTechnology.LaserTechnology -- ^ Whether it's a laser technology
-  , uid :: Uid.Uid -- ^ Weapon unique ID
-  , plasmaTechnology :: Maybe PlasmaTechnology.PlasmaTechnology -- ^ Whether it's a plasma technology
+  , mirror :: Maybe Mirror.Mirror -- ^ Whether this weapon is from mirror universe
   , name :: Name.Name -- ^ Weapon name
-  , photonicTechnology :: Maybe PhotonicTechnology.PhotonicTechnology -- ^ Whether it's a photonic technology
   , phaserTechnology :: Maybe PhaserTechnology.PhaserTechnology -- ^ Whether it's a phaser technology
+  , photonicTechnology :: Maybe PhotonicTechnology.PhotonicTechnology -- ^ Whether it's a photonic technology
+  , plasmaTechnology :: Maybe PlasmaTechnology.PlasmaTechnology -- ^ Whether it's a plasma technology
+  , uid :: Uid.Uid -- ^ Weapon unique ID
   }
   deriving (Eq, Show)
 
@@ -35,12 +35,12 @@ weaponFullSchema :: FC.Fleece schema => schema WeaponFull
 weaponFullSchema =
   FC.object $
     FC.constructor WeaponFull
-      #+ FC.optional "handHeldWeapon" handHeldWeapon HandHeldWeapon.handHeldWeaponSchema
-      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
       #+ FC.optional "alternateReality" alternateReality AlternateReality.alternateRealitySchema
+      #+ FC.optional "handHeldWeapon" handHeldWeapon HandHeldWeapon.handHeldWeaponSchema
       #+ FC.optional "laserTechnology" laserTechnology LaserTechnology.laserTechnologySchema
-      #+ FC.required "uid" uid Uid.uidSchema
-      #+ FC.optional "plasmaTechnology" plasmaTechnology PlasmaTechnology.plasmaTechnologySchema
+      #+ FC.optional "mirror" mirror Mirror.mirrorSchema
       #+ FC.required "name" name Name.nameSchema
-      #+ FC.optional "photonicTechnology" photonicTechnology PhotonicTechnology.photonicTechnologySchema
       #+ FC.optional "phaserTechnology" phaserTechnology PhaserTechnology.phaserTechnologySchema
+      #+ FC.optional "photonicTechnology" photonicTechnology PhotonicTechnology.photonicTechnologySchema
+      #+ FC.optional "plasmaTechnology" plasmaTechnology PlasmaTechnology.plasmaTechnologySchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/WeaponHeader.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/WeaponHeader.hs
@@ -12,8 +12,8 @@ import qualified StarTrek.Types.WeaponHeader.Name as Name
 import qualified StarTrek.Types.WeaponHeader.Uid as Uid
 
 data WeaponHeader = WeaponHeader
-  { uid :: Uid.Uid -- ^ Weapon unique ID
-  , name :: Name.Name -- ^ Weapon name
+  { name :: Name.Name -- ^ Weapon name
+  , uid :: Uid.Uid -- ^ Weapon unique ID
   }
   deriving (Eq, Show)
 
@@ -21,5 +21,5 @@ weaponHeaderSchema :: FC.Fleece schema => schema WeaponHeader
 weaponHeaderSchema =
   FC.object $
     FC.constructor WeaponHeader
-      #+ FC.required "uid" uid Uid.uidSchema
       #+ FC.required "name" name Name.nameSchema
+      #+ FC.required "uid" uid Uid.uidSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/DateTimeFormats.hs
@@ -18,13 +18,13 @@ import qualified TestCases.Types.DateTimeFormats.ZonedTimeField as ZonedTimeFiel
 import qualified TestCases.Types.DateTimeFormats.ZonedTimeInUnionField as ZonedTimeInUnionField
 
 data DateTimeFormats = DateTimeFormats
-  { zonedTimeField :: Maybe ZonedTimeField.ZonedTimeField
+  { customLocalTimeField :: Maybe CustomLocalTimeField.CustomLocalTimeField
+  , customUtcTimeField :: Maybe CustomUtcTimeField.CustomUtcTimeField
+  , customZonedTimeField :: Maybe CustomZonedTimeField.CustomZonedTimeField
   , defaultTimeField :: Maybe DefaultTimeField.DefaultTimeField
   , localTimeField :: Maybe LocalTimeField.LocalTimeField
-  , customLocalTimeField :: Maybe CustomLocalTimeField.CustomLocalTimeField
   , utcTimeField :: Maybe UtcTimeField.UtcTimeField
-  , customZonedTimeField :: Maybe CustomZonedTimeField.CustomZonedTimeField
-  , customUtcTimeField :: Maybe CustomUtcTimeField.CustomUtcTimeField
+  , zonedTimeField :: Maybe ZonedTimeField.ZonedTimeField
   , zonedTimeInUnionField :: Maybe ZonedTimeInUnionField.ZonedTimeInUnionField
   }
   deriving (Show)
@@ -33,11 +33,11 @@ dateTimeFormatsSchema :: FC.Fleece schema => schema DateTimeFormats
 dateTimeFormatsSchema =
   FC.object $
     FC.constructor DateTimeFormats
-      #+ FC.optional "zonedTimeField" zonedTimeField ZonedTimeField.zonedTimeFieldSchema
+      #+ FC.optional "customLocalTimeField" customLocalTimeField CustomLocalTimeField.customLocalTimeFieldSchema
+      #+ FC.optional "customUtcTimeField" customUtcTimeField CustomUtcTimeField.customUtcTimeFieldSchema
+      #+ FC.optional "customZonedTimeField" customZonedTimeField CustomZonedTimeField.customZonedTimeFieldSchema
       #+ FC.optional "defaultTimeField" defaultTimeField DefaultTimeField.defaultTimeFieldSchema
       #+ FC.optional "localTimeField" localTimeField LocalTimeField.localTimeFieldSchema
-      #+ FC.optional "customLocalTimeField" customLocalTimeField CustomLocalTimeField.customLocalTimeFieldSchema
       #+ FC.optional "utcTimeField" utcTimeField UtcTimeField.utcTimeFieldSchema
-      #+ FC.optional "customZonedTimeField" customZonedTimeField CustomZonedTimeField.customZonedTimeFieldSchema
-      #+ FC.optional "customUtcTimeField" customUtcTimeField CustomUtcTimeField.customUtcTimeFieldSchema
+      #+ FC.optional "zonedTimeField" zonedTimeField ZonedTimeField.zonedTimeFieldSchema
       #+ FC.optional "zonedTimeInUnionField" zonedTimeInUnionField ZonedTimeInUnionField.zonedTimeInUnionFieldSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/FieldDescriptions.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/FieldDescriptions.hs
@@ -13,9 +13,9 @@ import qualified TestCases.Types.FieldDescriptions.NoDescription as NoDescriptio
 import qualified TestCases.Types.FieldDescriptions.WithDescription as WithDescription
 
 data FieldDescriptions = FieldDescriptions
-  { withDescription :: Maybe WithDescription.WithDescription -- ^ This field has a description
+  { emptyDescription :: Maybe EmptyDescription.EmptyDescription
   , noDescription :: Maybe NoDescription.NoDescription
-  , emptyDescription :: Maybe EmptyDescription.EmptyDescription
+  , withDescription :: Maybe WithDescription.WithDescription -- ^ This field has a description
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ fieldDescriptionsSchema :: FC.Fleece schema => schema FieldDescriptions
 fieldDescriptionsSchema =
   FC.object $
     FC.constructor FieldDescriptions
-      #+ FC.optional "withDescription" withDescription WithDescription.withDescriptionSchema
-      #+ FC.optional "noDescription" noDescription NoDescription.noDescriptionSchema
       #+ FC.optional "emptyDescription" emptyDescription EmptyDescription.emptyDescriptionSchema
+      #+ FC.optional "noDescription" noDescription NoDescription.noDescriptionSchema
+      #+ FC.optional "withDescription" withDescription WithDescription.withDescriptionSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/FieldTestCases.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/FieldTestCases.hs
@@ -18,14 +18,14 @@ import qualified TestCases.Types.FieldTestCases.RequiredField as RequiredField
 import qualified TestCases.Types.FieldTestCases.RequiredNullableField as RequiredNullableField
 
 data FieldTestCases = FieldTestCases
-  { optionalNullableField :: Maybe (Either FC.Null OptionalNullableField.OptionalNullableField)
-  , optionalArrayField :: Maybe [OptionalArrayFieldItem.OptionalArrayFieldItem]
-  , requiredNullableField :: Either FC.Null RequiredNullableField.RequiredNullableField
-  , optionalField :: Maybe OptionalField.OptionalField
-  , requiredField :: RequiredField.RequiredField
-  , optionalNullableArrayField :: Maybe (Either FC.Null [OptionalNullableArrayFieldItem.OptionalNullableArrayFieldItem])
+  { arrayField :: [ArrayFieldItem.ArrayFieldItem]
   , nullableArrayField :: Either FC.Null [NullableArrayFieldItem.NullableArrayFieldItem]
-  , arrayField :: [ArrayFieldItem.ArrayFieldItem]
+  , optionalArrayField :: Maybe [OptionalArrayFieldItem.OptionalArrayFieldItem]
+  , optionalField :: Maybe OptionalField.OptionalField
+  , optionalNullableArrayField :: Maybe (Either FC.Null [OptionalNullableArrayFieldItem.OptionalNullableArrayFieldItem])
+  , optionalNullableField :: Maybe (Either FC.Null OptionalNullableField.OptionalNullableField)
+  , requiredField :: RequiredField.RequiredField
+  , requiredNullableField :: Either FC.Null RequiredNullableField.RequiredNullableField
   }
   deriving (Eq, Show)
 
@@ -33,11 +33,11 @@ fieldTestCasesSchema :: FC.Fleece schema => schema FieldTestCases
 fieldTestCasesSchema =
   FC.object $
     FC.constructor FieldTestCases
-      #+ FC.optional "optionalNullableField" optionalNullableField (FC.nullable OptionalNullableField.optionalNullableFieldSchema)
-      #+ FC.optional "optionalArrayField" optionalArrayField (FC.list OptionalArrayFieldItem.optionalArrayFieldItemSchema)
-      #+ FC.required "requiredNullableField" requiredNullableField (FC.nullable RequiredNullableField.requiredNullableFieldSchema)
-      #+ FC.optional "optionalField" optionalField OptionalField.optionalFieldSchema
-      #+ FC.required "requiredField" requiredField RequiredField.requiredFieldSchema
-      #+ FC.optional "optionalNullableArrayField" optionalNullableArrayField (FC.nullable (FC.list OptionalNullableArrayFieldItem.optionalNullableArrayFieldItemSchema))
-      #+ FC.required "nullableArrayField" nullableArrayField (FC.nullable (FC.list NullableArrayFieldItem.nullableArrayFieldItemSchema))
       #+ FC.required "arrayField" arrayField (FC.list ArrayFieldItem.arrayFieldItemSchema)
+      #+ FC.required "nullableArrayField" nullableArrayField (FC.nullable (FC.list NullableArrayFieldItem.nullableArrayFieldItemSchema))
+      #+ FC.optional "optionalArrayField" optionalArrayField (FC.list OptionalArrayFieldItem.optionalArrayFieldItemSchema)
+      #+ FC.optional "optionalField" optionalField OptionalField.optionalFieldSchema
+      #+ FC.optional "optionalNullableArrayField" optionalNullableArrayField (FC.nullable (FC.list OptionalNullableArrayFieldItem.optionalNullableArrayFieldItemSchema))
+      #+ FC.optional "optionalNullableField" optionalNullableField (FC.nullable OptionalNullableField.optionalNullableFieldSchema)
+      #+ FC.required "requiredField" requiredField RequiredField.requiredFieldSchema
+      #+ FC.required "requiredNullableField" requiredNullableField (FC.nullable RequiredNullableField.requiredNullableFieldSchema)

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/NameConflicts.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/NameConflicts.hs
@@ -35,31 +35,31 @@ import qualified TestCases.Types.NameConflicts.Type as Type
 import qualified TestCases.Types.NameConflicts.Where as Where
 
 data NameConflicts = NameConflicts
-  { int64 :: Maybe Int64.Int64
-  , nameConflicts :: Maybe NameConflicts.NameConflicts
-  , int32 :: Maybe Int32.Int32
-  , case_ :: Maybe Case.Case
-  , of_ :: Maybe Of.Of
-  , then_ :: Maybe Then.Then
-  , deriving_ :: Maybe Deriving.Deriving
-  , let_ :: Maybe Let.Let
-  , where_ :: Maybe Where.Where
+  { case_ :: Maybe Case.Case
+  , class_ :: Maybe Class.Class
   , data_ :: Maybe Data.Data
-  , module_ :: Maybe Module.Module
-  , text :: Maybe Text.Text
+  , deriving_ :: Maybe Deriving.Deriving
   , do_ :: Maybe Do.Do
   , else_ :: Maybe Else.Else
-  , infixr_ :: Maybe Infixr.Infixr
-  , import_ :: Maybe Import.Import
-  , scientific :: Maybe Scientific.Scientific
-  , infixl_ :: Maybe Infixl.Infixl
   , if_ :: Maybe If.If
-  , newtype_ :: Maybe Newtype.Newtype
-  , class_ :: Maybe Class.Class
-  , type_ :: Maybe Type.Type
+  , import_ :: Maybe Import.Import
   , in_ :: Maybe In.In
-  , instance_ :: Maybe Instance.Instance
   , infix_ :: Maybe Infix.Infix
+  , infixl_ :: Maybe Infixl.Infixl
+  , infixr_ :: Maybe Infixr.Infixr
+  , instance_ :: Maybe Instance.Instance
+  , int32 :: Maybe Int32.Int32
+  , int64 :: Maybe Int64.Int64
+  , let_ :: Maybe Let.Let
+  , module_ :: Maybe Module.Module
+  , nameConflicts :: Maybe NameConflicts.NameConflicts
+  , newtype_ :: Maybe Newtype.Newtype
+  , of_ :: Maybe Of.Of
+  , scientific :: Maybe Scientific.Scientific
+  , text :: Maybe Text.Text
+  , then_ :: Maybe Then.Then
+  , type_ :: Maybe Type.Type
+  , where_ :: Maybe Where.Where
   }
   deriving (Eq, Show)
 
@@ -67,28 +67,28 @@ nameConflictsSchema :: FC.Fleece schema => schema NameConflicts
 nameConflictsSchema =
   FC.object $
     FC.constructor NameConflicts
-      #+ FC.optional "int64" int64 Int64.int64Schema
-      #+ FC.optional "nameConflicts" nameConflicts NameConflicts.nameConflictsSchema
-      #+ FC.optional "int32" int32 Int32.int32Schema
       #+ FC.optional "case" case_ Case.caseSchema
-      #+ FC.optional "of" of_ Of.ofSchema
-      #+ FC.optional "then" then_ Then.thenSchema
-      #+ FC.optional "deriving" deriving_ Deriving.derivingSchema
-      #+ FC.optional "let" let_ Let.letSchema
-      #+ FC.optional "where" where_ Where.whereSchema
+      #+ FC.optional "class" class_ Class.classSchema
       #+ FC.optional "data" data_ Data.dataSchema
-      #+ FC.optional "module" module_ Module.moduleSchema
-      #+ FC.optional "text" text Text.textSchema
+      #+ FC.optional "deriving" deriving_ Deriving.derivingSchema
       #+ FC.optional "do" do_ Do.doSchema
       #+ FC.optional "else" else_ Else.elseSchema
-      #+ FC.optional "infixr" infixr_ Infixr.infixrSchema
-      #+ FC.optional "import" import_ Import.importSchema
-      #+ FC.optional "scientific" scientific Scientific.scientificSchema
-      #+ FC.optional "infixl" infixl_ Infixl.infixlSchema
       #+ FC.optional "if" if_ If.ifSchema
-      #+ FC.optional "newtype" newtype_ Newtype.newtypeSchema
-      #+ FC.optional "class" class_ Class.classSchema
-      #+ FC.optional "type" type_ Type.typeSchema
+      #+ FC.optional "import" import_ Import.importSchema
       #+ FC.optional "in" in_ In.inSchema
-      #+ FC.optional "instance" instance_ Instance.instanceSchema
       #+ FC.optional "infix" infix_ Infix.infixSchema
+      #+ FC.optional "infixl" infixl_ Infixl.infixlSchema
+      #+ FC.optional "infixr" infixr_ Infixr.infixrSchema
+      #+ FC.optional "instance" instance_ Instance.instanceSchema
+      #+ FC.optional "int32" int32 Int32.int32Schema
+      #+ FC.optional "int64" int64 Int64.int64Schema
+      #+ FC.optional "let" let_ Let.letSchema
+      #+ FC.optional "module" module_ Module.moduleSchema
+      #+ FC.optional "nameConflicts" nameConflicts NameConflicts.nameConflictsSchema
+      #+ FC.optional "newtype" newtype_ Newtype.newtypeSchema
+      #+ FC.optional "of" of_ Of.ofSchema
+      #+ FC.optional "scientific" scientific Scientific.scientificSchema
+      #+ FC.optional "text" text Text.textSchema
+      #+ FC.optional "then" then_ Then.thenSchema
+      #+ FC.optional "type" type_ Type.typeSchema
+      #+ FC.optional "where" where_ Where.whereSchema

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-openapi3
-version:        0.4.4.0
+version:        0.4.5.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-openapi3#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-openapi3/package.yaml
+++ b/json-fleece-openapi3/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-openapi3
-version:             0.4.4.0
+version:             0.4.5.0
 github:              "flipstone/json-fleece/json-fleece-openapi3"
 license:             BSD3
 author:              "Author name here"

--- a/json-fleece-openapi3/src/Fleece/OpenApi3.hs
+++ b/json-fleece-openapi3/src/Fleece/OpenApi3.hs
@@ -10,7 +10,9 @@ import Control.Monad.Reader (ReaderT, ask, asks, runReaderT)
 import Control.Monad.Trans (lift)
 import qualified Data.Aeson as Aeson
 import Data.Bifunctor (bimap, first)
+import Data.Function (on)
 import qualified Data.HashMap.Strict.InsOrd as IOHM
+import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map.Strict as Map
@@ -1186,7 +1188,10 @@ mkOpenApiObjectFormat section schemaKey typeName schema = do
         (CGU.CodeGenAdditionalProperties . schemaTypeInfoDependent)
         mbAdditionalProperties
 
-  pure (dependencies, CGU.CodeGenObject typeOptions fields mbCodeGenAdditionalProps)
+    sortedFields =
+      List.sortBy (compare `on` CGU.codeGenFieldName) fields
+
+  pure (dependencies, CGU.CodeGenObject typeOptions sortedFields mbCodeGenAdditionalProps)
 
 mkAdditionalPropertiesInlineItemSchema ::
   CGU.CodeSection ->

--- a/json-fleece-swagger2/examples/uber/Uber/Types/Activities.hs
+++ b/json-fleece-swagger2/examples/uber/Uber/Types/Activities.hs
@@ -14,9 +14,9 @@ import qualified Uber.Types.Activities.Offset as Offset
 import qualified Uber.Types.Activity as Activity
 
 data Activities = Activities
-  { limit :: Maybe Limit.Limit -- ^ Number of items to retrieve (100 max).
-  , count :: Maybe Count.Count -- ^ Total number of items available.
+  { count :: Maybe Count.Count -- ^ Total number of items available.
   , history :: Maybe [Activity.Activity]
+  , limit :: Maybe Limit.Limit -- ^ Number of items to retrieve (100 max).
   , offset :: Maybe Offset.Offset -- ^ Position in pagination.
   }
   deriving (Eq, Show)
@@ -25,7 +25,7 @@ activitiesSchema :: FC.Fleece schema => schema Activities
 activitiesSchema =
   FC.object $
     FC.constructor Activities
-      #+ FC.optional "limit" limit Limit.limitSchema
       #+ FC.optional "count" count Count.countSchema
       #+ FC.optional "history" history (FC.list Activity.activitySchema)
+      #+ FC.optional "limit" limit Limit.limitSchema
       #+ FC.optional "offset" offset Offset.offsetSchema

--- a/json-fleece-swagger2/examples/uber/Uber/Types/Error.hs
+++ b/json-fleece-swagger2/examples/uber/Uber/Types/Error.hs
@@ -13,9 +13,9 @@ import qualified Uber.Types.Error.Fields as Fields
 import qualified Uber.Types.Error.Message as Message
 
 data Error = Error
-  { fields :: Maybe Fields.Fields
+  { code :: Maybe Code.Code
+  , fields :: Maybe Fields.Fields
   , message :: Maybe Message.Message
-  , code :: Maybe Code.Code
   }
   deriving (Eq, Show)
 
@@ -23,6 +23,6 @@ errorSchema :: FC.Fleece schema => schema Error
 errorSchema =
   FC.object $
     FC.constructor Error
+      #+ FC.optional "code" code Code.codeSchema
       #+ FC.optional "fields" fields Fields.fieldsSchema
       #+ FC.optional "message" message Message.messageSchema
-      #+ FC.optional "code" code Code.codeSchema

--- a/json-fleece-swagger2/examples/uber/Uber/Types/PriceEstimate.hs
+++ b/json-fleece-swagger2/examples/uber/Uber/Types/PriceEstimate.hs
@@ -18,12 +18,12 @@ import qualified Uber.Types.PriceEstimate.SurgeMultiplier as SurgeMultiplier
 
 data PriceEstimate = PriceEstimate
   { currencyCode :: Maybe CurrencyCode.CurrencyCode -- ^ [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code.
-  , productId :: Maybe ProductId.ProductId -- ^ Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles
   , displayName :: Maybe DisplayName.DisplayName -- ^ Display name of product.
-  , surgeMultiplier :: Maybe SurgeMultiplier.SurgeMultiplier -- ^ Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.
+  , estimate :: Maybe Estimate.Estimate -- ^ Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or "Metered" for TAXI.
   , highEstimate :: Maybe HighEstimate.HighEstimate -- ^ Upper bound of the estimated price.
   , lowEstimate :: Maybe LowEstimate.LowEstimate -- ^ Lower bound of the estimated price.
-  , estimate :: Maybe Estimate.Estimate -- ^ Formatted string of estimate in local currency of the start location. Estimate could be a range, a single number (flat rate) or "Metered" for TAXI.
+  , productId :: Maybe ProductId.ProductId -- ^ Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles
+  , surgeMultiplier :: Maybe SurgeMultiplier.SurgeMultiplier -- ^ Expected surge multiplier. Surge is active if surge_multiplier is greater than 1. Price estimate already factors in the surge multiplier.
   }
   deriving (Eq, Show)
 
@@ -32,9 +32,9 @@ priceEstimateSchema =
   FC.object $
     FC.constructor PriceEstimate
       #+ FC.optional "currency_code" currencyCode CurrencyCode.currencyCodeSchema
-      #+ FC.optional "product_id" productId ProductId.productIdSchema
       #+ FC.optional "display_name" displayName DisplayName.displayNameSchema
-      #+ FC.optional "surge_multiplier" surgeMultiplier SurgeMultiplier.surgeMultiplierSchema
+      #+ FC.optional "estimate" estimate Estimate.estimateSchema
       #+ FC.optional "high_estimate" highEstimate HighEstimate.highEstimateSchema
       #+ FC.optional "low_estimate" lowEstimate LowEstimate.lowEstimateSchema
-      #+ FC.optional "estimate" estimate Estimate.estimateSchema
+      #+ FC.optional "product_id" productId ProductId.productIdSchema
+      #+ FC.optional "surge_multiplier" surgeMultiplier SurgeMultiplier.surgeMultiplierSchema

--- a/json-fleece-swagger2/examples/uber/Uber/Types/Product.hs
+++ b/json-fleece-swagger2/examples/uber/Uber/Types/Product.hs
@@ -16,10 +16,10 @@ import qualified Uber.Types.Product.ProductId as ProductId
 
 data Product = Product
   { capacity :: Maybe Capacity.Capacity -- ^ Capacity of product. For example, 4 people.
-  , productId :: Maybe ProductId.ProductId -- ^ Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
-  , displayName :: Maybe DisplayName.DisplayName -- ^ Display name of product.
   , description :: Maybe Description.Description -- ^ Description of product.
+  , displayName :: Maybe DisplayName.DisplayName -- ^ Display name of product.
   , image :: Maybe Image.Image -- ^ Image URL representing the product.
+  , productId :: Maybe ProductId.ProductId -- ^ Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
   }
   deriving (Eq, Show)
 
@@ -28,7 +28,7 @@ productSchema =
   FC.object $
     FC.constructor Product
       #+ FC.optional "capacity" capacity Capacity.capacitySchema
-      #+ FC.optional "product_id" productId ProductId.productIdSchema
-      #+ FC.optional "display_name" displayName DisplayName.displayNameSchema
       #+ FC.optional "description" description Description.descriptionSchema
+      #+ FC.optional "display_name" displayName DisplayName.displayNameSchema
       #+ FC.optional "image" image Image.imageSchema
+      #+ FC.optional "product_id" productId ProductId.productIdSchema

--- a/json-fleece-swagger2/examples/uber/Uber/Types/Profile.hs
+++ b/json-fleece-swagger2/examples/uber/Uber/Types/Profile.hs
@@ -16,10 +16,10 @@ import qualified Uber.Types.Profile.PromoCode as PromoCode
 
 data Profile = Profile
   { email :: Maybe Email.Email -- ^ Email address of the Uber user
-  , promoCode :: Maybe PromoCode.PromoCode -- ^ Promo code of the Uber user.
-  , lastName :: Maybe LastName.LastName -- ^ Last name of the Uber user.
   , firstName :: Maybe FirstName.FirstName -- ^ First name of the Uber user.
+  , lastName :: Maybe LastName.LastName -- ^ Last name of the Uber user.
   , picture :: Maybe Picture.Picture -- ^ Image URL of the Uber user.
+  , promoCode :: Maybe PromoCode.PromoCode -- ^ Promo code of the Uber user.
   }
   deriving (Eq, Show)
 
@@ -28,7 +28,7 @@ profileSchema =
   FC.object $
     FC.constructor Profile
       #+ FC.optional "email" email Email.emailSchema
-      #+ FC.optional "promo_code" promoCode PromoCode.promoCodeSchema
-      #+ FC.optional "last_name" lastName LastName.lastNameSchema
       #+ FC.optional "first_name" firstName FirstName.firstNameSchema
+      #+ FC.optional "last_name" lastName LastName.lastNameSchema
       #+ FC.optional "picture" picture Picture.pictureSchema
+      #+ FC.optional "promo_code" promoCode PromoCode.promoCodeSchema


### PR DESCRIPTION
Although we would like for the fields in generated records to match the
order that they're specified in the OpenApi spec, library support for
preserving the order while parsing the `OpenApi` description is currently
lacking. In order to provide at least a *stable* order that does not vary
with changes to the underlying libraries, this sorts the fields by their
name while constructing the description of the object for the code
generation layer.
