### PR TITLE
Adds option to generate re-exports of record field submodules

### DIFF
--- a/json-fleece-codegen-util/codegen-prelude.dhall
+++ b/json-fleece-codegen-util/codegen-prelude.dhall
@@ -13,11 +13,13 @@ let
         { dateTimeFormat : DateTimeFormat
         , formatSpecifier : Optional Text
         , deriveClasses : DeriveClasses
+        , reexportFields : Bool
         }
     , default =
         { dateTimeFormat = DateTimeFormat.UTCTime
         , formatSpecifier = None Text
         , deriveClasses = DeriveClasses.Default
+        , reexportFields = False
         }
     }
 

--- a/json-fleece-codegen-util/json-fleece-codegen-util.cabal
+++ b/json-fleece-codegen-util/json-fleece-codegen-util.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-codegen-util
-version:        0.14.3.0
+version:        0.15.0.0
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-codegen-util#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-codegen-util/package.yaml
+++ b/json-fleece-codegen-util/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-codegen-util
-version:             0.14.3.0
+version:             0.15.0.0
 github:              "flipstone/json-fleece/json-fleece-codegen-util"
 license:             MIT
 license-file:        LICENSE

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
@@ -104,6 +104,7 @@ data TypeOptions = TypeOptions
   { dateTimeFormat :: DateTimeFormat
   , formatSpecifier :: Maybe T.Text
   , deriveClasses :: Maybe [DerivableClass]
+  , reexportFields :: Bool
   }
 
 deriveClassNames :: TypeOptions -> Maybe [HC.TypeName]
@@ -1373,6 +1374,23 @@ requiredPragmasForFormat format =
       , "{-# LANGUAGE TypeApplications #-}"
       ]
 
+childModuleReferencesInCode :: HC.ModuleName -> HC.HaskellCode -> [HC.ModuleName]
+childModuleReferencesInCode parentModule code =
+  let
+    parentPrefix =
+      HC.moduleNameToText parentModule <> "."
+
+    isChild modName =
+      T.isPrefixOf parentPrefix (HC.moduleNameToText modName)
+
+    allRefs =
+      HC.references code
+  in
+    Set.toList
+      . Set.filter isChild
+      . Set.map HC.externalReferenceModule
+      $ allRefs
+
 generateSchemaCode ::
   CodeGenMap ->
   CodeGenTypeReferencesMap ->
@@ -1401,8 +1419,15 @@ generateSchemaCode typeMap refMap codeGenType = do
     generateCodeGenDataFormat typeMap references typeName format
 
   let
+    reexportModules =
+      case format of
+        CodeGenObject typeOptions _ _
+          | reexportFields typeOptions ->
+              childModuleReferencesInCode moduleName moduleBody
+        _ -> []
+
     header =
-      schemaTypeModuleHeader moduleName typeName extraExports
+      schemaTypeModuleHeader moduleName typeName extraExports reexportModules
 
     pragmas =
       HC.lines
@@ -1410,22 +1435,32 @@ generateSchemaCode typeMap refMap codeGenType = do
             : requiredPragmasForFormat format
         )
 
+    reexportImports =
+      case reexportModules of
+        [] -> mempty
+        _ ->
+          HC.lines (map (\m -> "import " <> HC.toCode m) reexportModules)
+
     code =
-      HC.declarations
+      HC.declarations $
         [ pragmas
         , header
         , importDeclarations moduleName moduleBody
-        , moduleBody
         ]
+          <> (if null reexportModules then [] else [reexportImports])
+          <> [moduleBody]
 
   pure (path, code)
 
 schemaTypeModuleHeader ::
-  HC.ModuleName -> HC.TypeName -> [HC.VarName] -> HC.HaskellCode
-schemaTypeModuleHeader moduleName typeName extraExports =
+  HC.ModuleName -> HC.TypeName -> [HC.VarName] -> [HC.ModuleName] -> HC.HaskellCode
+schemaTypeModuleHeader moduleName typeName extraExports reexportModules =
   let
     schemaName =
       fleeceSchemaNameForType typeName
+
+    moduleReexportLines =
+      map (\m -> "module " <> HC.toCode m) reexportModules
 
     exportLines =
       HC.delimitLines
@@ -1434,6 +1469,7 @@ schemaTypeModuleHeader moduleName typeName extraExports =
         ( (HC.typeNameToCode Nothing typeName <> "(..)")
             : HC.varNameToCode Nothing schemaName
             : map (HC.varNameToCode Nothing) extraExports
+            ++ moduleReexportLines
         )
   in
     HC.lines

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/Config.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/Config.hs
@@ -48,6 +48,7 @@ typeOptionsDecoder =
       <$> Dhall.field "dateTimeFormat" dateTimeFormatDecoder
       <*> Dhall.field "formatSpecifier" formatSpecifierDecoder
       <*> Dhall.field "deriveClasses" deriveClassesDecoder
+      <*> Dhall.field "reexportFields" Dhall.bool
 
 formatSpecifierDecoder :: Dhall.Decoder (Maybe T.Text)
 formatSpecifierDecoder = Dhall.maybe Dhall.strictText

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
@@ -23,6 +23,7 @@ module Fleece.CodeGenUtil.HaskellCode
   , ToCode (toCode)
   , FromCode (fromCode)
   , ExternalReference (..)
+  , externalReferenceModule
   , ExternalReferences
   , addReferences
   , references
@@ -122,6 +123,12 @@ data ExternalReference
 
 type ExternalReferences =
   Set.Set ExternalReference
+
+externalReferenceModule :: ExternalReference -> ModuleName
+externalReferenceModule ref =
+  case ref of
+    TypeReference modName _ _ -> modName
+    VarReference modName _ _ -> modName
 
 instance ToCode HaskellCode where
   toCode = id

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/ReexportFieldsExample.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/ReexportFieldsExample.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.ReexportFieldsExample
+  ( ReexportFieldsExample(..)
+  , reexportFieldsExampleSchema
+  , module TestCases.Types.ReexportFieldsExample.Age
+  , module TestCases.Types.ReexportFieldsExample.Name
+  ) where
+
+import Fleece.Core ((#+))
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Maybe, Show)
+import qualified TestCases.Types.ReexportFieldsExample.Age as Age
+import qualified TestCases.Types.ReexportFieldsExample.Name as Name
+
+import TestCases.Types.ReexportFieldsExample.Age
+import TestCases.Types.ReexportFieldsExample.Name
+
+data ReexportFieldsExample = ReexportFieldsExample
+  { age :: Maybe Age.Age
+  , name :: Name.Name
+  }
+  deriving (Eq, Show)
+
+reexportFieldsExampleSchema :: FC.Fleece t => FC.Schema t ReexportFieldsExample
+reexportFieldsExampleSchema =
+  FC.object $
+    FC.constructor ReexportFieldsExample
+      #+ FC.optional "age" age Age.ageSchema
+      #+ FC.required "name" name Name.nameSchema

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/ReexportFieldsExample/Age.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/ReexportFieldsExample/Age.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.ReexportFieldsExample.Age
+  ( Age(..)
+  , ageSchema
+  ) where
+
+import qualified Data.Int as I
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Age = Age I.Int32
+  deriving (Show, Eq)
+
+ageSchema :: FC.Fleece t => FC.Schema t Age
+ageSchema =
+  FC.coerceSchema FC.int32

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/ReexportFieldsExample/Name.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/ReexportFieldsExample/Name.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module TestCases.Types.ReexportFieldsExample.Name
+  ( Name(..)
+  , nameSchema
+  ) where
+
+import qualified Data.Text as T
+import qualified Fleece.Core as FC
+import Prelude (Eq, Show)
+
+newtype Name = Name T.Text
+  deriving (Show, Eq)
+
+nameSchema :: FC.Fleece t => FC.Schema t Name
+nameSchema =
+  FC.coerceSchema FC.text

--- a/json-fleece-openapi3/examples/test-cases/codegen.dhall
+++ b/json-fleece-openapi3/examples/test-cases/codegen.dhall
@@ -112,5 +112,11 @@ in
                   { deriveClasses = CodeGen.derive CodeGen.noClasses
                   }
             }
+          , { type = "TestCases.Types.ReexportFieldsExample.ReexportFieldsExample"
+            , options =
+                CodeGen.TypeOptions::
+                  { reexportFields = True
+                  }
+            }
           ]
       }

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -298,6 +298,9 @@ library
       TestCases.Types.OneOfWithInlineObject.Option4.Nested.Name
       TestCases.Types.OneOfWithInlineObject.Option4.Nested.Number
       TestCases.Types.OneOfWithNullable
+      TestCases.Types.ReexportFieldsExample
+      TestCases.Types.ReexportFieldsExample.Age
+      TestCases.Types.ReexportFieldsExample.Name
       TestCases.Types.ReferenceOneOf
       TestCases.Types.ReferenceOneOfInsideOneOf
       TestCases.Types.ScheduledDateTime

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -1341,3 +1341,14 @@ components:
           format: date-time
           example: '2024-05-27T14:05:00Z'
       additionalProperties: false
+
+    ReexportFieldsExample:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        age:
+          type: integer
+          format: int32

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-openapi3
-version:        0.4.8.1
+version:        0.4.8.2
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-openapi3#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -2148,6 +2148,9 @@ extra-source-files:
     examples/test-cases/TestCases/Types/OneOfWithInlineObject/Option4/Nested/Name.hs
     examples/test-cases/TestCases/Types/OneOfWithInlineObject/Option4/Nested/Number.hs
     examples/test-cases/TestCases/Types/OneOfWithNullable.hs
+    examples/test-cases/TestCases/Types/ReexportFieldsExample.hs
+    examples/test-cases/TestCases/Types/ReexportFieldsExample/Age.hs
+    examples/test-cases/TestCases/Types/ReexportFieldsExample/Name.hs
     examples/test-cases/TestCases/Types/ReferenceOneOf.hs
     examples/test-cases/TestCases/Types/ReferenceOneOfInsideOneOf.hs
     examples/test-cases/TestCases/Types/ScheduledDateTime.hs
@@ -2195,7 +2198,7 @@ library
     , containers >=0.6 && <0.8
     , http-media ==0.8.*
     , insert-ordered-containers ==0.2.*
-    , json-fleece-codegen-util ==0.14.*
+    , json-fleece-codegen-util >=0.14 && <0.16
     , mtl >=2.2 && <2.4
     , non-empty-text ==0.2.*
     , openapi3 ==3.2.*
@@ -2221,7 +2224,7 @@ executable fleece-openapi3
   ghc-options: -rtsopts -threaded
   build-depends:
       base >=4.7 && <5
-    , json-fleece-codegen-util ==0.14.*
+    , json-fleece-codegen-util >=0.14 && <0.16
     , json-fleece-openapi3
   default-language: Haskell2010
   if flag(strict)
@@ -2246,7 +2249,7 @@ test-suite json-fleece-openapi3-test
     , bytestring >=0.11 && <0.13
     , file-embed >=0.0.15 && <0.0.17
     , hedgehog
-    , json-fleece-codegen-util ==0.14.*
+    , json-fleece-codegen-util >=0.14 && <0.16
     , json-fleece-openapi3
     , yaml ==0.11.*
   default-language: Haskell2010

--- a/json-fleece-openapi3/package.yaml
+++ b/json-fleece-openapi3/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-openapi3
-version:             0.4.8.1
+version:             0.4.8.2
 github:              "flipstone/json-fleece/json-fleece-openapi3"
 license:             MIT
 license-file:        LICENSE
@@ -56,7 +56,7 @@ when:
 
 dependencies:
   - base >= 4.7 && < 5
-  - json-fleece-codegen-util >= 0.14 && < 0.15
+  - json-fleece-codegen-util >= 0.14 && < 0.16
 
 extra-source-files:
   - examples/star-trek/codegen.dhall

--- a/json-fleece-swagger2/json-fleece-swagger2.cabal
+++ b/json-fleece-swagger2/json-fleece-swagger2.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-swagger2
-version:        0.4.0.6
+version:        0.4.0.7
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-swagger2#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -88,7 +88,7 @@ library
   build-depends:
       base >=4.7 && <5
     , insert-ordered-containers ==0.2.*
-    , json-fleece-codegen-util ==0.14.*
+    , json-fleece-codegen-util >=0.14 && <0.16
     , json-fleece-openapi3 ==0.4.*
     , openapi3 ==3.2.*
     , swagger2 ==2.8.*
@@ -112,7 +112,7 @@ executable fleece-swagger2
   ghc-options: -rtsopts -threaded
   build-depends:
       base >=4.7 && <5
-    , json-fleece-codegen-util ==0.14.*
+    , json-fleece-codegen-util >=0.14 && <0.16
     , json-fleece-swagger2
   default-language: Haskell2010
   if flag(strict)
@@ -138,7 +138,7 @@ test-suite json-fleece-swagger2-test
     , bytestring >=0.11 && <0.13
     , file-embed >=0.0.15 && <0.0.17
     , hedgehog
-    , json-fleece-codegen-util ==0.14.*
+    , json-fleece-codegen-util >=0.14 && <0.16
     , json-fleece-swagger2
   default-language: Haskell2010
   if flag(strict)

--- a/json-fleece-swagger2/package.yaml
+++ b/json-fleece-swagger2/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-swagger2
-version:             0.4.0.6
+version:             0.4.0.7
 github:              "flipstone/json-fleece/json-fleece-swagger2"
 license:             MIT
 license-file:        LICENSE
@@ -20,7 +20,7 @@ tested-with:
 
 dependencies:
 - base >= 4.7 && < 5
-- json-fleece-codegen-util >= 0.14 && < 0.15
+- json-fleece-codegen-util >= 0.14 && < 0.16
 
 flags:
   strict:


### PR DESCRIPTION
This adds a `reexportFields` option to `TypeOptions`. When this option is set on a record type, the record module will re-export all the submodules generated for the fields of the record.

This might cause a compilation error if there are naming conflicts between the modules (e.g. two enums with the same values). Checking for conflicts is not handled by the codegen -- the generated code will simply not compile.

The option defaults to false (disabled). It must be opted in to for now. It can be enable for specific types, or for all types via `defaultTypeOptions`. In the latter case, it can then be disabled for any specific types whose modules do not compile with the reexports present.

We might choose to change the default to enabled in the future.