### PR TITLE
Optimizations for better streamed encoding

### DIFF
--- a/json-fleece-aeson-beeline/json-fleece-aeson-beeline.cabal
+++ b/json-fleece-aeson-beeline/json-fleece-aeson-beeline.cabal
@@ -41,7 +41,7 @@ library
     , bytestring >=0.11 && <0.13
     , http-client ==0.7.*
     , json-fleece-aeson ==0.5.*
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
   default-language: Haskell2010
   if flag(strict)
     ghc-options: -Weverything -Werror -Wno-missing-local-signatures -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-prepositive-qualified-module -Wno-implicit-prelude -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-missing-deriving-strategies -Wno-all-missed-specialisations -Wno-missed-specialisations -Wno-unticked-promoted-constructors

--- a/json-fleece-aeson-beeline/package.yaml
+++ b/json-fleece-aeson-beeline/package.yaml
@@ -61,7 +61,7 @@ library:
   source-dirs: src
   dependencies:
     - json-fleece-aeson >= 0.5 && < 0.6
-    - json-fleece-core >= 0.11 && < 0.12
+    - json-fleece-core >= 0.12 && < 0.13
     - beeline-http-client >= 0.2 && < 0.10
     - bytestring >= 0.11 && < 0.13
     - http-client >= 0.7 && < 0.8

--- a/json-fleece-aeson/json-fleece-aeson.cabal
+++ b/json-fleece-aeson/json-fleece-aeson.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-aeson
-version:        0.5.0.0
+version:        0.5.1.0
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-aeson#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -45,7 +45,7 @@ library
     , base >=4.7 && <5
     , bytestring >=0.11 && <0.13
     , containers >=0.6 && <0.8
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
     , shrubbery ==0.2.*
     , text >=1.2 && <2.2
     , vector >=0.12 && <0.14
@@ -74,7 +74,7 @@ test-suite json-fleece-aeson-test
     , containers >=0.6 && <0.8
     , hedgehog
     , json-fleece-aeson
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
     , json-fleece-examples
     , scientific >=0.3.7 && <0.4
     , shrubbery ==0.2.*

--- a/json-fleece-aeson/package.yaml
+++ b/json-fleece-aeson/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-aeson
-version:             0.5.0.0
+version:             0.5.1.0
 github:              "flipstone/json-fleece/json-fleece-aeson"
 license:             MIT
 license-file:        LICENSE
@@ -23,7 +23,7 @@ dependencies:
   - aeson >= 2.0 && < 2.3
   - bytestring >= 0.11 && < 0.13
   - containers >= 0.6 && < 0.8
-  - json-fleece-core >= 0.11 && < 0.12
+  - json-fleece-core >= 0.12 && < 0.13
   - text >= 1.2 && < 2.2
   - vector >= 0.12 && < 0.14
   - shrubbery >= 0.2 && < 0.3

--- a/json-fleece-aeson/src/Fleece/Aeson/Encoder.hs
+++ b/json-fleece-aeson/src/Fleece/Aeson/Encoder.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE RankNTypes #-}
@@ -83,6 +84,12 @@ instance FC.Fleece Encoder where
     in
       Encoder (AesonTypes.listEncoding itemToEncoding . V.toList)
 
+  interpretList _listName schema =
+    let
+      Encoder itemToEncoding = FC.schemaInterpreter schema
+    in
+      Encoder (AesonTypes.listEncoding itemToEncoding)
+
   interpretNullable _nullableName schema =
     Encoder $ \mbValue ->
       let
@@ -97,29 +104,23 @@ instance FC.Fleece Encoder where
       key = AesonKey.fromString name
       Encoder toEncoding = FC.schemaInterpreter schema
     in
-      Field $ \object ->
-        AesonEncoding.pair key (toEncoding (accessor object))
+      Field (AesonEncoding.pair key . toEncoding . accessor)
 
   optional name accessor schema =
     let
       key = AesonKey.fromString name
       Encoder toEncoding = FC.schemaInterpreter schema
     in
-      Field $ \object ->
-        case accessor object of
-          Just value ->
-            AesonEncoding.pair key (toEncoding value)
-          Nothing ->
-            mempty
+      Field (maybe mempty (AesonEncoding.pair key . toEncoding) . accessor)
 
   additionalFields accessor schema =
-    AdditionalFields $ \object ->
+    AdditionalFields $
       let
         Encoder toEncoding = FC.schemaInterpreter schema
       in
         Map.foldMapWithKey
           (\key value -> AesonEncoding.pair (AesonKey.fromText key) (toEncoding value))
-          (accessor object)
+          . accessor
 
   mapField _f encoder =
     coerce encoder
@@ -129,11 +130,25 @@ instance FC.Fleece Encoder where
 
   field (Object mkStart) (Field mkNext) =
     Object $ \object ->
-      mkStart object <> mkNext object
+      -- Evaluate start and next to WHNF so that object does not need to be retained
+      -- while the fields are encoded. This way earlier fields can be released while
+      -- later ones are encoded.
+      let
+        !start = mkStart object
+        !next = mkNext object
+      in
+        start <> next
 
   additional (Object mkStart) (AdditionalFields mkRest) =
     Object $ \object ->
-      mkStart object <> mkRest object
+      -- Evaluate start and rest to WHNF so that object does not need to be retained
+      -- while the fields are encoded. This way earlier fields can be released while
+      -- later ones are encoded.
+      let
+        !start = mkStart object
+        !rest = mkRest object
+      in
+        start <> rest
 
   interpretObjectNamed _name (Object toSeries) =
     Encoder (Aeson.pairs . toSeries)

--- a/json-fleece-aeson/src/Fleece/Aeson/EncoderDecoder.hs
+++ b/json-fleece-aeson/src/Fleece/Aeson/EncoderDecoder.hs
@@ -77,6 +77,12 @@ instance FC.Fleece EncoderDecoder where
       , encoderDecoderDecoder = FC.interpretArray name (decoder itemSchema)
       }
 
+  interpretList name itemSchema =
+    EncoderDecoder
+      { encoderDecoderEncoder = FC.interpretList name (encoder itemSchema)
+      , encoderDecoderDecoder = FC.interpretList name (decoder itemSchema)
+      }
+
   interpretNull name =
     EncoderDecoder
       { encoderDecoderEncoder = FC.interpretNull name

--- a/json-fleece-aeson/src/Fleece/Aeson/ToValue.hs
+++ b/json-fleece-aeson/src/Fleece/Aeson/ToValue.hs
@@ -23,6 +23,7 @@ import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as Enc
 import qualified Data.Text.Lazy as TL
+import qualified Data.Vector as V
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import Shrubbery (type (@=))
 import qualified Shrubbery
@@ -86,6 +87,12 @@ instance FC.Fleece ToValue where
       ToValue itemToJSON = FC.schemaInterpreter schema
     in
       ToValue (Aeson.Array . fmap itemToJSON)
+
+  interpretList _listName schema =
+    let
+      ToValue itemToJSON = FC.schemaInterpreter schema
+    in
+      ToValue (Aeson.Array . V.fromList . map itemToJSON)
 
   interpretNullable _nullableName schema =
     ToValue $ \mbValue ->

--- a/json-fleece-core/json-fleece-core.cabal
+++ b/json-fleece-core/json-fleece-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-core
-version:        0.11.1.0
+version:        0.12.0.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-core#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues

--- a/json-fleece-core/package.yaml
+++ b/json-fleece-core/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-core
-version:             0.11.1.0
+version:             0.12.0.0
 github:              "flipstone/json-fleece/json-fleece-core"
 license:             MIT
 license-file:        LICENSE

--- a/json-fleece-core/src/Fleece/Core.hs
+++ b/json-fleece-core/src/Fleece/Core.hs
@@ -15,6 +15,7 @@ module Fleece.Core
   , interpretNumber
   , interpretBoolean
   , interpretArray
+  , interpretList
   , interpretNull
   , interpretObjectNamed
   , interpretNullable

--- a/json-fleece-core/src/Fleece/Core/Class.hs
+++ b/json-fleece-core/src/Fleece/Core/Class.hs
@@ -18,6 +18,7 @@ module Fleece.Core.Class
       , interpretNumber
       , interpretBoolean
       , interpretArray
+      , interpretList
       , interpretNull
       , required
       , optional
@@ -158,6 +159,14 @@ class Fleece t where
   interpretBoolean :: Name -> t Bool
 
   interpretArray :: Name -> Schema t a -> t (V.Vector a)
+
+  interpretList :: Name -> Schema t a -> t [a]
+  interpretList name schema =
+    interpretValidateAnonymous V.fromList (Right . V.toList) $
+      Schema
+        { schemaName = name
+        , schemaInterpreter = interpretArray name schema
+        }
 
   interpretNull :: Name -> t Null
 

--- a/json-fleece-core/src/Fleece/Core/Schemas.hs
+++ b/json-fleece-core/src/Fleece/Core/Schemas.hs
@@ -68,7 +68,7 @@ import Fleece.Core.Class
   , Fleece
   , Null (Null)
   , Object
-  , Schema
+  , Schema (Schema, schemaInterpreter, schemaName)
   , TaggedUnionMembers
   , UnionMembers
   , additionalFields
@@ -76,6 +76,7 @@ import Fleece.Core.Class
   , boundedEnumNamed
   , constructor
   , format
+  , interpretList
   , maxLength
   , minItems
   , minLength
@@ -83,7 +84,6 @@ import Fleece.Core.Class
   , number
   , objectNamed
   , optional
-  , schemaName
   , taggedUnionMemberWithTag
   , taggedUnionNamed
   , text
@@ -99,6 +99,7 @@ import Fleece.Core.Class
   )
 import Fleece.Core.Name
   ( Name
+  , annotateName
   , defaultSchemaName
   , nameToString
   , unqualifiedName
@@ -321,10 +322,14 @@ optionalNullable encoding name accessor schema =
 
 list :: Fleece t => Schema t a -> Schema t [a]
 list itemSchema =
-  transformAnonymous
-    V.fromList
-    V.toList
-    (array itemSchema)
+  let
+    listName =
+      annotateName (schemaName itemSchema) "array"
+  in
+    Schema
+      { schemaName = listName
+      , schemaInterpreter = interpretList listName itemSchema
+      }
 
 map :: (Fleece t, Typeable a) => Schema t a -> Schema t (Map.Map T.Text a)
 map innerSchema =

--- a/json-fleece-examples/json-fleece-examples.cabal
+++ b/json-fleece-examples/json-fleece-examples.cabal
@@ -38,7 +38,7 @@ library
   build-depends:
       base >=4.7 && <5
     , containers >=0.6 && <0.8
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
     , scientific >=0.3.7 && <0.4
     , shrubbery ==0.2.*
     , text >=1.2 && <2.2

--- a/json-fleece-examples/package.yaml
+++ b/json-fleece-examples/package.yaml
@@ -21,7 +21,7 @@ tested-with:
 dependencies:
   - base >= 4.7 && < 5
   - containers >= 0.6 && < 0.8
-  - json-fleece-core >= 0.11 && < 0.12
+  - json-fleece-core >= 0.12 && < 0.13
   - scientific >= 0.3.7 && < 0.4
   - shrubbery >= 0.2 && < 0.3
   - text >= 1.2 && < 2.2

--- a/json-fleece-hermes/json-fleece-hermes.cabal
+++ b/json-fleece-hermes/json-fleece-hermes.cabal
@@ -40,7 +40,7 @@ library
     , bytestring >=0.11 && <0.13
     , containers >=0.6 && <0.8
     , hermes-json >=0.6 && <0.8
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
     , shrubbery ==0.2.*
     , text >=2.0
   default-language: Haskell2010
@@ -67,7 +67,7 @@ test-suite json-fleece-hermes-test
     , bytestring >=0.11 && <0.13
     , containers >=0.6 && <0.8
     , hedgehog
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
     , json-fleece-examples
     , json-fleece-hermes
     , scientific >=0.3.7 && <0.4
@@ -102,7 +102,7 @@ benchmark json-fleece-hermes-bench
     , deepseq
     , hermes-json
     , json-fleece-aeson
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
     , json-fleece-hermes
     , tasty-bench
     , text

--- a/json-fleece-hermes/package.yaml
+++ b/json-fleece-hermes/package.yaml
@@ -21,7 +21,7 @@ tested-with:
 dependencies:
   - base >= 4.7 && < 5
   - bytestring >= 0.11 && < 0.13
-  - json-fleece-core >= 0.11 && < 0.12
+  - json-fleece-core >= 0.12 && < 0.13
   - text >= 2.0 # This could be problematic for anyone using LTS 20 or below
 
 flags:

--- a/json-fleece-markdown/json-fleece-markdown.cabal
+++ b/json-fleece-markdown/json-fleece-markdown.cabal
@@ -42,7 +42,7 @@ library
       base >=4.7 && <5
     , containers >=0.6 && <0.8
     , dlist ==1.0.*
-    , json-fleece-core >=0.11.1 && <0.12
+    , json-fleece-core ==0.12.*
     , non-empty-text ==0.2.*
     , text >=1.2 && <2.2
   default-language: Haskell2010

--- a/json-fleece-markdown/package.yaml
+++ b/json-fleece-markdown/package.yaml
@@ -63,7 +63,7 @@ library:
   exposed-modules:
     - Fleece.Markdown
   dependencies:
-    - json-fleece-core >= 0.11.1 && < 0.12
+    - json-fleece-core >= 0.12 && < 0.13
     - containers >= 0.6 && < 0.8
     - dlist >= 1.0 && < 1.1
     - non-empty-text >= 0.2 && < 0.3

--- a/json-fleece-openapi3/examples/star-trek/package.yaml
+++ b/json-fleece-openapi3/examples/star-trek/package.yaml
@@ -13,7 +13,7 @@ dependencies:
   - base >= 4.7 && < 5
   - text
   - scientific
-  - json-fleece-core >= 0.11 && < 0.12
+  - json-fleece-core >= 0.12 && < 0.13
   - json-fleece-aeson-beeline >= 0.3 && < 0.4
   - beeline-params >= 0.2 && < 0.4
   - beeline-routing >= 0.3 && < 0.4

--- a/json-fleece-openapi3/examples/star-trek/star-trek.cabal
+++ b/json-fleece-openapi3/examples/star-trek/star-trek.cabal
@@ -1871,7 +1871,7 @@ library
     , beeline-params >=0.2 && <0.4
     , beeline-routing ==0.3.*
     , json-fleece-aeson-beeline ==0.3.*
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
     , scientific
     , text
     , time

--- a/json-fleece-openapi3/examples/test-cases/package.yaml
+++ b/json-fleece-openapi3/examples/test-cases/package.yaml
@@ -16,7 +16,7 @@ dependencies:
   - bounded-text
   - non-empty-text
   - scientific
-  - json-fleece-core >= 0.11 && < 0.12
+  - json-fleece-core >= 0.12 && < 0.13
   - json-fleece-aeson-beeline >= 0.3 && < 0.4
   - beeline-params >= 0.2 && < 0.4
   - beeline-routing >= 0.3 && < 0.4

--- a/json-fleece-openapi3/examples/test-cases/test-cases.cabal
+++ b/json-fleece-openapi3/examples/test-cases/test-cases.cabal
@@ -351,7 +351,7 @@ library
     , bounded-text
     , containers
     , json-fleece-aeson-beeline ==0.3.*
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
     , non-empty-text
     , scientific
     , shrubbery ==0.2.*

--- a/json-fleece-pretty-print/json-fleece-pretty-print.cabal
+++ b/json-fleece-pretty-print/json-fleece-pretty-print.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-pretty-print
-version:        0.3.0.0
+version:        0.3.1.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-pretty-print#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -39,7 +39,7 @@ library
       base >=4.7 && <5
     , containers >=0.6 && <0.8
     , dlist ==1.0.*
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
     , scientific ==0.3.*
     , shrubbery ==0.2.*
     , text >=1.2 && <2.2
@@ -65,7 +65,7 @@ test-suite json-fleece-pretty-print-test
       base >=4.7 && <5
     , containers >=0.6 && <0.8
     , hedgehog
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
     , json-fleece-examples
     , json-fleece-pretty-print
     , shrubbery ==0.2.*

--- a/json-fleece-pretty-print/package.yaml
+++ b/json-fleece-pretty-print/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-pretty-print
-version:             0.3.0.0
+version:             0.3.1.0
 github:              "flipstone/json-fleece/json-fleece-pretty-print"
 license:             MIT
 license-file:        LICENSE
@@ -20,7 +20,7 @@ tested-with:
 
 dependencies:
   - base >= 4.7 && < 5
-  - json-fleece-core >= 0.11 && < 0.12
+  - json-fleece-core >= 0.12 && < 0.13
   - shrubbery >= 0.2 && < 0.3
   - text >= 1.2 && < 2.2
 

--- a/json-fleece-pretty-print/src/Fleece/PrettyPrint.hs
+++ b/json-fleece-pretty-print/src/Fleece/PrettyPrint.hs
@@ -136,6 +136,18 @@ instance FC.Fleece PrettyPrinter where
               . map (prefixArrayItem . itemToPretty)
               $ nonEmptyList
 
+  interpretList _listName schema =
+    PrettyPrinter $ \items ->
+      let
+        PrettyPrinter itemToPretty = FC.schemaInterpreter schema
+      in
+        case items of
+          [] -> Inline "[]"
+          nonEmptyList ->
+            Block
+              . map (prefixArrayItem . itemToPretty)
+              $ nonEmptyList
+
   interpretNull _name =
     PrettyPrinter showInline
 

--- a/json-fleece-swagger2/examples/uber/package.yaml
+++ b/json-fleece-swagger2/examples/uber/package.yaml
@@ -13,7 +13,7 @@ dependencies:
   - base >= 4.7 && < 5
   - text
   - scientific
-  - json-fleece-core >= 0.11 && < 0.12
+  - json-fleece-core >= 0.12 && < 0.13
   - json-fleece-aeson-beeline >= 0.3 && < 0.4
   - beeline-params >= 0.2 && < 0.4
   - beeline-routing >= 0.3 && < 0.4

--- a/json-fleece-swagger2/examples/uber/uber.cabal
+++ b/json-fleece-swagger2/examples/uber/uber.cabal
@@ -74,7 +74,7 @@ library
     , beeline-params >=0.2 && <0.4
     , beeline-routing ==0.3.*
     , json-fleece-aeson-beeline ==0.3.*
-    , json-fleece-core ==0.11.*
+    , json-fleece-core ==0.12.*
     , scientific
     , text
     , time


### PR DESCRIPTION
- Updates `field` and `additionalFields` to ensure the entire object
  is not retained while all fields are encoded

- Adds `interpretList` primitive so that lists can be encoded without
  being converted to `Vector`. This allows the head of the list to
  be released rather than retaining the entire vector while the
  elements are encoded

- Adds `interpretList` implementations to instances where it allows
  for an optimization. Uses the default for other instances (e.g.
  decoding where underlying libraries use `Vector` anyhow)
