### PR TITLE
Support newer dependencies

### DIFF
--- a/json-fleece-hermes/json-fleece-hermes.cabal
+++ b/json-fleece-hermes/json-fleece-hermes.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.38.1.
+-- This file has been generated from package.yaml by hpack version 0.39.6.
 --
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-hermes
-version:        0.3.0.0
+version:        0.3.1.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-hermes#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -39,7 +39,7 @@ library
       base >=4.7 && <5
     , bytestring >=0.11 && <0.13
     , containers >=0.6 && <0.8
-    , hermes-json >=0.6 && <0.8
+    , hermes-json >=0.6 && <0.9
     , json-fleece-core ==0.12.*
     , shrubbery ==0.2.*
     , text >=2.0

--- a/json-fleece-hermes/package.yaml
+++ b/json-fleece-hermes/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-hermes
-version:             0.3.0.0
+version:             0.3.1.0
 github:              "flipstone/json-fleece/json-fleece-hermes"
 license:             MIT
 license-file:        LICENSE
@@ -65,7 +65,7 @@ library:
     - Fleece.Hermes
   dependencies:
     - containers >= 0.6 && < 0.8
-    - hermes-json >= 0.6 && < 0.8
+    - hermes-json >= 0.6 && < 0.9
     - shrubbery >= 0.2 && < 0.3
 
 tests:

--- a/json-fleece-openapi3/json-fleece-openapi3.cabal
+++ b/json-fleece-openapi3/json-fleece-openapi3.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-openapi3
-version:        0.4.11.0
+version:        0.4.12.0
 description:    Please see the README on GitHub at <https://github.com/flipstone/json-fleece-openapi3#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -2237,13 +2237,10 @@ library
     , bytestring >=0.11 && <0.13
     , containers >=0.6 && <0.8
     , http-media ==0.8.*
-    , insert-ordered-containers ==0.2.*
     , json-fleece-codegen-util ==0.17.*
     , mtl >=2.2 && <2.4
     , non-empty-text ==0.2.*
-    , openapi3 ==3.2.*
     , scientific ==0.3.*
-    , swagger2 ==2.8.*
     , text >=1.2 && <2.2
   default-language: Haskell2010
   if flag(strict)
@@ -2254,6 +2251,13 @@ library
       ghc-options: -Wno-defaulted-exception-context
   else
     ghc-options: -Wall
+  if impl (ghc < 9.12)
+    build-depends:
+        insert-ordered-containers ==0.2.*
+      , openapi3 >=3.2 && <3.2.5
+  if impl (ghc >= 9.12)
+    build-depends:
+        openapi3 >=3.2.5 && <3.3
 
 executable fleece-openapi3
   main-is: Main.hs

--- a/json-fleece-openapi3/package.yaml
+++ b/json-fleece-openapi3/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-openapi3
-version:             0.4.11.0
+version:             0.4.12.0
 github:              "flipstone/json-fleece/json-fleece-openapi3"
 license:             MIT
 license-file:        LICENSE
@@ -78,13 +78,18 @@ library:
     - bytestring >= 0.11 && < 0.13
     - containers >= 0.6 && < 0.8
     - http-media >= 0.8 && < 0.9
-    - insert-ordered-containers >= 0.2 && < 0.3
     - mtl >= 2.2 && < 2.4
     - non-empty-text >= 0.2 && < 0.3
-    - openapi3 >= 3.2 && < 3.3
     - scientific >= 0.3 && < 0.4
-    - swagger2 >= 2.8 && < 2.9
     - text >= 1.2 && < 2.2
+  when:
+    - condition: "impl (ghc < 9.12)"
+      dependencies:
+        - insert-ordered-containers >= 0.2 && < 0.3
+        - openapi3 >= 3.2 && < 3.2.5
+    - condition: "impl (ghc >= 9.12)"
+      dependencies:
+        - openapi3 >= 3.2.5 && < 3.3
 
 executables:
   fleece-openapi3:

--- a/json-fleece-openapi3/src/Fleece/OpenApi3.hs
+++ b/json-fleece-openapi3/src/Fleece/OpenApi3.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -20,7 +21,11 @@ import qualified Data.Aeson as Aeson
 import Data.Bifunctor (bimap)
 import Data.Containers.ListUtils (nubOrd)
 import qualified Data.Foldable as Foldable
-import qualified Data.HashMap.Strict.InsOrd as IOHM
+#if MIN_VERSION_openapi3(3,2,5)
+import qualified "openapi3" Data.HashMap.Strict.InsOrd.Compat as IOHM
+#else
+import qualified "insert-ordered-containers" Data.HashMap.Strict.InsOrd as IOHM
+#endif
 import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import qualified Data.List.NonEmpty as NEL

--- a/json-fleece-openapi3/src/Fleece/OpenApi3/Traversal.hs
+++ b/json-fleece-openapi3/src/Fleece/OpenApi3/Traversal.hs
@@ -285,8 +285,7 @@ unorderedTraverseWithKey ::
   IOHM.InsOrdHashMap T.Text v1 ->
   f (IOHM.InsOrdHashMap T.Text v2)
 #if MIN_VERSION_openapi3(3,2,5)
-unorderedTraverseWithKey f =
-  fmap IOHM.fromList . traverse (\(k, v) -> (,) k <$> f k v) . IOHM.toList
+unorderedTraverseWithKey = IOHM.traverseWithKey
 #else
 unorderedTraverseWithKey = IOHM.unorderedTraverseWithKey
 #endif

--- a/json-fleece-openapi3/src/Fleece/OpenApi3/Traversal.hs
+++ b/json-fleece-openapi3/src/Fleece/OpenApi3/Traversal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
 
 module Fleece.OpenApi3.Traversal
   ( traverseOpenApiSchemas
@@ -10,9 +11,13 @@ module Fleece.OpenApi3.Traversal
 import Control.Applicative (liftA2)
 #endif
 import qualified Data.ByteString.Char8 as BS8
-import qualified Data.HashMap.Strict.InsOrd as IOHM
+#if MIN_VERSION_openapi3(3,2,5)
+import qualified "openapi3" Data.HashMap.Strict.InsOrd.Compat as IOHM
+import qualified Data.Maybe as Maybe
+#else
+import qualified "insert-ordered-containers" Data.HashMap.Strict.InsOrd as IOHM
+#endif
 import qualified Data.OpenApi as OA
-import qualified Data.Swagger as Swagger
 import qualified Data.Text as T
 import qualified Network.HTTP.Media as Media
 
@@ -52,7 +57,7 @@ traverseComponentsSchemas fn components =
         OA.Inline a -> Just a
     mkComponents schemas responses params requestBodies headers callbacks =
       components
-        { OA._componentsSchemas = IOHM.mapMaybe getInline schemas
+        { OA._componentsSchemas = mapMaybe getInline schemas
         , OA._componentsResponses = responses
         , OA._componentsParameters = params
         , OA._componentsRequestBodies = requestBodies
@@ -61,7 +66,7 @@ traverseComponentsSchemas fn components =
         }
   in
     mkComponents
-      <$> IOHM.unorderedTraverseWithKey (\k -> fn k . OA.Inline) (OA._componentsSchemas components)
+      <$> unorderedTraverseWithKey (\k -> fn k . OA.Inline) (OA._componentsSchemas components)
       <*> IOHM.unorderedTraverseWithKey (traverseResponseSchemas fn) (OA._componentsResponses components)
       <*> IOHM.unorderedTraverseWithKey (traverseParamSchemas . fn) (OA._componentsParameters components)
       <*> IOHM.unorderedTraverseWithKey (traverseRequestBodySchemas fn) (OA._componentsRequestBodies components)
@@ -245,7 +250,7 @@ traverseResponsesSchemas ::
   f OA.Responses
 traverseResponsesSchemas fn operationKey responses =
   let
-    mkResponseKey :: Swagger.HttpStatusCode -> T.Text
+    mkResponseKey :: OA.HttpStatusCode -> T.Text
     mkResponseKey statusCode = operationKey <> "." <> T.pack (show statusCode)
 
     mkResponses def res =
@@ -262,3 +267,26 @@ traverseResponsesSchemas fn operationKey responses =
 renderMediaType :: Media.MediaType -> T.Text
 renderMediaType =
   T.pack . BS8.unpack . Media.renderHeader
+
+mapMaybe ::
+  (v1 -> Maybe v2) ->
+  IOHM.InsOrdHashMap T.Text v1 ->
+  IOHM.InsOrdHashMap T.Text v2
+#if MIN_VERSION_openapi3(3,2,5)
+mapMaybe f =
+  IOHM.fromList . Maybe.mapMaybe (\(k, v) -> (,) k <$> f v) . IOHM.toList
+#else
+mapMaybe = IOHM.mapMaybe
+#endif
+
+unorderedTraverseWithKey ::
+  Applicative f =>
+  (T.Text -> v1 -> f v2) ->
+  IOHM.InsOrdHashMap T.Text v1 ->
+  f (IOHM.InsOrdHashMap T.Text v2)
+#if MIN_VERSION_openapi3(3,2,5)
+unorderedTraverseWithKey f =
+  fmap IOHM.fromList . traverse (\(k, v) -> (,) k <$> f k v) . IOHM.toList
+#else
+unorderedTraverseWithKey = IOHM.unorderedTraverseWithKey
+#endif

--- a/json-fleece-swagger2/json-fleece-swagger2.cabal
+++ b/json-fleece-swagger2/json-fleece-swagger2.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           json-fleece-swagger2
-version:        0.4.0.9
+version:        0.4.1.0
 description:    Please see the README on GitHub at <https://github.com/githubuser/json-fleece-swagger2#readme>
 homepage:       https://github.com/flipstone/json-fleece#readme
 bug-reports:    https://github.com/flipstone/json-fleece/issues
@@ -87,11 +87,9 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , insert-ordered-containers ==0.2.*
     , json-fleece-codegen-util >=0.14 && <0.18
     , json-fleece-openapi3 ==0.4.*
     , openapi3 ==3.2.*
-    , swagger2 ==2.8.*
     , text >=1.2 && <2.2
   default-language: Haskell2010
   if flag(strict)
@@ -102,6 +100,14 @@ library
       ghc-options: -Wno-defaulted-exception-context
   else
     ghc-options: -Wall
+  if impl (ghc < 9.12)
+    build-depends:
+        insert-ordered-containers ==0.2.*
+      , swagger2 ==2.8.*
+  if impl (ghc >= 9.12)
+    build-depends:
+        hashable ==1.5.*
+      , swagger2 ==2.9.*
 
 executable fleece-swagger2
   main-is: Main.hs

--- a/json-fleece-swagger2/json-fleece-swagger2.cabal
+++ b/json-fleece-swagger2/json-fleece-swagger2.cabal
@@ -89,7 +89,6 @@ library
       base >=4.7 && <5
     , json-fleece-codegen-util >=0.14 && <0.18
     , json-fleece-openapi3 ==0.4.*
-    , openapi3 ==3.2.*
     , text >=1.2 && <2.2
   default-language: Haskell2010
   if flag(strict)
@@ -103,10 +102,12 @@ library
   if impl (ghc < 9.12)
     build-depends:
         insert-ordered-containers ==0.2.*
+      , openapi3 >=3.2 && <3.2.5
       , swagger2 ==2.8.*
   if impl (ghc >= 9.12)
     build-depends:
         hashable ==1.5.*
+      , openapi3 >=3.2.5 && <3.3
       , swagger2 ==2.9.*
 
 executable fleece-swagger2

--- a/json-fleece-swagger2/package.yaml
+++ b/json-fleece-swagger2/package.yaml
@@ -69,17 +69,18 @@ library:
     - Fleece.Swagger2
   dependencies:
     - json-fleece-openapi3 >= 0.4 && < 0.5
-    - openapi3 >= 3.2 &&  < 3.3
     - text >= 1.2 && < 2.2
   when:
     - condition: "impl (ghc < 9.12)"
       dependencies:
         - insert-ordered-containers >= 0.2 && < 0.3
         - swagger2 >= 2.8 && < 2.9
+        - openapi3 >= 3.2 &&  < 3.2.5
     - condition: "impl (ghc >= 9.12)"
       dependencies:
         - hashable >= 1.5 && < 1.6
         - swagger2 >= 2.9 && < 2.10
+        - openapi3 >= 3.2.5 &&  < 3.3
 
 executables:
   fleece-swagger2:

--- a/json-fleece-swagger2/package.yaml
+++ b/json-fleece-swagger2/package.yaml
@@ -1,5 +1,5 @@
 name:                json-fleece-swagger2
-version:             0.4.0.9
+version:             0.4.1.0
 github:              "flipstone/json-fleece/json-fleece-swagger2"
 license:             MIT
 license-file:        LICENSE
@@ -69,10 +69,17 @@ library:
     - Fleece.Swagger2
   dependencies:
     - json-fleece-openapi3 >= 0.4 && < 0.5
-    - insert-ordered-containers >= 0.2 && < 0.3
-    - swagger2 >= 2.8 && < 2.9
     - openapi3 >= 3.2 &&  < 3.3
     - text >= 1.2 && < 2.2
+  when:
+    - condition: "impl (ghc < 9.12)"
+      dependencies:
+        - insert-ordered-containers >= 0.2 && < 0.3
+        - swagger2 >= 2.8 && < 2.9
+    - condition: "impl (ghc >= 9.12)"
+      dependencies:
+        - hashable >= 1.5 && < 1.6
+        - swagger2 >= 2.9 && < 2.10
 
 executables:
   fleece-swagger2:

--- a/json-fleece-swagger2/src/Fleece/Swagger2.hs
+++ b/json-fleece-swagger2/src/Fleece/Swagger2.hs
@@ -1,14 +1,21 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PackageImports #-}
 
 module Fleece.Swagger2
   ( generateSwaggerFleeceCode
   ) where
 
-import Data.Coerce (coerce)
 import Data.Either (partitionEithers)
-import qualified Data.HashMap.Strict.InsOrd as IOHM
+#if MIN_VERSION_swagger2(2,9,0)
+import Data.Hashable (Hashable)
+import qualified "openapi3" Data.HashMap.Strict.InsOrd.Compat as OpenApiIOHM
+import qualified "swagger2" Data.HashMap.Strict.InsOrd.Compat as IOHM
+#else
+import qualified "insert-ordered-containers" Data.HashMap.Strict.InsOrd as IOHM
+#endif
 import qualified Data.OpenApi as OA
 import qualified Data.Swagger as SW
 import qualified Data.Swagger.Internal as SWI
@@ -33,10 +40,10 @@ swaggerToOpenApi swagger = do
   -- generateOpenApiFleeceCodeUses
   pure $
     OA.OpenApi
-      { OA._openApiPaths = paths
+      { OA._openApiPaths = toOpenApiInsOrd paths
       , OA._openApiComponents =
           OA.Components
-            { OA._componentsSchemas = schemas
+            { OA._componentsSchemas = toOpenApiInsOrd schemas
             , OA._componentsResponses = mempty
             , OA._componentsParameters = mempty
             , OA._componentsExamples = mempty
@@ -114,7 +121,7 @@ swaggerOperationToOpenApi operation = do
       , OA._operationResponses = responses
       , OA._operationCallbacks = mempty
       , OA._operationDeprecated = SW._operationDeprecated operation
-      , OA._operationSecurity = coerce (SW._operationSecurity operation)
+      , OA._operationSecurity = convertSecurity (SW._operationSecurity operation)
       , OA._operationServers = []
       }
 
@@ -125,7 +132,7 @@ swaggerResponsesToOpenApi responses = do
   pure $
     OA.Responses
       { OA._responsesDefault = responsesDefault
-      , OA._responsesResponses = responsesResponses
+      , OA._responsesResponses = toOpenApiInsOrd responsesResponses
       }
 
 swaggerResponseRefToOpenApi :: SW.Referenced SW.Response -> CGU.CodeGen (OA.Referenced OA.Response)
@@ -159,8 +166,8 @@ swaggerResponseToOpenApi response = do
   pure $
     OA.Response
       { OA._responseDescription = SW._responseDescription response
-      , OA._responseContent = content
-      , OA._responseHeaders = headers
+      , OA._responseContent = toOpenApiInsOrd content
+      , OA._responseHeaders = toOpenApiInsOrd headers
       , OA._responseLinks = mempty
       }
 
@@ -273,7 +280,7 @@ swaggerParamToOpenApi param = do
       pure . Left $
         OA.RequestBody
           { OA._requestBodyDescription = SW._paramDescription param
-          , OA._requestBodyContent = content
+          , OA._requestBodyContent = toOpenApiInsOrd content
           , OA._requestBodyRequired = SW._paramRequired param
           }
     SW.ParamOther otherSchema -> do
@@ -390,7 +397,7 @@ swaggerSchemaToOpenApi schema = do
       , OA._schemaOneOf = Nothing
       , OA._schemaNot = Nothing
       , OA._schemaAnyOf = Nothing
-      , OA._schemaProperties = openApiProps
+      , OA._schemaProperties = toOpenApiInsOrd openApiProps
       , OA._schemaAdditionalProperties = openApiAdditionalProps
       , OA._schemaDiscriminator = fmap swaggerDiscriminatorToOpenApi (SW._schemaDiscriminator schema)
       , OA._schemaReadOnly = SW._schemaReadOnly schema
@@ -515,3 +522,22 @@ traverseRef f ref =
   case ref of
     SW.Ref (SW.Reference refKey) -> pure (OA.Ref (OA.Reference refKey))
     SW.Inline item -> fmap OA.Inline (f item)
+
+#if MIN_VERSION_swagger2(2,9,0)
+toOpenApiInsOrd ::
+  Hashable k =>
+  IOHM.InsOrdHashMap k v ->
+  OpenApiIOHM.InsOrdHashMap k v
+toOpenApiInsOrd =
+  OpenApiIOHM.fromList . IOHM.toList
+#else
+toOpenApiInsOrd ::
+  IOHM.InsOrdHashMap k v ->
+  IOHM.InsOrdHashMap k v
+toOpenApiInsOrd =
+  id
+#endif
+
+convertSecurity :: [SW.SecurityRequirement] -> [OA.SecurityRequirement]
+convertSecurity =
+  fmap (OA.SecurityRequirement . toOpenApiInsOrd . SW.getSecurityRequirement)

--- a/stack-ghc-9.12.yaml
+++ b/stack-ghc-9.12.yaml
@@ -1,30 +1,17 @@
 <<: !include stack-base.yaml
 
-resolver: nightly-2025-10-06
+resolver: nightly-2026-07-21
 extra-deps:
   - github: flipstone/beeline
-    commit: e31206f52fec7e96c15de9a2bab9ef1876db137b
+    commit: 2abc1e519e6090407cde246e889828137e50a86f
     subdirs:
       - beeline-params
       - beeline-routing
       - beeline-http-client
   - github: flipstone/shrubbery
-    commit: a064ede07e01b753a6eb310fc24d9fd8da1ad826
+    commit: 8e9dfb0f84a1e11e2e6fc8e10297e06c71939855
   - github: flipstone/bounded-text
-    commit: 3ef94eeda5402857423284d0c4e021a8c8032498
+    commit: f31ad5f2e5f1249d9b09c158736e489397a9afcd
   - template-haskell-lift-0.1.0.0
   - template-haskell-quasiquoter-0.1.0.0
-
-  - hermes-json-0.7.0.0@sha256:d1fe74cc26fc7c4de12e4eab2bb74cda4eb9b4dc311c297caa23e40bdb1bd3b6,3943
-
-  # Not in the LTS
-  - openapi3-3.2.4@sha256:7309864a9a59b4654b21ef477444fb26bf8d393eba795dd8de089b368ea74c2a,4982
-  - swagger2-2.8.10@sha256:e2cd0e2077b3f2571a3bfca2aca0ba03d10086800803d9c0b7bb895f7aad8441,4689
-
-  # For openapi3 and swagger2
-  - QuickCheck-2.15.0.1@sha256:0cfd337bb9e6fbf09255bd24bb498a156f1d9bcd465396ac8657b25034b9ee31,9046
-
-allow-newer: true
-allow-newer-deps:
-  - hermes-json
-
+  - hermes-json-0.8.0.0

--- a/stack-ghc-9.12.yaml.lock
+++ b/stack-ghc-9.12.yaml.lock
@@ -9,62 +9,62 @@ packages:
     pantry-tree:
       sha256: 44791687ad987b596ff02fd1776386bef293a27e097c7c589a3bb76a9a81f200
       size: 1210
-    sha256: 93fff6138e28d8989741b4fc8622096d2211dad35f1d113a341d89d0d3235d8f
-    size: 36315
+    sha256: a7b2100e53385cca5258727c09c87c070d9ec6bee9869f13b67cef516cd15435
+    size: 36309
     subdir: beeline-params
-    url: https://github.com/flipstone/beeline/archive/e31206f52fec7e96c15de9a2bab9ef1876db137b.tar.gz
+    url: https://github.com/flipstone/beeline/archive/2abc1e519e6090407cde246e889828137e50a86f.tar.gz
     version: 0.3.0.0
   original:
     subdir: beeline-params
-    url: https://github.com/flipstone/beeline/archive/e31206f52fec7e96c15de9a2bab9ef1876db137b.tar.gz
+    url: https://github.com/flipstone/beeline/archive/2abc1e519e6090407cde246e889828137e50a86f.tar.gz
 - completed:
     name: beeline-routing
     pantry-tree:
       sha256: 555ab8a55094ffa801fa8ee8e8fc9b11ec21c08cff29e5dc152ae7f171fa3ccd
       size: 1119
-    sha256: 93fff6138e28d8989741b4fc8622096d2211dad35f1d113a341d89d0d3235d8f
-    size: 36315
+    sha256: a7b2100e53385cca5258727c09c87c070d9ec6bee9869f13b67cef516cd15435
+    size: 36309
     subdir: beeline-routing
-    url: https://github.com/flipstone/beeline/archive/e31206f52fec7e96c15de9a2bab9ef1876db137b.tar.gz
+    url: https://github.com/flipstone/beeline/archive/2abc1e519e6090407cde246e889828137e50a86f.tar.gz
     version: 0.3.0.2
   original:
     subdir: beeline-routing
-    url: https://github.com/flipstone/beeline/archive/e31206f52fec7e96c15de9a2bab9ef1876db137b.tar.gz
+    url: https://github.com/flipstone/beeline/archive/2abc1e519e6090407cde246e889828137e50a86f.tar.gz
 - completed:
     name: beeline-http-client
     pantry-tree:
       sha256: fb7c6a76d68e12173b4a0a5d7f9ad282dea0c092773d26b8e4998756b0de2713
       size: 725
-    sha256: 93fff6138e28d8989741b4fc8622096d2211dad35f1d113a341d89d0d3235d8f
-    size: 36315
+    sha256: a7b2100e53385cca5258727c09c87c070d9ec6bee9869f13b67cef516cd15435
+    size: 36309
     subdir: beeline-http-client
-    url: https://github.com/flipstone/beeline/archive/e31206f52fec7e96c15de9a2bab9ef1876db137b.tar.gz
+    url: https://github.com/flipstone/beeline/archive/2abc1e519e6090407cde246e889828137e50a86f.tar.gz
     version: 0.9.0.2
   original:
     subdir: beeline-http-client
-    url: https://github.com/flipstone/beeline/archive/e31206f52fec7e96c15de9a2bab9ef1876db137b.tar.gz
+    url: https://github.com/flipstone/beeline/archive/2abc1e519e6090407cde246e889828137e50a86f.tar.gz
 - completed:
     name: shrubbery
     pantry-tree:
-      sha256: d16c6b171d9b360098760d2c2269ded8eaae823ed9aa5c7a36598673e83fb9e3
-      size: 2834
-    sha256: 8bb3b52a8f9cb3f6edc5ee0c4584c81187b05966d59d718a247a6707479e2e33
-    size: 30344
-    url: https://github.com/flipstone/shrubbery/archive/a064ede07e01b753a6eb310fc24d9fd8da1ad826.tar.gz
-    version: 0.2.3.1
+      sha256: 3f952a81c5e7d21b840b16cbf5f11a37dd2e6c28601ff642264e0a16d0d56fe3
+      size: 2924
+    sha256: 0889dbd453d50e7e000a9137730d49fe6eed355ce08d3206525fab57b45e1a1b
+    size: 30241
+    url: https://github.com/flipstone/shrubbery/archive/8e9dfb0f84a1e11e2e6fc8e10297e06c71939855.tar.gz
+    version: 0.2.3.2
   original:
-    url: https://github.com/flipstone/shrubbery/archive/a064ede07e01b753a6eb310fc24d9fd8da1ad826.tar.gz
+    url: https://github.com/flipstone/shrubbery/archive/8e9dfb0f84a1e11e2e6fc8e10297e06c71939855.tar.gz
 - completed:
     name: bounded-text
     pantry-tree:
-      sha256: e98540b1877ae4709420472f83e8fd04b987eaeb914df72bb33b0bbe55debac2
+      sha256: f96d276efc5209ff50e737ee3cba2cd5ebb273a701864ef5419144c811ff1455
       size: 2162
-    sha256: 29c500737d8e481fe2e3325fe643a9cafc565ffd06b754bf14219f579d927f5d
-    size: 11885
-    url: https://github.com/flipstone/bounded-text/archive/3ef94eeda5402857423284d0c4e021a8c8032498.tar.gz
+    sha256: bcd338c8386d4a18515c049e61e683673eaada8e1c4855631fb66c3a5ed889dc
+    size: 11893
+    url: https://github.com/flipstone/bounded-text/archive/f31ad5f2e5f1249d9b09c158736e489397a9afcd.tar.gz
     version: 0.1.2.0
   original:
-    url: https://github.com/flipstone/bounded-text/archive/3ef94eeda5402857423284d0c4e021a8c8032498.tar.gz
+    url: https://github.com/flipstone/bounded-text/archive/f31ad5f2e5f1249d9b09c158736e489397a9afcd.tar.gz
 - completed:
     hackage: template-haskell-lift-0.1.0.0@sha256:f6cd3ee45b0c68480c400bfca9f08f39e8e87a5eb823f206dbe06ab1923a4f1c,1136
     pantry-tree:
@@ -80,36 +80,15 @@ packages:
   original:
     hackage: template-haskell-quasiquoter-0.1.0.0
 - completed:
-    hackage: hermes-json-0.7.0.0@sha256:d1fe74cc26fc7c4de12e4eab2bb74cda4eb9b4dc311c297caa23e40bdb1bd3b6,3943
+    hackage: hermes-json-0.8.0.0@sha256:5e688000f0bd4166043564382994b3d2a856d211de82cf4006cfc5646d8327ca,3756
     pantry-tree:
-      sha256: 77f7eb467a7a8fdd0b73b2bc1a51c309fd32fbcd063d99a14540cda34f3926c1
+      sha256: 974b081c935f5b2a85973b0214ac64d490ef96bc5104ccbe8af420d2f3a1999c
       size: 1332
   original:
-    hackage: hermes-json-0.7.0.0@sha256:d1fe74cc26fc7c4de12e4eab2bb74cda4eb9b4dc311c297caa23e40bdb1bd3b6,3943
-- completed:
-    hackage: openapi3-3.2.4@sha256:7309864a9a59b4654b21ef477444fb26bf8d393eba795dd8de089b368ea74c2a,4982
-    pantry-tree:
-      sha256: 1ac8db74ee9753398df1b87f2556c83cce42994c3a2c80faa13169ddba250ab0
-      size: 2263
-  original:
-    hackage: openapi3-3.2.4@sha256:7309864a9a59b4654b21ef477444fb26bf8d393eba795dd8de089b368ea74c2a,4982
-- completed:
-    hackage: swagger2-2.8.10@sha256:e2cd0e2077b3f2571a3bfca2aca0ba03d10086800803d9c0b7bb895f7aad8441,4689
-    pantry-tree:
-      sha256: 1d9fe7cb9fb7c42425a9bc4fe1bb22ebf51d7dd91c04516117c065afd2392626
-      size: 2192
-  original:
-    hackage: swagger2-2.8.10@sha256:e2cd0e2077b3f2571a3bfca2aca0ba03d10086800803d9c0b7bb895f7aad8441,4689
-- completed:
-    hackage: QuickCheck-2.15.0.1@sha256:0cfd337bb9e6fbf09255bd24bb498a156f1d9bcd465396ac8657b25034b9ee31,9046
-    pantry-tree:
-      sha256: 27dddf0b64cc7d7e154326059c89b70da61530c25623af7ef576dd9db0c53821
-      size: 2437
-  original:
-    hackage: QuickCheck-2.15.0.1@sha256:0cfd337bb9e6fbf09255bd24bb498a156f1d9bcd465396ac8657b25034b9ee31,9046
+    hackage: hermes-json-0.8.0.0
 snapshots:
 - completed:
-    sha256: 3fb5b5166a4665e3b23251fab8fefe0683fd69131773d104e136e45029130109
-    size: 696191
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2025/10/6.yaml
-  original: nightly-2025-10-06
+    sha256: 6ef23a49b8110fe1d2564dc1d0952d190dbaa8aea4019183df1db3ae0a531790
+    size: 759079
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2026/7/21.yaml
+  original: nightly-2026-07-21


### PR DESCRIPTION
This updates the Stack configuration to use the latest Nightly, and adds support
for the packages contained therein.

Since this repo primarily uses Stack, I have opted to avoid a combinatorial
explosion, and simply constrainted the new versions of these dependencies to
ghc-9.12. This is consistent with Stackage now that LTS-24 was downgraded to use
openapi3-3.2.4.

I tested this with the following `cabal.project`:

```
packages: json-fleece-core json-fleece-openapi3 ../shrubbery ../bounded-text json-fleece-codegen-util json-fleece-swagger2

tests:True

source-repository-package
  type: git
  location: https://github.com/dhall-lang/dhall-haskell.git
  tag: 44f952ac477a5ec4fef9ba1d329ce6ee3d172648
  subdir: dhall
```

with both GHC 9.10 and 9.12.
