### PR TITLE
Exports to-text function for enum params

### DIFF
--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumIntParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumIntParam.hs
@@ -3,6 +3,7 @@
 
 module TestCases.Operations.TestCases.HeaderParams.InlineEnumIntParam
   ( InlineEnumIntParam(..)
+  , inlineEnumIntParamToText
   , paramDef
   ) where
 

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumParam.hs
@@ -3,6 +3,7 @@
 
 module TestCases.Operations.TestCases.HeaderParams.InlineEnumParam
   ( InlineEnumParam(..)
+  , inlineEnumParamToText
   , paramDef
   ) where
 

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumIntParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumIntParam.hs
@@ -3,6 +3,7 @@
 
 module TestCases.Operations.TestCases.QueryParams.InlineEnumIntParam
   ( InlineEnumIntParam(..)
+  , inlineEnumIntParamToText
   , paramDef
   ) where
 

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumParam.hs
@@ -3,6 +3,7 @@
 
 module TestCases.Operations.TestCases.QueryParams.InlineEnumParam
   ( InlineEnumParam(..)
+  , inlineEnumParamToText
   , paramDef
   ) where
 


### PR DESCRIPTION
This adds the to-text function for any `Enum` param types in operations modules to the export list. This allows for their use in parsing or converting the types for creating these API calls.