### PR TITLE
Adds from-text functions for enums

### DIFF
--- a/json-fleece-codegen-util/json-fleece-codegen-util.cabal
+++ b/json-fleece-codegen-util/json-fleece-codegen-util.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-codegen-util
-version:        0.14.3.0
+version:        0.14.3.1
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-codegen-util#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-codegen-util/package.yaml
+++ b/json-fleece-codegen-util/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-codegen-util
-version:             0.14.3.0
+version:             0.14.3.1
 github:              "flipstone/json-fleece/json-fleece-codegen-util"
 license:             MIT
 license-file:        LICENSE

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
@@ -2121,20 +2121,20 @@ generateEnum typeName enumValues typeOptions =
       fold
         [ HC.typeNameToCodeDefaultQualification textType
         , " -> "
-        , HC.eitherOf
+        , HC.eitherOfQualified
             (HC.typeNameToCodeDefaultQualification stringType)
             (HC.typeNameToCode Nothing typeName)
         ]
 
     mkFromTextCase (text, constructor) =
       HC.caseMatch (HC.stringLiteral text) $
-        HC.typeNameToCodeDefaultQualification mkRight
+        HC.typeNameToCodeDefaultQualification (HC.eitherType "Right")
           <> " "
           <> HC.toCode constructor
 
     fromTextErrorCase =
       HC.caseMatch "v" $
-        HC.typeNameToCodeDefaultQualification mkLeft
+        HC.typeNameToCodeDefaultQualification (HC.eitherType "Left")
           <> " "
           <> HC.dollar
           <> " "
@@ -2233,14 +2233,6 @@ integerType =
 boolType :: HC.TypeName
 boolType =
   HC.preludeType "Bool"
-
-mkLeft :: HC.TypeName
-mkLeft =
-  HC.toTypeName "Data.Either" (Just "Either") "Left"
-
-mkRight :: HC.TypeName
-mkRight =
-  HC.toTypeName "Data.Either" (Just "Either") "Right"
 
 fleeceClass :: HC.TypeName
 fleeceClass =

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil.hs
@@ -70,6 +70,7 @@ module Fleece.CodeGenUtil
 
 import Control.Monad.Reader (ReaderT, ask, asks, runReaderT)
 import Control.Monad.Trans (lift)
+import Data.Foldable (fold)
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map.Strict as Map
 import Data.Maybe (catMaybes, mapMaybe)
@@ -1174,7 +1175,10 @@ generateOperationParamCode codeGenOperationParam = do
                     (HC.fromCode (HC.typeNameToCodeDefaultQualification haskellType))
                     (deriveClassNames typeOptions)
               Left enumValues ->
-                Just . snd $ generateEnum typeName enumValues typeOptions
+                let
+                  (_, _, enum) = generateEnum typeName enumValues typeOptions
+                in
+                  Just enum
             else Nothing
 
         defName =
@@ -1314,11 +1318,46 @@ operationParamHeader param =
         ParamTypeHaskell _typeName ->
           Nothing
 
+    typeFromTextExport =
+      case codeGenOperationParamType param of
+        ParamTypeString ->
+          Nothing
+        ParamTypeBoolean ->
+          Nothing
+        ParamTypeEnum _vals ->
+          if moduleMatchesTypeName
+            then
+              Just
+                . HC.varNameToCode Nothing
+                $ fromTextFunctionVarName moduleName Nothing typeName
+            else Nothing
+        ParamTypeInteger ->
+          Nothing
+        ParamTypeInt ->
+          Nothing
+        ParamTypeInt8 ->
+          Nothing
+        ParamTypeInt16 ->
+          Nothing
+        ParamTypeInt32 ->
+          Nothing
+        ParamTypeInt64 ->
+          Nothing
+        ParamTypeScientific ->
+          Nothing
+        ParamTypeDouble ->
+          Nothing
+        ParamTypeFloat ->
+          Nothing
+        ParamTypeHaskell _typeName ->
+          Nothing
+
     exportLines =
       HC.delimitLines "( " ", " $
         catMaybes
           [ typeExport
           , typeToTextExport
+          , typeFromTextExport
           , Just
               . HC.varNameToCode Nothing
               $ codeGenOperationParamDefName param
@@ -1567,7 +1606,7 @@ generateFleeceEnum ::
   ([HC.VarName], HC.HaskellCode)
 generateFleeceEnum typeName enumValues typeOptions =
   let
-    (toTextName, enum) =
+    (toTextName, fromTextName, enum) =
       generateEnum typeName enumValues typeOptions
 
     fleeceSchema =
@@ -1575,7 +1614,7 @@ generateFleeceEnum typeName enumValues typeOptions =
         [ fleeceCoreVar "boundedEnum" <> " " <> HC.varNameToCode Nothing toTextName
         ]
   in
-    ([toTextName], HC.declarations [enum, fleeceSchema])
+    ([toTextName, fromTextName], HC.declarations [enum, fleeceSchema])
 
 generateFleeceUnion ::
   CodeGenMap ->
@@ -2037,7 +2076,7 @@ generateEnum ::
   HC.TypeName ->
   [T.Text] ->
   TypeOptions ->
-  (HC.VarName, HC.HaskellCode)
+  (HC.VarName, HC.VarName, HC.HaskellCode)
 generateEnum typeName enumValues typeOptions =
   let
     mkEnumItem t =
@@ -2073,15 +2112,53 @@ generateEnum typeName enumValues typeOptions =
         )
 
     mkToTextCase (text, constructor) =
-      HC.caseMatch constructor (HC.stringLiteral text)
+      HC.caseMatch (HC.toCode constructor) (HC.stringLiteral text)
+
+    fromTextName =
+      fromTextFunctionVarName moduleName Nothing typeName
+
+    fromTextType =
+      fold
+        [ HC.typeNameToCodeDefaultQualification textType
+        , " -> "
+        , HC.eitherOf
+            (HC.typeNameToCodeDefaultQualification stringType)
+            (HC.typeNameToCode Nothing typeName)
+        ]
+
+    mkFromTextCase (text, constructor) =
+      HC.caseMatch (HC.stringLiteral text) $
+        HC.typeNameToCodeDefaultQualification mkRight
+          <> " "
+          <> HC.toCode constructor
+
+    fromTextErrorCase =
+      HC.caseMatch "v" $
+        HC.typeNameToCodeDefaultQualification mkLeft
+          <> " "
+          <> HC.dollar
+          <> " "
+          <> HC.stringLiteral ("Unknown " <> HC.typeNameText typeName <> ": ")
+          <> " "
+          <> HC.semigroupConcat
+          <> " v"
+
+    fromText =
+      HC.lines
+        ( HC.typeAnnotate fromTextName fromTextType
+            : HC.varNameToCode Nothing fromTextName <> " txt ="
+            : HC.indent 2 "case " <> HC.varNameToCodeDefaultQualification textUnpack <> " txt of"
+            : (map (HC.indent 4 . mkFromTextCase) enumItems) <> [HC.indent 4 fromTextErrorCase]
+        )
 
     body =
       HC.declarations
         [ enumDeclaration
         , toText
+        , fromText
         ]
   in
-    (toTextName, body)
+    (toTextName, fromTextName, body)
 
 data CodeSection
   = Type
@@ -2101,6 +2178,10 @@ generatedModuleName section text = do
       <> sectionModule section
       <> HC.toModuleName text
 
+stringType :: HC.TypeName
+stringType =
+  HC.preludeType "String"
+
 textType :: HC.TypeName
 textType =
   HC.toTypeName "Data.Text" (Just "T") "Text"
@@ -2108,6 +2189,10 @@ textType =
 textPack :: HC.VarName
 textPack =
   HC.toVarName "Data.Text" (Just "T") "pack"
+
+textUnpack :: HC.VarName
+textUnpack =
+  HC.toVarName "Data.Text" (Just "T") "unpack"
 
 floatType :: HC.TypeName
 floatType =
@@ -2148,6 +2233,14 @@ integerType =
 boolType :: HC.TypeName
 boolType =
   HC.preludeType "Bool"
+
+mkLeft :: HC.TypeName
+mkLeft =
+  HC.toTypeName "Data.Either" (Just "Either") "Left"
+
+mkRight :: HC.TypeName
+mkRight =
+  HC.toTypeName "Data.Either" (Just "Either") "Right"
 
 fleeceClass :: HC.TypeName
 fleeceClass =
@@ -2474,3 +2567,10 @@ toTextFunctionVarName moduleName mbQualifier typeName =
     moduleName
     mbQualifier
     (HC.typeNameText typeName <> "ToText")
+
+fromTextFunctionVarName :: HC.ModuleName -> Maybe T.Text -> HC.TypeName -> HC.VarName
+fromTextFunctionVarName moduleName mbQualifier typeName =
+  HC.toVarName
+    moduleName
+    mbQualifier
+    (HC.typeNameText typeName <> "FromText")

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
@@ -611,8 +611,8 @@ intLiteral n =
   String.fromString (show n)
 
 caseMatch :: HaskellCode -> HaskellCode -> HaskellCode
-caseMatch _case output =
-  _case <> " -> " <> output
+caseMatch case_ output =
+  case_ <> " -> " <> output
 
 eqClass :: TypeName
 eqClass =

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
@@ -48,6 +48,7 @@ module Fleece.CodeGenUtil.HaskellCode
   , mapOf
   , maybeOf
   , eitherOf
+  , eitherOfQualified
   , dollar
   , semigroupConcat
   , functorMap
@@ -68,6 +69,7 @@ module Fleece.CodeGenUtil.HaskellCode
   , enumClass
   , boundedClass
   , preludeType
+  , eitherType
   , shrubberyType
   , nonEmptyType
   , fixDigitPrefixVarName
@@ -515,6 +517,14 @@ eitherOf left right =
     <> fromCode " "
     <> guardParens right
 
+eitherOfQualified :: TypeExpression -> TypeExpression -> TypeExpression
+eitherOfQualified left right =
+  typeNameToCode (Just "Either") (eitherType "Either")
+    <> fromCode " "
+    <> guardParens left
+    <> fromCode " "
+    <> guardParens right
+
 guardParens :: TypeExpression -> TypeExpression
 guardParens name =
   let
@@ -627,6 +637,10 @@ boundedClass =
 preludeType :: T.Text -> TypeName
 preludeType =
   toTypeName "Prelude" Nothing
+
+eitherType :: T.Text -> TypeName
+eitherType =
+  toTypeName "Data.Either" (Just "Either")
 
 shrubberyType :: T.Text -> TypeName
 shrubberyType =

--- a/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
+++ b/json-fleece-codegen-util/src/Fleece/CodeGenUtil/HaskellCode.hs
@@ -49,6 +49,7 @@ module Fleece.CodeGenUtil.HaskellCode
   , maybeOf
   , eitherOf
   , dollar
+  , semigroupConcat
   , functorMap
   , record
   , delimitLines
@@ -544,6 +545,10 @@ dollar :: HaskellCode
 dollar =
   addReferences [VarReference "Prelude" Nothing "($)"] "$"
 
+semigroupConcat :: HaskellCode
+semigroupConcat =
+  addReferences [VarReference "Prelude" Nothing "(<>)"] "<>"
+
 functorMap :: HaskellCode
 functorMap =
   addReferences [VarReference "Prelude" Nothing "fmap"] "fmap"
@@ -595,9 +600,9 @@ intLiteral :: Int -> HaskellCode
 intLiteral n =
   String.fromString (show n)
 
-caseMatch :: ConstructorName -> HaskellCode -> HaskellCode
-caseMatch constructor body =
-  toCode constructor <> " -> " <> body
+caseMatch :: HaskellCode -> HaskellCode -> HaskellCode
+caseMatch _case output =
+  _case <> " -> " <> output
 
 eqClass :: TypeName
 eqClass =

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AstronomicalObjectType.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AstronomicalObjectType.hs
@@ -4,11 +4,13 @@ module StarTrek.Types.AstronomicalObjectType
   ( AstronomicalObjectType(..)
   , astronomicalObjectTypeSchema
   , astronomicalObjectTypeToText
+  , astronomicalObjectTypeFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data AstronomicalObjectType
   = PLANET
@@ -71,6 +73,38 @@ astronomicalObjectTypeToText v =
       STARSYSTEM -> "STAR_SYSTEM"
       SECTOR -> "SECTOR"
       REGION -> "REGION"
+
+astronomicalObjectTypeFromText :: T.Text -> Either String AstronomicalObjectType
+astronomicalObjectTypeFromText txt =
+  case T.unpack txt of
+    "PLANET" -> Either.Right PLANET
+    "D_CLASS_PLANET" -> Either.Right DCLASSPLANET
+    "H_CLASS_PLANET" -> Either.Right HCLASSPLANET
+    "GAS_GIANT_PLANET" -> Either.Right GASGIANTPLANET
+    "K_CLASS_PLANET" -> Either.Right KCLASSPLANET
+    "L_CLASS_PLANET" -> Either.Right LCLASSPLANET
+    "M_CLASS_PLANET" -> Either.Right MCLASSPLANET
+    "Y_CLASS_PLANET" -> Either.Right YCLASSPLANET
+    "ROGUE_PLANET" -> Either.Right ROGUEPLANET
+    "ARTIFICIAL_PLANET" -> Either.Right ARTIFICIALPLANET
+    "ASTEROID" -> Either.Right ASTEROID
+    "ASTEROIDAL_MOON" -> Either.Right ASTEROIDALMOON
+    "ASTEROID_BELT" -> Either.Right ASTEROIDBELT
+    "CLUSTER" -> Either.Right CLUSTER
+    "COMET" -> Either.Right COMET
+    "CONSTELLATION" -> Either.Right CONSTELLATION
+    "GALAXY" -> Either.Right GALAXY
+    "MOON" -> Either.Right MOON
+    "M_CLASS_MOON" -> Either.Right MCLASSMOON
+    "NEBULA" -> Either.Right NEBULA
+    "PLANETOID" -> Either.Right PLANETOID
+    "D_CLASS_PLANETOID" -> Either.Right DCLASSPLANETOID
+    "QUASAR" -> Either.Right QUASAR
+    "STAR" -> Either.Right STAR
+    "STAR_SYSTEM" -> Either.Right STARSYSTEM
+    "SECTOR" -> Either.Right SECTOR
+    "REGION" -> Either.Right REGION
+    v -> Either.Left $ "Unknown AstronomicalObjectType: " <> v
 
 astronomicalObjectTypeSchema :: FC.Fleece t => FC.Schema t AstronomicalObjectType
 astronomicalObjectTypeSchema =

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AstronomicalObjectType.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/AstronomicalObjectType.hs
@@ -10,7 +10,7 @@ module StarTrek.Types.AstronomicalObjectType
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data AstronomicalObjectType
   = PLANET
@@ -74,7 +74,7 @@ astronomicalObjectTypeToText v =
       SECTOR -> "SECTOR"
       REGION -> "REGION"
 
-astronomicalObjectTypeFromText :: T.Text -> Either String AstronomicalObjectType
+astronomicalObjectTypeFromText :: T.Text -> Either.Either String AstronomicalObjectType
 astronomicalObjectTypeFromText txt =
   case T.unpack txt of
     "PLANET" -> Either.Right PLANET

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BloodType.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BloodType.hs
@@ -10,7 +10,7 @@ module StarTrek.Types.BloodType
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data BloodType
   = BNEGATIVE
@@ -26,7 +26,7 @@ bloodTypeToText v =
       ONEGATIVE -> "O_NEGATIVE"
       TNEGATIVE -> "T_NEGATIVE"
 
-bloodTypeFromText :: T.Text -> Either String BloodType
+bloodTypeFromText :: T.Text -> Either.Either String BloodType
 bloodTypeFromText txt =
   case T.unpack txt of
     "B_NEGATIVE" -> Either.Right BNEGATIVE

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BloodType.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/BloodType.hs
@@ -4,11 +4,13 @@ module StarTrek.Types.BloodType
   ( BloodType(..)
   , bloodTypeSchema
   , bloodTypeToText
+  , bloodTypeFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data BloodType
   = BNEGATIVE
@@ -23,6 +25,14 @@ bloodTypeToText v =
       BNEGATIVE -> "B_NEGATIVE"
       ONEGATIVE -> "O_NEGATIVE"
       TNEGATIVE -> "T_NEGATIVE"
+
+bloodTypeFromText :: T.Text -> Either String BloodType
+bloodTypeFromText txt =
+  case T.unpack txt of
+    "B_NEGATIVE" -> Either.Right BNEGATIVE
+    "O_NEGATIVE" -> Either.Right ONEGATIVE
+    "T_NEGATIVE" -> Either.Right TNEGATIVE
+    v -> Either.Left $ "Unknown BloodType: " <> v
 
 bloodTypeSchema :: FC.Fleece t => FC.Schema t BloodType
 bloodTypeSchema =

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ContentRatingSystem.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ContentRatingSystem.hs
@@ -10,7 +10,7 @@ module StarTrek.Types.ContentRatingSystem
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data ContentRatingSystem
   = BBFC
@@ -72,7 +72,7 @@ contentRatingSystemToText v =
       GSRR -> "GSRR"
       ITUNES -> "ITUNES"
 
-contentRatingSystemFromText :: T.Text -> Either String ContentRatingSystem
+contentRatingSystemFromText :: T.Text -> Either.Either String ContentRatingSystem
 contentRatingSystemFromText txt =
   case T.unpack txt of
     "BBFC" -> Either.Right BBFC

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ContentRatingSystem.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ContentRatingSystem.hs
@@ -4,11 +4,13 @@ module StarTrek.Types.ContentRatingSystem
   ( ContentRatingSystem(..)
   , contentRatingSystemSchema
   , contentRatingSystemToText
+  , contentRatingSystemFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data ContentRatingSystem
   = BBFC
@@ -69,6 +71,37 @@ contentRatingSystemToText v =
       ADESE -> "ADESE"
       GSRR -> "GSRR"
       ITUNES -> "ITUNES"
+
+contentRatingSystemFromText :: T.Text -> Either String ContentRatingSystem
+contentRatingSystemFromText txt =
+  case T.unpack txt of
+    "BBFC" -> Either.Right BBFC
+    "OFLC" -> Either.Right OFLC
+    "OFLCNZ" -> Either.Right OFLCNZ
+    "DJCTQ" -> Either.Right DJCTQ
+    "MDA" -> Either.Right MDA
+    "MPAA" -> Either.Right MPAA
+    "CHVRS" -> Either.Right CHVRS
+    "RCQ" -> Either.Right RCQ
+    "IFCO" -> Either.Right IFCO
+    "FSK" -> Either.Right FSK
+    "NICAM" -> Either.Right NICAM
+    "MCCYP" -> Either.Right MCCYP
+    "EIRIN" -> Either.Right EIRIN
+    "HK" -> Either.Right HK
+    "CBFC" -> Either.Right CBFC
+    "NMHH" -> Either.Right NMHH
+    "VRC" -> Either.Right VRC
+    "RSAC" -> Either.Right RSAC
+    "ESRB" -> Either.Right ESRB
+    "ELSPA" -> Either.Right ELSPA
+    "PEGI" -> Either.Right PEGI
+    "USK" -> Either.Right USK
+    "SELL" -> Either.Right SELL
+    "ADESE" -> Either.Right ADESE
+    "GSRR" -> Either.Right GSRR
+    "ITUNES" -> Either.Right ITUNES
+    v -> Either.Left $ "Unknown ContentRatingSystem: " <> v
 
 contentRatingSystemSchema :: FC.Fleece t => FC.Schema t ContentRatingSystem
 contentRatingSystemSchema =

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Gender.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Gender.hs
@@ -10,7 +10,7 @@ module StarTrek.Types.Gender
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data Gender
   = F
@@ -24,7 +24,7 @@ genderToText v =
       F -> "F"
       M -> "M"
 
-genderFromText :: T.Text -> Either String Gender
+genderFromText :: T.Text -> Either.Either String Gender
 genderFromText txt =
   case T.unpack txt of
     "F" -> Either.Right F

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Gender.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/Gender.hs
@@ -4,11 +4,13 @@ module StarTrek.Types.Gender
   ( Gender(..)
   , genderSchema
   , genderToText
+  , genderFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data Gender
   = F
@@ -21,6 +23,13 @@ genderToText v =
     case v of
       F -> "F"
       M -> "M"
+
+genderFromText :: T.Text -> Either String Gender
+genderFromText txt =
+  case T.unpack txt of
+    "F" -> Either.Right F
+    "M" -> Either.Right M
+    v -> Either.Left $ "Unknown Gender: " <> v
 
 genderSchema :: FC.Fleece t => FC.Schema t Gender
 genderSchema =

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaritalStatus.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaritalStatus.hs
@@ -4,11 +4,13 @@ module StarTrek.Types.MaritalStatus
   ( MaritalStatus(..)
   , maritalStatusSchema
   , maritalStatusToText
+  , maritalStatusFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data MaritalStatus
   = SINGLE
@@ -33,6 +35,19 @@ maritalStatusToText v =
       SEPARATED -> "SEPARATED"
       WIDOWED -> "WIDOWED"
       CAPTAINSWOMAN -> "CAPTAINS_WOMAN"
+
+maritalStatusFromText :: T.Text -> Either String MaritalStatus
+maritalStatusFromText txt =
+  case T.unpack txt of
+    "SINGLE" -> Either.Right SINGLE
+    "ENGAGED" -> Either.Right ENGAGED
+    "MARRIED" -> Either.Right MARRIED
+    "DIVORCED" -> Either.Right DIVORCED
+    "REMARRIED" -> Either.Right REMARRIED
+    "SEPARATED" -> Either.Right SEPARATED
+    "WIDOWED" -> Either.Right WIDOWED
+    "CAPTAINS_WOMAN" -> Either.Right CAPTAINSWOMAN
+    v -> Either.Left $ "Unknown MaritalStatus: " <> v
 
 maritalStatusSchema :: FC.Fleece t => FC.Schema t MaritalStatus
 maritalStatusSchema =

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaritalStatus.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/MaritalStatus.hs
@@ -10,7 +10,7 @@ module StarTrek.Types.MaritalStatus
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data MaritalStatus
   = SINGLE
@@ -36,7 +36,7 @@ maritalStatusToText v =
       WIDOWED -> "WIDOWED"
       CAPTAINSWOMAN -> "CAPTAINS_WOMAN"
 
-maritalStatusFromText :: T.Text -> Either String MaritalStatus
+maritalStatusFromText :: T.Text -> Either.Either String MaritalStatus
 maritalStatusFromText txt =
   case T.unpack txt of
     "SINGLE" -> Either.Right SINGLE

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ProductionRunUnit.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ProductionRunUnit.hs
@@ -4,11 +4,13 @@ module StarTrek.Types.ProductionRunUnit
   ( ProductionRunUnit(..)
   , productionRunUnitSchema
   , productionRunUnitToText
+  , productionRunUnitFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data ProductionRunUnit
   = BOX
@@ -21,6 +23,13 @@ productionRunUnitToText v =
     case v of
       BOX -> "BOX"
       SET -> "SET"
+
+productionRunUnitFromText :: T.Text -> Either String ProductionRunUnit
+productionRunUnitFromText txt =
+  case T.unpack txt of
+    "BOX" -> Either.Right BOX
+    "SET" -> Either.Right SET
+    v -> Either.Left $ "Unknown ProductionRunUnit: " <> v
 
 productionRunUnitSchema :: FC.Fleece t => FC.Schema t ProductionRunUnit
 productionRunUnitSchema =

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ProductionRunUnit.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ProductionRunUnit.hs
@@ -10,7 +10,7 @@ module StarTrek.Types.ProductionRunUnit
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data ProductionRunUnit
   = BOX
@@ -24,7 +24,7 @@ productionRunUnitToText v =
       BOX -> "BOX"
       SET -> "SET"
 
-productionRunUnitFromText :: T.Text -> Either String ProductionRunUnit
+productionRunUnitFromText :: T.Text -> Either.Either String ProductionRunUnit
 productionRunUnitFromText txt =
   case T.unpack txt of
     "BOX" -> Either.Right BOX

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ReferenceType.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ReferenceType.hs
@@ -4,11 +4,13 @@ module StarTrek.Types.ReferenceType
   ( ReferenceType(..)
   , referenceTypeSchema
   , referenceTypeToText
+  , referenceTypeFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data ReferenceType
   = ASIN
@@ -21,6 +23,13 @@ referenceTypeToText v =
     case v of
       ASIN -> "ASIN"
       ISBN -> "ISBN"
+
+referenceTypeFromText :: T.Text -> Either String ReferenceType
+referenceTypeFromText txt =
+  case T.unpack txt of
+    "ASIN" -> Either.Right ASIN
+    "ISBN" -> Either.Right ISBN
+    v -> Either.Left $ "Unknown ReferenceType: " <> v
 
 referenceTypeSchema :: FC.Fleece t => FC.Schema t ReferenceType
 referenceTypeSchema =

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ReferenceType.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ReferenceType.hs
@@ -10,7 +10,7 @@ module StarTrek.Types.ReferenceType
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data ReferenceType
   = ASIN
@@ -24,7 +24,7 @@ referenceTypeToText v =
       ASIN -> "ASIN"
       ISBN -> "ISBN"
 
-referenceTypeFromText :: T.Text -> Either String ReferenceType
+referenceTypeFromText :: T.Text -> Either.Either String ReferenceType
 referenceTypeFromText txt =
   case T.unpack txt of
     "ASIN" -> Either.Right ASIN

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ResponseSortDirection.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ResponseSortDirection.hs
@@ -10,7 +10,7 @@ module StarTrek.Types.ResponseSortDirection
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data ResponseSortDirection
   = ASC
@@ -24,7 +24,7 @@ responseSortDirectionToText v =
       ASC -> "ASC"
       DESC -> "DESC"
 
-responseSortDirectionFromText :: T.Text -> Either String ResponseSortDirection
+responseSortDirectionFromText :: T.Text -> Either.Either String ResponseSortDirection
 responseSortDirectionFromText txt =
   case T.unpack txt of
     "ASC" -> Either.Right ASC

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ResponseSortDirection.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/ResponseSortDirection.hs
@@ -4,11 +4,13 @@ module StarTrek.Types.ResponseSortDirection
   ( ResponseSortDirection(..)
   , responseSortDirectionSchema
   , responseSortDirectionToText
+  , responseSortDirectionFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data ResponseSortDirection
   = ASC
@@ -21,6 +23,13 @@ responseSortDirectionToText v =
     case v of
       ASC -> "ASC"
       DESC -> "DESC"
+
+responseSortDirectionFromText :: T.Text -> Either String ResponseSortDirection
+responseSortDirectionFromText txt =
+  case T.unpack txt of
+    "ASC" -> Either.Right ASC
+    "DESC" -> Either.Right DESC
+    v -> Either.Left $ "Unknown ResponseSortDirection: " <> v
 
 responseSortDirectionSchema :: FC.Fleece t => FC.Schema t ResponseSortDirection
 responseSortDirectionSchema =

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoReleaseFormat.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoReleaseFormat.hs
@@ -4,11 +4,13 @@ module StarTrek.Types.VideoReleaseFormat
   ( VideoReleaseFormat(..)
   , videoReleaseFormatSchema
   , videoReleaseFormatToText
+  , videoReleaseFormatFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data VideoReleaseFormat
   = SUPER8
@@ -45,6 +47,25 @@ videoReleaseFormatToText v =
       BLURAY -> "BLU_RAY"
       BLURAY4KUHD -> "BLU_RAY_4K_UHD"
       DIGITALFORMAT -> "DIGITAL_FORMAT"
+
+videoReleaseFormatFromText :: T.Text -> Either String VideoReleaseFormat
+videoReleaseFormatFromText txt =
+  case T.unpack txt of
+    "SUPER_8" -> Either.Right SUPER8
+    "BETAMAX" -> Either.Right BETAMAX
+    "VHS" -> Either.Right VHS
+    "CED" -> Either.Right CED
+    "LD" -> Either.Right LD
+    "VHD" -> Either.Right VHD
+    "VCD" -> Either.Right VCD
+    "VIDEO_8" -> Either.Right VIDEO8
+    "DVD" -> Either.Right DVD
+    "UMD" -> Either.Right UMD
+    "HD_DVD" -> Either.Right HDDVD
+    "BLU_RAY" -> Either.Right BLURAY
+    "BLU_RAY_4K_UHD" -> Either.Right BLURAY4KUHD
+    "DIGITAL_FORMAT" -> Either.Right DIGITALFORMAT
+    v -> Either.Left $ "Unknown VideoReleaseFormat: " <> v
 
 videoReleaseFormatSchema :: FC.Fleece t => FC.Schema t VideoReleaseFormat
 videoReleaseFormatSchema =

--- a/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoReleaseFormat.hs
+++ b/json-fleece-openapi3/examples/star-trek/StarTrek/Types/VideoReleaseFormat.hs
@@ -10,7 +10,7 @@ module StarTrek.Types.VideoReleaseFormat
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data VideoReleaseFormat
   = SUPER8
@@ -48,7 +48,7 @@ videoReleaseFormatToText v =
       BLURAY4KUHD -> "BLU_RAY_4K_UHD"
       DIGITALFORMAT -> "DIGITAL_FORMAT"
 
-videoReleaseFormatFromText :: T.Text -> Either String VideoReleaseFormat
+videoReleaseFormatFromText :: T.Text -> Either.Either String VideoReleaseFormat
 videoReleaseFormatFromText txt =
   case T.unpack txt of
     "SUPER_8" -> Either.Right SUPER8

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/InlineAllofParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/InlineAllofParam.hs
@@ -4,13 +4,15 @@
 module TestCases.Operations.InlineAllOf.InlineAllofParam
   ( InlineAllofParam(..)
   , inlineAllofParamToText
+  , inlineAllofParamFromText
   , paramDef
   ) where
 
 import qualified Beeline.Params as P
 import qualified Beeline.Routing as R
+import qualified Data.Either as Either
 import qualified Data.Text as T
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data InlineAllofParam
   = InlineAllofParam100
@@ -27,6 +29,15 @@ inlineAllofParamToText v =
       InlineAllofParam200 -> "200"
       InlineAllofParam300 -> "300"
       Green -> "Green"
+
+inlineAllofParamFromText :: T.Text -> Either String InlineAllofParam
+inlineAllofParamFromText txt =
+  case T.unpack txt of
+    "100" -> Either.Right InlineAllofParam100
+    "200" -> Either.Right InlineAllofParam200
+    "300" -> Either.Right InlineAllofParam300
+    "Green" -> Either.Right Green
+    v -> Either.Left $ "Unknown InlineAllofParam: " <> v
 
 paramDef :: R.ParameterDefinition InlineAllofParam
 paramDef =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/InlineAllofParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/InlineAllofParam.hs
@@ -12,7 +12,7 @@ import qualified Beeline.Params as P
 import qualified Beeline.Routing as R
 import qualified Data.Either as Either
 import qualified Data.Text as T
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data InlineAllofParam
   = InlineAllofParam100
@@ -30,7 +30,7 @@ inlineAllofParamToText v =
       InlineAllofParam300 -> "300"
       Green -> "Green"
 
-inlineAllofParamFromText :: T.Text -> Either String InlineAllofParam
+inlineAllofParamFromText :: T.Text -> Either.Either String InlineAllofParam
 inlineAllofParamFromText txt =
   case T.unpack txt of
     "100" -> Either.Right InlineAllofParam100

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/RequestBody/FieldE.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/RequestBody/FieldE.hs
@@ -4,11 +4,13 @@ module TestCases.Operations.InlineAllOf.RequestBody.FieldE
   ( FieldE(..)
   , fieldESchema
   , fieldEToText
+  , fieldEFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data FieldE
   = Enum1
@@ -23,6 +25,14 @@ fieldEToText v =
       Enum1 -> "enum1"
       Enum2 -> "enum2"
       Enum3 -> "enum3"
+
+fieldEFromText :: T.Text -> Either String FieldE
+fieldEFromText txt =
+  case T.unpack txt of
+    "enum1" -> Either.Right Enum1
+    "enum2" -> Either.Right Enum2
+    "enum3" -> Either.Right Enum3
+    v -> Either.Left $ "Unknown FieldE: " <> v
 
 fieldESchema :: FC.Fleece t => FC.Schema t FieldE
 fieldESchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/RequestBody/FieldE.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/RequestBody/FieldE.hs
@@ -10,7 +10,7 @@ module TestCases.Operations.InlineAllOf.RequestBody.FieldE
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data FieldE
   = Enum1
@@ -26,7 +26,7 @@ fieldEToText v =
       Enum2 -> "enum2"
       Enum3 -> "enum3"
 
-fieldEFromText :: T.Text -> Either String FieldE
+fieldEFromText :: T.Text -> Either.Either String FieldE
 fieldEFromText txt =
   case T.unpack txt of
     "enum1" -> Either.Right Enum1

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/Response200Body/FieldE.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/Response200Body/FieldE.hs
@@ -4,11 +4,13 @@ module TestCases.Operations.InlineAllOf.Response200Body.FieldE
   ( FieldE(..)
   , fieldESchema
   , fieldEToText
+  , fieldEFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data FieldE
   = Enum1
@@ -23,6 +25,14 @@ fieldEToText v =
       Enum1 -> "enum1"
       Enum2 -> "enum2"
       Enum3 -> "enum3"
+
+fieldEFromText :: T.Text -> Either String FieldE
+fieldEFromText txt =
+  case T.unpack txt of
+    "enum1" -> Either.Right Enum1
+    "enum2" -> Either.Right Enum2
+    "enum3" -> Either.Right Enum3
+    v -> Either.Left $ "Unknown FieldE: " <> v
 
 fieldESchema :: FC.Fleece t => FC.Schema t FieldE
 fieldESchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/Response200Body/FieldE.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/InlineAllOf/Response200Body/FieldE.hs
@@ -10,7 +10,7 @@ module TestCases.Operations.InlineAllOf.Response200Body.FieldE
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data FieldE
   = Enum1
@@ -26,7 +26,7 @@ fieldEToText v =
       Enum2 -> "enum2"
       Enum3 -> "enum3"
 
-fieldEFromText :: T.Text -> Either String FieldE
+fieldEFromText :: T.Text -> Either.Either String FieldE
 fieldEFromText txt =
   case T.unpack txt of
     "enum1" -> Either.Right Enum1

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/OneOfWithInlineEnum/Option1.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/OneOfWithInlineEnum/Option1.hs
@@ -10,7 +10,7 @@ module TestCases.Operations.OneOfWithInlineEnum.Option1
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data Option1
   = One
@@ -26,7 +26,7 @@ option1ToText v =
       Two -> "two"
       Three -> "three"
 
-option1FromText :: T.Text -> Either String Option1
+option1FromText :: T.Text -> Either.Either String Option1
 option1FromText txt =
   case T.unpack txt of
     "one" -> Either.Right One

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/OneOfWithInlineEnum/Option1.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/OneOfWithInlineEnum/Option1.hs
@@ -4,11 +4,13 @@ module TestCases.Operations.OneOfWithInlineEnum.Option1
   ( Option1(..)
   , option1Schema
   , option1ToText
+  , option1FromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data Option1
   = One
@@ -23,6 +25,14 @@ option1ToText v =
       One -> "one"
       Two -> "two"
       Three -> "three"
+
+option1FromText :: T.Text -> Either String Option1
+option1FromText txt =
+  case T.unpack txt of
+    "one" -> Either.Right One
+    "two" -> Either.Right Two
+    "three" -> Either.Right Three
+    v -> Either.Left $ "Unknown Option1: " <> v
 
 option1Schema :: FC.Fleece t => FC.Schema t Option1
 option1Schema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/OneOfWithInlineEnum/Option2.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/OneOfWithInlineEnum/Option2.hs
@@ -4,11 +4,13 @@ module TestCases.Operations.OneOfWithInlineEnum.Option2
   ( Option2(..)
   , option2Schema
   , option2ToText
+  , option2FromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data Option2
   = Uno
@@ -23,6 +25,14 @@ option2ToText v =
       Uno -> "uno"
       Dos -> "dos"
       Tres -> "tres"
+
+option2FromText :: T.Text -> Either String Option2
+option2FromText txt =
+  case T.unpack txt of
+    "uno" -> Either.Right Uno
+    "dos" -> Either.Right Dos
+    "tres" -> Either.Right Tres
+    v -> Either.Left $ "Unknown Option2: " <> v
 
 option2Schema :: FC.Fleece t => FC.Schema t Option2
 option2Schema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/OneOfWithInlineEnum/Option2.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/OneOfWithInlineEnum/Option2.hs
@@ -10,7 +10,7 @@ module TestCases.Operations.OneOfWithInlineEnum.Option2
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data Option2
   = Uno
@@ -26,7 +26,7 @@ option2ToText v =
       Dos -> "dos"
       Tres -> "tres"
 
-option2FromText :: T.Text -> Either String Option2
+option2FromText :: T.Text -> Either.Either String Option2
 option2FromText txt =
   case T.unpack txt of
     "uno" -> Either.Right Uno

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumIntParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumIntParam.hs
@@ -4,13 +4,15 @@
 module TestCases.Operations.TestCases.HeaderParams.InlineEnumIntParam
   ( InlineEnumIntParam(..)
   , inlineEnumIntParamToText
+  , inlineEnumIntParamFromText
   , paramDef
   ) where
 
 import qualified Beeline.Params as P
 import qualified Beeline.Routing as R
+import qualified Data.Either as Either
 import qualified Data.Text as T
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data InlineEnumIntParam
   = InlineEnumIntParam10
@@ -25,6 +27,14 @@ inlineEnumIntParamToText v =
       InlineEnumIntParam10 -> "10"
       InlineEnumIntParam20 -> "20"
       InlineEnumIntParam30 -> "30"
+
+inlineEnumIntParamFromText :: T.Text -> Either String InlineEnumIntParam
+inlineEnumIntParamFromText txt =
+  case T.unpack txt of
+    "10" -> Either.Right InlineEnumIntParam10
+    "20" -> Either.Right InlineEnumIntParam20
+    "30" -> Either.Right InlineEnumIntParam30
+    v -> Either.Left $ "Unknown InlineEnumIntParam: " <> v
 
 paramDef :: R.ParameterDefinition InlineEnumIntParam
 paramDef =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumIntParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumIntParam.hs
@@ -12,7 +12,7 @@ import qualified Beeline.Params as P
 import qualified Beeline.Routing as R
 import qualified Data.Either as Either
 import qualified Data.Text as T
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data InlineEnumIntParam
   = InlineEnumIntParam10
@@ -28,7 +28,7 @@ inlineEnumIntParamToText v =
       InlineEnumIntParam20 -> "20"
       InlineEnumIntParam30 -> "30"
 
-inlineEnumIntParamFromText :: T.Text -> Either String InlineEnumIntParam
+inlineEnumIntParamFromText :: T.Text -> Either.Either String InlineEnumIntParam
 inlineEnumIntParamFromText txt =
   case T.unpack txt of
     "10" -> Either.Right InlineEnumIntParam10

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumParam.hs
@@ -12,7 +12,7 @@ import qualified Beeline.Params as P
 import qualified Beeline.Routing as R
 import qualified Data.Either as Either
 import qualified Data.Text as T
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data InlineEnumParam
   = Baz
@@ -28,7 +28,7 @@ inlineEnumParamToText v =
       Bat -> "bat"
       Bax -> "bax"
 
-inlineEnumParamFromText :: T.Text -> Either String InlineEnumParam
+inlineEnumParamFromText :: T.Text -> Either.Either String InlineEnumParam
 inlineEnumParamFromText txt =
   case T.unpack txt of
     "baz" -> Either.Right Baz

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/HeaderParams/InlineEnumParam.hs
@@ -4,13 +4,15 @@
 module TestCases.Operations.TestCases.HeaderParams.InlineEnumParam
   ( InlineEnumParam(..)
   , inlineEnumParamToText
+  , inlineEnumParamFromText
   , paramDef
   ) where
 
 import qualified Beeline.Params as P
 import qualified Beeline.Routing as R
+import qualified Data.Either as Either
 import qualified Data.Text as T
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data InlineEnumParam
   = Baz
@@ -25,6 +27,14 @@ inlineEnumParamToText v =
       Baz -> "baz"
       Bat -> "bat"
       Bax -> "bax"
+
+inlineEnumParamFromText :: T.Text -> Either String InlineEnumParam
+inlineEnumParamFromText txt =
+  case T.unpack txt of
+    "baz" -> Either.Right Baz
+    "bat" -> Either.Right Bat
+    "bax" -> Either.Right Bax
+    v -> Either.Left $ "Unknown InlineEnumParam: " <> v
 
 paramDef :: R.ParameterDefinition InlineEnumParam
 paramDef =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumArrayRequestBody/RequestBodyItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumArrayRequestBody/RequestBodyItem.hs
@@ -10,7 +10,7 @@ module TestCases.Operations.TestCases.InlineEnumArrayRequestBody.RequestBodyItem
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data RequestBodyItem
   = Foo
@@ -26,7 +26,7 @@ requestBodyItemToText v =
       Bar -> "bar"
       Baz -> "baz"
 
-requestBodyItemFromText :: T.Text -> Either String RequestBodyItem
+requestBodyItemFromText :: T.Text -> Either.Either String RequestBodyItem
 requestBodyItemFromText txt =
   case T.unpack txt of
     "foo" -> Either.Right Foo

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumArrayRequestBody/RequestBodyItem.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumArrayRequestBody/RequestBodyItem.hs
@@ -4,11 +4,13 @@ module TestCases.Operations.TestCases.InlineEnumArrayRequestBody.RequestBodyItem
   ( RequestBodyItem(..)
   , requestBodyItemSchema
   , requestBodyItemToText
+  , requestBodyItemFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data RequestBodyItem
   = Foo
@@ -23,6 +25,14 @@ requestBodyItemToText v =
       Foo -> "foo"
       Bar -> "bar"
       Baz -> "baz"
+
+requestBodyItemFromText :: T.Text -> Either String RequestBodyItem
+requestBodyItemFromText txt =
+  case T.unpack txt of
+    "foo" -> Either.Right Foo
+    "bar" -> Either.Right Bar
+    "baz" -> Either.Right Baz
+    v -> Either.Left $ "Unknown RequestBodyItem: " <> v
 
 requestBodyItemSchema :: FC.Fleece t => FC.Schema t RequestBodyItem
 requestBodyItemSchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumResponses/Response200Body.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumResponses/Response200Body.hs
@@ -10,7 +10,7 @@ module TestCases.Operations.TestCases.InlineEnumResponses.Response200Body
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data Response200Body
   = Foo
@@ -24,7 +24,7 @@ response200BodyToText v =
       Foo -> "foo"
       Bar -> "bar"
 
-response200BodyFromText :: T.Text -> Either String Response200Body
+response200BodyFromText :: T.Text -> Either.Either String Response200Body
 response200BodyFromText txt =
   case T.unpack txt of
     "foo" -> Either.Right Foo

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumResponses/Response200Body.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumResponses/Response200Body.hs
@@ -4,11 +4,13 @@ module TestCases.Operations.TestCases.InlineEnumResponses.Response200Body
   ( Response200Body(..)
   , response200BodySchema
   , response200BodyToText
+  , response200BodyFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data Response200Body
   = Foo
@@ -21,6 +23,13 @@ response200BodyToText v =
     case v of
       Foo -> "foo"
       Bar -> "bar"
+
+response200BodyFromText :: T.Text -> Either String Response200Body
+response200BodyFromText txt =
+  case T.unpack txt of
+    "foo" -> Either.Right Foo
+    "bar" -> Either.Right Bar
+    v -> Either.Left $ "Unknown Response200Body: " <> v
 
 response200BodySchema :: FC.Fleece t => FC.Schema t Response200Body
 response200BodySchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumResponses/Response201Body.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumResponses/Response201Body.hs
@@ -10,7 +10,7 @@ module TestCases.Operations.TestCases.InlineEnumResponses.Response201Body
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data Response201Body
   = Baz
@@ -24,7 +24,7 @@ response201BodyToText v =
       Baz -> "baz"
       Bat -> "bat"
 
-response201BodyFromText :: T.Text -> Either String Response201Body
+response201BodyFromText :: T.Text -> Either.Either String Response201Body
 response201BodyFromText txt =
   case T.unpack txt of
     "baz" -> Either.Right Baz

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumResponses/Response201Body.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/InlineEnumResponses/Response201Body.hs
@@ -4,11 +4,13 @@ module TestCases.Operations.TestCases.InlineEnumResponses.Response201Body
   ( Response201Body(..)
   , response201BodySchema
   , response201BodyToText
+  , response201BodyFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data Response201Body
   = Baz
@@ -21,6 +23,13 @@ response201BodyToText v =
     case v of
       Baz -> "baz"
       Bat -> "bat"
+
+response201BodyFromText :: T.Text -> Either String Response201Body
+response201BodyFromText txt =
+  case T.unpack txt of
+    "baz" -> Either.Right Baz
+    "bat" -> Either.Right Bat
+    v -> Either.Left $ "Unknown Response201Body: " <> v
 
 response201BodySchema :: FC.Fleece t => FC.Schema t Response201Body
 response201BodySchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumIntParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumIntParam.hs
@@ -12,7 +12,7 @@ import qualified Beeline.Params as P
 import qualified Beeline.Routing as R
 import qualified Data.Either as Either
 import qualified Data.Text as T
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data InlineEnumIntParam
   = InlineEnumIntParam10
@@ -28,7 +28,7 @@ inlineEnumIntParamToText v =
       InlineEnumIntParam20 -> "20"
       InlineEnumIntParam30 -> "30"
 
-inlineEnumIntParamFromText :: T.Text -> Either String InlineEnumIntParam
+inlineEnumIntParamFromText :: T.Text -> Either.Either String InlineEnumIntParam
 inlineEnumIntParamFromText txt =
   case T.unpack txt of
     "10" -> Either.Right InlineEnumIntParam10

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumIntParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumIntParam.hs
@@ -4,13 +4,15 @@
 module TestCases.Operations.TestCases.QueryParams.InlineEnumIntParam
   ( InlineEnumIntParam(..)
   , inlineEnumIntParamToText
+  , inlineEnumIntParamFromText
   , paramDef
   ) where
 
 import qualified Beeline.Params as P
 import qualified Beeline.Routing as R
+import qualified Data.Either as Either
 import qualified Data.Text as T
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data InlineEnumIntParam
   = InlineEnumIntParam10
@@ -25,6 +27,14 @@ inlineEnumIntParamToText v =
       InlineEnumIntParam10 -> "10"
       InlineEnumIntParam20 -> "20"
       InlineEnumIntParam30 -> "30"
+
+inlineEnumIntParamFromText :: T.Text -> Either String InlineEnumIntParam
+inlineEnumIntParamFromText txt =
+  case T.unpack txt of
+    "10" -> Either.Right InlineEnumIntParam10
+    "20" -> Either.Right InlineEnumIntParam20
+    "30" -> Either.Right InlineEnumIntParam30
+    v -> Either.Left $ "Unknown InlineEnumIntParam: " <> v
 
 paramDef :: R.ParameterDefinition InlineEnumIntParam
 paramDef =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumParam.hs
@@ -12,7 +12,7 @@ import qualified Beeline.Params as P
 import qualified Beeline.Routing as R
 import qualified Data.Either as Either
 import qualified Data.Text as T
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data InlineEnumParam
   = Baz
@@ -28,7 +28,7 @@ inlineEnumParamToText v =
       Bat -> "bat"
       Bax -> "bax"
 
-inlineEnumParamFromText :: T.Text -> Either String InlineEnumParam
+inlineEnumParamFromText :: T.Text -> Either.Either String InlineEnumParam
 inlineEnumParamFromText txt =
   case T.unpack txt of
     "baz" -> Either.Right Baz

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Operations/TestCases/QueryParams/InlineEnumParam.hs
@@ -4,13 +4,15 @@
 module TestCases.Operations.TestCases.QueryParams.InlineEnumParam
   ( InlineEnumParam(..)
   , inlineEnumParamToText
+  , inlineEnumParamFromText
   , paramDef
   ) where
 
 import qualified Beeline.Params as P
 import qualified Beeline.Routing as R
+import qualified Data.Either as Either
 import qualified Data.Text as T
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data InlineEnumParam
   = Baz
@@ -25,6 +27,14 @@ inlineEnumParamToText v =
       Baz -> "baz"
       Bat -> "bat"
       Bax -> "bax"
+
+inlineEnumParamFromText :: T.Text -> Either String InlineEnumParam
+inlineEnumParamFromText txt =
+  case T.unpack txt of
+    "baz" -> Either.Right Baz
+    "bat" -> Either.Right Bat
+    "bax" -> Either.Right Bax
+    v -> Either.Left $ "Unknown InlineEnumParam: " <> v
 
 paramDef :: R.ParameterDefinition InlineEnumParam
 paramDef =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfFieldsEthroughG/FieldE.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfFieldsEthroughG/FieldE.hs
@@ -10,7 +10,7 @@ module TestCases.Types.AllOfFieldsEthroughG.FieldE
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data FieldE
   = Enum1
@@ -24,7 +24,7 @@ fieldEToText v =
       Enum1 -> "enum1"
       Enum3 -> "enum3"
 
-fieldEFromText :: T.Text -> Either String FieldE
+fieldEFromText :: T.Text -> Either.Either String FieldE
 fieldEFromText txt =
   case T.unpack txt of
     "enum1" -> Either.Right Enum1

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfFieldsEthroughG/FieldE.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfFieldsEthroughG/FieldE.hs
@@ -4,11 +4,13 @@ module TestCases.Types.AllOfFieldsEthroughG.FieldE
   ( FieldE(..)
   , fieldESchema
   , fieldEToText
+  , fieldEFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data FieldE
   = Enum1
@@ -21,6 +23,13 @@ fieldEToText v =
     case v of
       Enum1 -> "enum1"
       Enum3 -> "enum3"
+
+fieldEFromText :: T.Text -> Either String FieldE
+fieldEFromText txt =
+  case T.unpack txt of
+    "enum1" -> Either.Right Enum1
+    "enum3" -> Either.Right Enum3
+    v -> Either.Left $ "Unknown FieldE: " <> v
 
 fieldESchema :: FC.Fleece t => FC.Schema t FieldE
 fieldESchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfFieldsHthroughK/FieldI/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfFieldsHthroughK/FieldI/DatetimeType.hs
@@ -10,7 +10,7 @@ module TestCases.Types.AllOfFieldsHthroughK.FieldI.DatetimeType
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -22,7 +22,7 @@ datetimeTypeToText v =
     case v of
       UtcDatetime -> "utc_datetime"
 
-datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText :: T.Text -> Either.Either String DatetimeType
 datetimeTypeFromText txt =
   case T.unpack txt of
     "utc_datetime" -> Either.Right UtcDatetime

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfFieldsHthroughK/FieldI/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfFieldsHthroughK/FieldI/DatetimeType.hs
@@ -4,11 +4,13 @@ module TestCases.Types.AllOfFieldsHthroughK.FieldI.DatetimeType
   ( DatetimeType(..)
   , datetimeTypeSchema
   , datetimeTypeToText
+  , datetimeTypeFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -19,6 +21,12 @@ datetimeTypeToText v =
   T.pack $
     case v of
       UtcDatetime -> "utc_datetime"
+
+datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText txt =
+  case T.unpack txt of
+    "utc_datetime" -> Either.Right UtcDatetime
+    v -> Either.Left $ "Unknown DatetimeType: " <> v
 
 datetimeTypeSchema :: FC.Fleece t => FC.Schema t DatetimeType
 datetimeTypeSchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfObject/FieldE.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfObject/FieldE.hs
@@ -4,11 +4,13 @@ module TestCases.Types.AllOfObject.FieldE
   ( FieldE(..)
   , fieldESchema
   , fieldEToText
+  , fieldEFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data FieldE
   = Enum1
@@ -23,6 +25,14 @@ fieldEToText v =
       Enum1 -> "enum1"
       Enum2 -> "enum2"
       Enum3 -> "enum3"
+
+fieldEFromText :: T.Text -> Either String FieldE
+fieldEFromText txt =
+  case T.unpack txt of
+    "enum1" -> Either.Right Enum1
+    "enum2" -> Either.Right Enum2
+    "enum3" -> Either.Right Enum3
+    v -> Either.Left $ "Unknown FieldE: " <> v
 
 fieldESchema :: FC.Fleece t => FC.Schema t FieldE
 fieldESchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfObject/FieldE.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfObject/FieldE.hs
@@ -10,7 +10,7 @@ module TestCases.Types.AllOfObject.FieldE
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data FieldE
   = Enum1
@@ -26,7 +26,7 @@ fieldEToText v =
       Enum2 -> "enum2"
       Enum3 -> "enum3"
 
-fieldEFromText :: T.Text -> Either String FieldE
+fieldEFromText :: T.Text -> Either.Either String FieldE
 fieldEFromText txt =
   case T.unpack txt of
     "enum1" -> Either.Right Enum1

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfObject/FieldI/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfObject/FieldI/DatetimeType.hs
@@ -4,11 +4,13 @@ module TestCases.Types.AllOfObject.FieldI.DatetimeType
   ( DatetimeType(..)
   , datetimeTypeSchema
   , datetimeTypeToText
+  , datetimeTypeFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -19,6 +21,12 @@ datetimeTypeToText v =
   T.pack $
     case v of
       UtcDatetime -> "utc_datetime"
+
+datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText txt =
+  case T.unpack txt of
+    "utc_datetime" -> Either.Right UtcDatetime
+    v -> Either.Left $ "Unknown DatetimeType: " <> v
 
 datetimeTypeSchema :: FC.Fleece t => FC.Schema t DatetimeType
 datetimeTypeSchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfObject/FieldI/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/AllOfObject/FieldI/DatetimeType.hs
@@ -10,7 +10,7 @@ module TestCases.Types.AllOfObject.FieldI.DatetimeType
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -22,7 +22,7 @@ datetimeTypeToText v =
     case v of
       UtcDatetime -> "utc_datetime"
 
-datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText :: T.Text -> Either.Either String DatetimeType
 datetimeTypeFromText txt =
   case T.unpack txt of
     "utc_datetime" -> Either.Right UtcDatetime

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/EnumIntParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/EnumIntParam.hs
@@ -10,7 +10,7 @@ module TestCases.Types.EnumIntParam
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data EnumIntParam
   = EnumIntParam10
@@ -26,7 +26,7 @@ enumIntParamToText v =
       EnumIntParam20 -> "20"
       EnumIntParam30 -> "30"
 
-enumIntParamFromText :: T.Text -> Either String EnumIntParam
+enumIntParamFromText :: T.Text -> Either.Either String EnumIntParam
 enumIntParamFromText txt =
   case T.unpack txt of
     "10" -> Either.Right EnumIntParam10

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/EnumIntParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/EnumIntParam.hs
@@ -4,11 +4,13 @@ module TestCases.Types.EnumIntParam
   ( EnumIntParam(..)
   , enumIntParamSchema
   , enumIntParamToText
+  , enumIntParamFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data EnumIntParam
   = EnumIntParam10
@@ -23,6 +25,14 @@ enumIntParamToText v =
       EnumIntParam10 -> "10"
       EnumIntParam20 -> "20"
       EnumIntParam30 -> "30"
+
+enumIntParamFromText :: T.Text -> Either String EnumIntParam
+enumIntParamFromText txt =
+  case T.unpack txt of
+    "10" -> Either.Right EnumIntParam10
+    "20" -> Either.Right EnumIntParam20
+    "30" -> Either.Right EnumIntParam30
+    v -> Either.Left $ "Unknown EnumIntParam: " <> v
 
 enumIntParamSchema :: FC.Fleece t => FC.Schema t EnumIntParam
 enumIntParamSchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/EnumParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/EnumParam.hs
@@ -4,11 +4,13 @@ module TestCases.Types.EnumParam
   ( EnumParam(..)
   , enumParamSchema
   , enumParamToText
+  , enumParamFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data EnumParam
   = Foo
@@ -23,6 +25,14 @@ enumParamToText v =
       Foo -> "foo"
       Bar -> "bar"
       Baz -> "baz"
+
+enumParamFromText :: T.Text -> Either String EnumParam
+enumParamFromText txt =
+  case T.unpack txt of
+    "foo" -> Either.Right Foo
+    "bar" -> Either.Right Bar
+    "baz" -> Either.Right Baz
+    v -> Either.Left $ "Unknown EnumParam: " <> v
 
 enumParamSchema :: FC.Fleece t => FC.Schema t EnumParam
 enumParamSchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/EnumParam.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/EnumParam.hs
@@ -10,7 +10,7 @@ module TestCases.Types.EnumParam
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data EnumParam
   = Foo
@@ -26,7 +26,7 @@ enumParamToText v =
       Bar -> "bar"
       Baz -> "baz"
 
-enumParamFromText :: T.Text -> Either String EnumParam
+enumParamFromText :: T.Text -> Either.Either String EnumParam
 enumParamFromText txt =
   case T.unpack txt of
     "foo" -> Either.Right Foo

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineAllOf/RequestBody/FieldI/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineAllOf/RequestBody/FieldI/DatetimeType.hs
@@ -10,7 +10,7 @@ module TestCases.Types.InlineAllOf.RequestBody.FieldI.DatetimeType
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -22,7 +22,7 @@ datetimeTypeToText v =
     case v of
       UtcDatetime -> "utc_datetime"
 
-datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText :: T.Text -> Either.Either String DatetimeType
 datetimeTypeFromText txt =
   case T.unpack txt of
     "utc_datetime" -> Either.Right UtcDatetime

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineAllOf/RequestBody/FieldI/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineAllOf/RequestBody/FieldI/DatetimeType.hs
@@ -4,11 +4,13 @@ module TestCases.Types.InlineAllOf.RequestBody.FieldI.DatetimeType
   ( DatetimeType(..)
   , datetimeTypeSchema
   , datetimeTypeToText
+  , datetimeTypeFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -19,6 +21,12 @@ datetimeTypeToText v =
   T.pack $
     case v of
       UtcDatetime -> "utc_datetime"
+
+datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText txt =
+  case T.unpack txt of
+    "utc_datetime" -> Either.Right UtcDatetime
+    v -> Either.Left $ "Unknown DatetimeType: " <> v
 
 datetimeTypeSchema :: FC.Fleece t => FC.Schema t DatetimeType
 datetimeTypeSchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineAllOf/Response200Body/FieldI/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineAllOf/Response200Body/FieldI/DatetimeType.hs
@@ -4,11 +4,13 @@ module TestCases.Types.InlineAllOf.Response200Body.FieldI.DatetimeType
   ( DatetimeType(..)
   , datetimeTypeSchema
   , datetimeTypeToText
+  , datetimeTypeFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -19,6 +21,12 @@ datetimeTypeToText v =
   T.pack $
     case v of
       UtcDatetime -> "utc_datetime"
+
+datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText txt =
+  case T.unpack txt of
+    "utc_datetime" -> Either.Right UtcDatetime
+    v -> Either.Left $ "Unknown DatetimeType: " <> v
 
 datetimeTypeSchema :: FC.Fleece t => FC.Schema t DatetimeType
 datetimeTypeSchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineAllOf/Response200Body/FieldI/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/InlineAllOf/Response200Body/FieldI/DatetimeType.hs
@@ -10,7 +10,7 @@ module TestCases.Types.InlineAllOf.Response200Body.FieldI.DatetimeType
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -22,7 +22,7 @@ datetimeTypeToText v =
     case v of
       UtcDatetime -> "utc_datetime"
 
-datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText :: T.Text -> Either.Either String DatetimeType
 datetimeTypeFromText txt =
   case T.unpack txt of
     "utc_datetime" -> Either.Right UtcDatetime

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/ScheduledDateTime/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/ScheduledDateTime/DatetimeType.hs
@@ -10,7 +10,7 @@ module TestCases.Types.ScheduledDateTime.DatetimeType
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -22,7 +22,7 @@ datetimeTypeToText v =
     case v of
       UtcDatetime -> "utc_datetime"
 
-datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText :: T.Text -> Either.Either String DatetimeType
 datetimeTypeFromText txt =
   case T.unpack txt of
     "utc_datetime" -> Either.Right UtcDatetime

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/ScheduledDateTime/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/ScheduledDateTime/DatetimeType.hs
@@ -4,11 +4,13 @@ module TestCases.Types.ScheduledDateTime.DatetimeType
   ( DatetimeType(..)
   , datetimeTypeSchema
   , datetimeTypeToText
+  , datetimeTypeFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -19,6 +21,12 @@ datetimeTypeToText v =
   T.pack $
     case v of
       UtcDatetime -> "utc_datetime"
+
+datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText txt =
+  case T.unpack txt of
+    "utc_datetime" -> Either.Right UtcDatetime
+    v -> Either.Left $ "Unknown DatetimeType: " <> v
 
 datetimeTypeSchema :: FC.Fleece t => FC.Schema t DatetimeType
 datetimeTypeSchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/Status.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/Status.hs
@@ -4,11 +4,13 @@ module TestCases.Types.Status
   ( Status(..)
   , statusSchema
   , statusToText
+  , statusFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data Status
   = GOOD
@@ -23,6 +25,14 @@ statusToText v =
       GOOD -> "GOOD"
       BAD -> "BAD"
       UGLY -> "UGLY"
+
+statusFromText :: T.Text -> Either String Status
+statusFromText txt =
+  case T.unpack txt of
+    "GOOD" -> Either.Right GOOD
+    "BAD" -> Either.Right BAD
+    "UGLY" -> Either.Right UGLY
+    v -> Either.Left $ "Unknown Status: " <> v
 
 statusSchema :: FC.Fleece t => FC.Schema t Status
 statusSchema =

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/Status.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/Status.hs
@@ -10,7 +10,7 @@ module TestCases.Types.Status
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data Status
   = GOOD
@@ -26,7 +26,7 @@ statusToText v =
       BAD -> "BAD"
       UGLY -> "UGLY"
 
-statusFromText :: T.Text -> Either String Status
+statusFromText :: T.Text -> Either.Either String Status
 statusFromText txt =
   case T.unpack txt of
     "GOOD" -> Either.Right GOOD

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/UTCDateTime/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/UTCDateTime/DatetimeType.hs
@@ -10,7 +10,7 @@ module TestCases.Types.UTCDateTime.DatetimeType
 import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
+import Prelude (($), (<>), Bounded, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -22,7 +22,7 @@ datetimeTypeToText v =
     case v of
       UtcDatetime -> "utc_datetime"
 
-datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText :: T.Text -> Either.Either String DatetimeType
 datetimeTypeFromText txt =
   case T.unpack txt of
     "utc_datetime" -> Either.Right UtcDatetime

--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/UTCDateTime/DatetimeType.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/UTCDateTime/DatetimeType.hs
@@ -4,11 +4,13 @@ module TestCases.Types.UTCDateTime.DatetimeType
   ( DatetimeType(..)
   , datetimeTypeSchema
   , datetimeTypeToText
+  , datetimeTypeFromText
   ) where
 
+import qualified Data.Either as Either
 import qualified Data.Text as T
 import qualified Fleece.Core as FC
-import Prelude (($), Bounded, Enum, Eq, Ord, Show)
+import Prelude (($), (<>), Bounded, Either, Enum, Eq, Ord, Show, String)
 
 data DatetimeType
   = UtcDatetime
@@ -19,6 +21,12 @@ datetimeTypeToText v =
   T.pack $
     case v of
       UtcDatetime -> "utc_datetime"
+
+datetimeTypeFromText :: T.Text -> Either String DatetimeType
+datetimeTypeFromText txt =
+  case T.unpack txt of
+    "utc_datetime" -> Either.Right UtcDatetime
+    v -> Either.Left $ "Unknown DatetimeType: " <> v
 
 datetimeTypeSchema :: FC.Fleece t => FC.Schema t DatetimeType
 datetimeTypeSchema =


### PR DESCRIPTION
We often find ourselves missing these, so wherever we create `Enum a` to-text functions, we also generate `Text -> Either String a` functions.