### PR TITLE
Adds `schemaDocumentation` accessor to `json-fleece-markdown`

### DIFF
--- a/json-fleece-markdown/json-fleece-markdown.cabal
+++ b/json-fleece-markdown/json-fleece-markdown.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-markdown
-version:        0.8.0.1
+version:        0.8.1.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-markdown#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-markdown/package.yaml
+++ b/json-fleece-markdown/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-markdown
-version:             0.8.0.1
+version:             0.8.1.0
 github:              "flipstone/json-fleece/json-fleece-markdown"
 license:             MIT
 license-file:        LICENSE

--- a/json-fleece-markdown/src/Fleece/Markdown/FleeceInstance.hs
+++ b/json-fleece-markdown/src/Fleece/Markdown/FleeceInstance.hs
@@ -3,6 +3,7 @@
 module Fleece.Markdown.FleeceInstance
   ( Markdown
   , renderMarkdown
+  , schemaDocumentation
   ) where
 
 import Data.Coerce (coerce)
@@ -38,14 +39,18 @@ import Fleece.Markdown.SchemaDocumentation
   , schemaSelfReference
   )
 
-newtype Markdown a = Markdown SchemaDocumentation
+newtype Markdown a
+  = Markdown
+  { markdownSchemaDocumentation :: SchemaDocumentation
+  }
 
 renderMarkdown :: FC.Schema Markdown a -> LT.Text
-renderMarkdown schema =
-  let
-    Markdown schemaDoc = FC.schemaInterpreter schema
-  in
-    schemaDocumentationToMarkdown schemaDoc
+renderMarkdown =
+  schemaDocumentationToMarkdown . schemaDocumentation
+
+schemaDocumentation :: FC.Schema Markdown a -> SchemaDocumentation
+schemaDocumentation =
+  markdownSchemaDocumentation . FC.schemaInterpreter
 
 instance FC.Fleece Markdown where
   newtype Object Markdown _object _a


### PR DESCRIPTION
This accessor allows the caller to get access to the underlying
`SchemaDocumentation` in case they want to render it in their own
way.
