### PR TITLE
Adds schema for `Fixed` numbers

### DIFF
--- a/json-fleece-core/json-fleece-core.cabal
+++ b/json-fleece-core/json-fleece-core.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-core
-version:        0.7.0.0
+version:        0.7.1.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-core#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-core/package.yaml
+++ b/json-fleece-core/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-core
-version:             0.7.0.0
+version:             0.7.1.0
 github:              "flipstone/json-fleece/json-fleece-core"
 license:             BSD3
 author:              "Author name here"

--- a/json-fleece-core/src/Fleece/Core.hs
+++ b/json-fleece-core/src/Fleece/Core.hs
@@ -64,6 +64,8 @@ module Fleece.Core
   , float
   , realFloat
   , realFloatNamed
+  , fixed
+  , fixedNamed
   , SetDuplicateHandling (AllowInputDuplicates, RejectInputDuplicates)
   , set
   , string

--- a/json-fleece-core/src/Fleece/Core/Schemas.hs
+++ b/json-fleece-core/src/Fleece/Core/Schemas.hs
@@ -28,6 +28,8 @@ module Fleece.Core.Schemas
   , float
   , realFloat
   , realFloatNamed
+  , fixed
+  , fixedNamed
   , string
   , utcTime
   , utcTimeWithFormat
@@ -61,6 +63,7 @@ module Fleece.Core.Schemas
 import qualified Data.Attoparsec.Text as AttoText
 import qualified Data.Attoparsec.Time as AttoTime
 import Data.Coerce (Coercible, coerce)
+import Data.Fixed (Fixed, HasResolution)
 import qualified Data.Int as I
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as Map
@@ -557,6 +560,30 @@ realFloatNamed name =
     name
     fromFloatDigits
     toRealFloat
+    number
+
+fixed ::
+  (Fleece schema, HasResolution r, Typeable r) =>
+  schema (Fixed r)
+fixed =
+  let
+    name =
+      defaultSchemaName schema
+
+    schema =
+      fixedNamed name
+  in
+    schema
+
+fixedNamed ::
+  (Fleece schema, HasResolution r) =>
+  Name ->
+  schema (Fixed r)
+fixedNamed name =
+  transformNamed
+    name
+    realToFrac
+    realToFrac
     number
 
 string :: Fleece schema => schema String


### PR DESCRIPTION
I added `fixed` and `fixedNamed` schemas using `realToFrac` to handle the conversion to and from `Scientific`. Note that it is safe to use `realToFrac` to construct the `Scientific` in this case because calling `toRational` on `Fixed` cannot produce a decimal with a repetend.