### PR TITLE
Defers inline array schema items ref lookup

### DIFF
--- a/json-fleece-openapi3/examples/test-cases/TestCases/Types/OneOfWithInlineRefArrayItems.hs
+++ b/json-fleece-openapi3/examples/test-cases/TestCases/Types/OneOfWithInlineRefArrayItems.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE DataKinds #-}
+
+module TestCases.Types.OneOfWithInlineRefArrayItems
+  ( OneOfWithInlineRefArrayItems(..)
+  , oneOfWithInlineRefArrayItemsSchema
+  ) where
+
+import qualified Data.Map as Map
+import qualified Data.Text as T
+import Fleece.Core ((#|))
+import qualified Fleece.Core as FC
+import Prelude (($), Eq, Show)
+import qualified Shrubbery as Shrubbery
+import qualified TestCases.Types.Foo as Foo
+
+newtype OneOfWithInlineRefArrayItems = OneOfWithInlineRefArrayItems (Shrubbery.Union
+  '[ (Map.Map T.Text [Foo.Foo])
+   , T.Text
+   ])
+  deriving (Show, Eq)
+
+oneOfWithInlineRefArrayItemsSchema :: FC.Fleece t => FC.Schema t OneOfWithInlineRefArrayItems
+oneOfWithInlineRefArrayItemsSchema =
+  FC.coerceSchema $
+    FC.unionNamed (FC.qualifiedName "TestCases.Types.OneOfWithInlineRefArrayItems" "OneOfWithInlineRefArrayItems") $
+      FC.unionMember (FC.map (FC.list Foo.fooSchema))
+        #| FC.unionMember FC.text

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -312,6 +312,7 @@ library
       TestCases.Types.OneOfWithInlineObject
       TestCases.Types.OneOfWithInlineObject.Option4.Nested.Name
       TestCases.Types.OneOfWithInlineObject.Option4.Nested.Number
+      TestCases.Types.OneOfWithInlineRefArrayItems
       TestCases.Types.OneOfWithNullable
       TestCases.Types.ReexportFieldsExample
       TestCases.Types.ReexportFieldsExample.Age

--- a/json-fleece-openapi3/examples/test-cases/test-cases.yaml
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.yaml
@@ -915,6 +915,15 @@ components:
         type:
           type: string
 
+    OneOfWithInlineRefArrayItems:
+      oneOf:
+        - type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/Foo'
+        - type: string
+
     Bar:
       type: object
       properties:

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-openapi3
-version:        0.4.9.0
+version:        0.4.10.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-openapi3#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -2162,6 +2162,7 @@ extra-source-files:
     examples/test-cases/TestCases/Types/OneOfWithInlineObject.hs
     examples/test-cases/TestCases/Types/OneOfWithInlineObject/Option4/Nested/Name.hs
     examples/test-cases/TestCases/Types/OneOfWithInlineObject/Option4/Nested/Number.hs
+    examples/test-cases/TestCases/Types/OneOfWithInlineRefArrayItems.hs
     examples/test-cases/TestCases/Types/OneOfWithNullable.hs
     examples/test-cases/TestCases/Types/ReexportFieldsExample.hs
     examples/test-cases/TestCases/Types/ReexportFieldsExample/Age.hs

--- a/json-fleece-openapi3/package.yaml
+++ b/json-fleece-openapi3/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-openapi3
-version:             0.4.9.0
+version:             0.4.10.0
 github:              "flipstone/json-fleece/json-fleece-openapi3"
 license:             MIT
 license-file:        LICENSE

--- a/json-fleece-openapi3/src/Fleece/OpenApi3.hs
+++ b/json-fleece-openapi3/src/Fleece/OpenApi3.hs
@@ -17,7 +17,7 @@ import Control.Monad (join, when, (<=<))
 import Control.Monad.Reader (ReaderT, asks, runReaderT)
 import Control.Monad.Trans (lift)
 import qualified Data.Aeson as Aeson
-import Data.Bifunctor (bimap, first)
+import Data.Bifunctor (bimap)
 import Data.Containers.ListUtils (nubOrd)
 import qualified Data.Foldable as Foldable
 import Data.Function (on)
@@ -589,27 +589,24 @@ mkInlineArraySchema ::
   CGM SchemaTypeInfoWithDeps
 mkInlineArraySchema raiseError schemaKey schemaMap schema =
   let
-    lookupCodeGenType refKey =
-      case Map.lookup (CGU.SchemaKey refKey) schemaMap of
-        Just schemaEntry ->
-          pure . CGU.codeGenTypeSchemaInfo . schemaCodeGenType $ schemaEntry
-        Nothing ->
-          raiseError $
-            "Unable to resolve schema reference "
-              <> show refKey
-              <> "."
+    minItems =
+      OA._schemaMinItems schema
   in
     case OA._schemaItems schema of
-      Just (OA.OpenApiItemsObject (OA.Ref (OA.Reference itemRefKey))) -> do
-        itemSchemaInfo <- lookupCodeGenType itemRefKey
-        pure . schemaInfoWithoutDependencies . CGU.arrayLikeTypeInfo (OA._schemaMinItems schema) $ itemSchemaInfo
+      Just (OA.OpenApiItemsObject (OA.Ref ref)) ->
+        pure $
+          SchemaTypeInfoWithDeps
+            { schemaTypeInfoDependent =
+                Right . CGU.CodeGenRefArray minItems . CGU.TypeReference $ OA.getReference ref
+            , schemaTypeInfoDependencies = mempty
+            }
       Just (OA.OpenApiItemsObject (OA.Inline innerSchema)) ->
         let
           itemKey =
             schemaKey <> "Item"
         in
           fmap
-            (fmapSchemaInfoAndDeps $ first $ CGU.arrayLikeTypeInfo $ OA._schemaMinItems schema)
+            (fmapSchemaInfoAndDeps (bimap (CGU.arrayLikeTypeInfo minItems) (CGU.CodeGenRefArray minItems)))
             (mkInlineBodySchema raiseError itemKey schemaMap innerSchema)
       otherItemType ->
         raiseError $

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -9,40 +9,40 @@ packages:
     pantry-tree:
       sha256: d0db931040ec4773c3af456cad1ef600ed35438b23d3a1c7d15c2ad57b194558
       size: 1210
-    sha256: 6394c8c25087dd0ce952622ac0bcc5882dc916da28e5af8434181972d4227b98
-    size: 35878
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-params
-    url: https://github.com/flipstone/beeline/archive/567eb20702f8a0c6bfec246130dab861a7732110.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
     version: 0.2.0.0
   original:
     subdir: beeline-params
-    url: https://github.com/flipstone/beeline/archive/567eb20702f8a0c6bfec246130dab861a7732110.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: beeline-routing
     pantry-tree:
       sha256: ac9788a17532bdb3b7e77c7324e8f78f4f65ff12fe8828dfee16960aea2ba246
       size: 1119
-    sha256: 6394c8c25087dd0ce952622ac0bcc5882dc916da28e5af8434181972d4227b98
-    size: 35878
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-routing
-    url: https://github.com/flipstone/beeline/archive/567eb20702f8a0c6bfec246130dab861a7732110.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
     version: 0.3.0.2
   original:
     subdir: beeline-routing
-    url: https://github.com/flipstone/beeline/archive/567eb20702f8a0c6bfec246130dab861a7732110.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: beeline-http-client
     pantry-tree:
-      sha256: aaa852ff2f2d464e75e2d09bf7c72b89373952a853b263d1708a87f63a7cf17c
+      sha256: f15d423a64227d7bf1b2f8cc32f124eafb4e2af3b436350c551998d21178175e
       size: 725
-    sha256: 6394c8c25087dd0ce952622ac0bcc5882dc916da28e5af8434181972d4227b98
-    size: 35878
+    sha256: 225c76196f47339865086c6485e2e387894fd98e22177ac0c25181794aa0021d
+    size: 36266
     subdir: beeline-http-client
-    url: https://github.com/flipstone/beeline/archive/567eb20702f8a0c6bfec246130dab861a7732110.tar.gz
-    version: 0.9.0.1
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
+    version: 0.9.0.2
   original:
     subdir: beeline-http-client
-    url: https://github.com/flipstone/beeline/archive/567eb20702f8a0c6bfec246130dab861a7732110.tar.gz
+    url: https://github.com/flipstone/beeline/archive/0b2536c63089ca6bd8f4872787261f4cabe0be61.tar.gz
 - completed:
     name: shrubbery
     pantry-tree:


### PR DESCRIPTION
Previously we tried to eagerly resolve `$ref`s in array item schemas in `mkInlineArraySchema`, but the `schemaMap` doesn't contain all of the types at that point.

Also committed stack.yaml.lock, which looks like it didn't get added after the last beeline bump went out.