### PR TITLE
Makes `integer` an anonymous schema

### DIFF
--- a/json-fleece-core/json-fleece-core.cabal
+++ b/json-fleece-core/json-fleece-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-core
-version:        0.11.0.0
+version:        0.11.0.1
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-core#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-core/package.yaml
+++ b/json-fleece-core/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-core
-version:             0.11.0.0
+version:             0.11.0.1
 github:              "flipstone/json-fleece/json-fleece-core"
 license:             MIT
 license-file:        LICENSE

--- a/json-fleece-core/src/Fleece/Core/Schemas.hs
+++ b/json-fleece-core/src/Fleece/Core/Schemas.hs
@@ -81,7 +81,7 @@ import Fleece.Core.Class
   , text
   , transformAnonymous
   , transformNamed
-  , unboundedIntegralNumber
+  , unboundedIntegralNumberAnonymous
   , unionMemberWithIndex
   , unionNamed
   , validateAnonymous
@@ -379,7 +379,7 @@ nonEmptyText =
 
 integer :: Fleece t => Schema t Integer
 integer =
-  unboundedIntegralNumber
+  unboundedIntegralNumberAnonymous
 
 -- | Validates a 'number', failing if the precision is too high for the given resolution.
 fixed ::


### PR DESCRIPTION
I missed making the anonymous when I added anonymous. It should be
anonymous like the other numeric schemas fleece exposes
